### PR TITLE
Added when tag for datasets that get data from ndattributes.

### DIFF
--- a/ADApp/pluginSrc/NDFileHDF5Layout.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5Layout.cpp
@@ -40,25 +40,27 @@ void HdfAttribute::setOnFileOpen(bool onOpen)
 
 bool HdfAttribute::is_onFileOpen()
 {
-  return this->onFileOpen;
+  HdfWhen_t when = source.get_when_to_save();
+  return (when == OnFileOpen) || (when == OnFrame);
 }
 
 bool HdfAttribute::is_onFileClose()
 {
-  return !this->onFileOpen;
+  HdfWhen_t when = source.get_when_to_save();
+  return (when == OnFileClose) || (when == OnFrame);
 }
 
 // constructors
 HdfDataSource::HdfDataSource()
-: data_src(hdf_notset), val(""), datatype(hdf_int8){}
+: data_src(hdf_notset), val(""), datatype(hdf_int8), when_to_save(OnFrame){}
 HdfDataSource::HdfDataSource( HdfDataSrc_t srctype, const std::string& val)
-: data_src(srctype), val(val), datatype(hdf_string){}
+: data_src(srctype), val(val), datatype(hdf_string), when_to_save(OnFrame){}
 HdfDataSource::HdfDataSource( HdfDataSrc_t src, HDF_DataType_t type)
-: data_src(src), val(""), datatype(type){}
+: data_src(src), val(""), datatype(type), when_to_save(OnFrame){}
 HdfDataSource::HdfDataSource( HdfDataSrc_t src)
-: data_src(src), val(""), datatype(hdf_string){}
+: data_src(src), val(""), datatype(hdf_string), when_to_save(OnFrame){}
 HdfDataSource::HdfDataSource( const HdfDataSource& src)
-: data_src(src.data_src), val(src.val), datatype(src.datatype){}
+: data_src(src.data_src), val(src.val), datatype(src.datatype), when_to_save(src.when_to_save){}
 
 /** Assignment operator
  * Copies the sources private data members to this object.
@@ -68,6 +70,7 @@ HdfDataSource& HdfDataSource::operator=(const HdfDataSource& src)
 	this->data_src = src.data_src;
 	this->val = src.val;
 	this->datatype = src.datatype;
+   this->when_to_save = src.when_to_save;
 	return *this;
 };
 
@@ -132,6 +135,15 @@ void HdfDataSource::set_const_datatype_value(HDF_DataType_t dtype, const std::st
 	this->val = str_val;
 }
 
+void HdfDataSource::set_when_to_save(HdfWhen_t when)
+{
+    when_to_save = when;
+}
+
+HdfWhen_t HdfDataSource::get_when_to_save()
+{
+    return when_to_save;
+}
 
 /* ================== HdfElement Class public methods ==================== */
 HdfElement::HdfElement()

--- a/ADApp/pluginSrc/NDFileHDF5Layout.h
+++ b/ADApp/pluginSrc/NDFileHDF5Layout.h
@@ -16,6 +16,12 @@
 namespace hdf5 {
 
 typedef enum {
+   OnFrame,
+   OnFileOpen,
+   OnFileClose
+} HdfWhen_t;
+
+typedef enum {
 	hdf_notset,
 	hdf_detector,
 	hdf_ndattribute,
@@ -58,10 +64,14 @@ public:
     size_t datatype_size();
     void set_const_datatype_value(HDF_DataType_t dtype, const std::string& str_val);
 
+    void set_when_to_save(HdfWhen_t when);
+    HdfWhen_t get_when_to_save();
+   
 private:
     HdfDataSrc_t data_src;
     std::string val;
     HDF_DataType_t datatype;
+    HdfWhen_t when_to_save;
 };
 
 


### PR DESCRIPTION
Tested and detector datasets are not affected. They always save on every frame and ignore the when tag. The datasets that are for ndattributes can save OnFrame, OnFileOpen, and OnFileClose now. Merged with main areaDetector hdf5_xml branch before pull request. 
