### PR TITLE
NDFileTIFF: write all NDAttributes as TIFF ASCII tags.

### DIFF
--- a/ADApp/pluginSrc/NDFileTIFF.cpp
+++ b/ADApp/pluginSrc/NDFileTIFF.cpp
@@ -5,6 +5,20 @@
  * May 11, 2009
  */
 
+/*
+ * Modifed to write all NDAttributes as TIFF Ascii file tags.
+ * This uses private tag numbers between 65010 and 65500.
+ * The NDAttribute name is encoded along with the value as
+ * a string (because adding the name to the TIFFFieldInfo 
+ * struct doesn't seem to make it to the tag in the file).
+ *
+ * The NDAttributes from the driver are read from the NDArray.
+ * NDAttributes from the driver are appended to the 
+ * NDAttributeList for this plugin.
+ * 
+ * Matt Pearson, April 4, 2014.
+ */
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -18,6 +32,11 @@
 #include <epicsExport.h>
 
 static const char *driverName = "NDFileTIFF";
+
+const int NDFileTIFF::TIFFTAG_START_ = 65010;
+const int NDFileTIFF::TIFFTAG_END_ = 65500;
+
+#define MAX_ATTRIBUTE_STRING_SIZE 256
 
 /** Opens a TIFF file.
   * \param[in] fileName The name of the file to open.
@@ -33,9 +52,9 @@ asynStatus NDFileTIFF::openFile(const char *fileName, NDFileOpenMode_t openMode,
     size_t sizeX, sizeY, rowsPerStrip;
     int bitsPerSample=8, sampleFormat=SAMPLEFORMAT_INT, samplesPerPixel, photoMetric, planarConfig;
     int colorMode=NDColorModeMono;
-    NDAttribute *pAttribute;
-    char ManufacturerString[MAX_ATTRIBUTE_STRING_SIZE] = "Unknown";
-    char ModelString[MAX_ATTRIBUTE_STRING_SIZE] = "Unknown";
+    NDAttribute *pAttribute = NULL;
+    char tagString[MAX_ATTRIBUTE_STRING_SIZE] = {0};
+    char attrString[MAX_ATTRIBUTE_STRING_SIZE] = {0};
 
     /* We don't support reading yet */
     if (openMode & NDFileModeRead) return(asynError);
@@ -160,11 +179,169 @@ asynStatus NDFileTIFF::openFile(const char *fileName, NDFileOpenMode_t openMode,
     TIFFSetField(this->output, TIFFTAG_IMAGEWIDTH, (epicsUInt32)sizeX);
     TIFFSetField(this->output, TIFFTAG_IMAGELENGTH, (epicsUInt32)sizeY);
     TIFFSetField(this->output, TIFFTAG_ROWSPERSTRIP, (epicsUInt32)rowsPerStrip);
-    TIFFSetField(this->output, TIFFTAG_MAKE, ManufacturerString);
-    TIFFSetField(this->output, TIFFTAG_MODEL, ModelString);
+    
+    this->pFileAttributes->clear();
+    this->getAttributes(this->pFileAttributes);
+    pArray->pAttributeList->copy(this->pFileAttributes);
+ 
+    pAttribute = this->pFileAttributes->find("Model");
+    if (pAttribute) {
+      pAttribute->getValue(NDAttrString, tagString);
+      TIFFSetField(this->output, TIFFTAG_MODEL, tagString);
+    } else {
+      TIFFSetField(this->output, TIFFTAG_MODEL, "Unknown");
+    }
+    
+    pAttribute = this->pFileAttributes->find("Manufacturer");
+    if (pAttribute) {
+      pAttribute->getValue(NDAttrString, tagString);
+      TIFFSetField(this->output, TIFFTAG_MAKE, tagString);
+    } else {
+      TIFFSetField(this->output, TIFFTAG_MAKE, "Unknown");
+    }
+
+    TIFFSetField(this->output, TIFFTAG_SOFTWARE, "EPICS areaDetector");
+
+    int count = 0;
+    int tagId = TIFFTAG_START_;
+   
+    numAttributes_ = this->pFileAttributes->count();
+    asynPrint(this->pasynUserSelf, ASYN_TRACE_FLOW,
+		"%s:%s this->pFileAttributes->count(): %d\n",
+		driverName, functionName, numAttributes_);
+
+    fieldInfo_ = (TIFFFieldInfo**) malloc(numAttributes_ * sizeof(TIFFFieldInfo *));
+    if (fieldInfo_ == NULL) {
+      asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
+		"%s:%s error, fieldInfo_ malloc failed. file: %s\n",
+		driverName, functionName, fileName);
+      return asynError;
+    }
+    for (int i=0; i<numAttributes_; ++i) {
+      asynPrint(this->pasynUserSelf, ASYN_TRACE_FLOW,
+		"%s:%s Initializing %d fieldInfo_ entry.\n",
+		driverName, functionName, i);
+      fieldInfo_[i] = NULL;
+    }
+    
+    asynPrint(this->pasynUserSelf, ASYN_TRACE_FLOW,
+		"%s:%s Looping over attributes...\n",
+		driverName, functionName);
+
+    pAttribute = this->pFileAttributes->next(NULL);
+    while (pAttribute) {
+        
+      const char *attributeName = pAttribute->getName();
+      //const char *attributeDescription = pAttribute->getDescription();
+      const char *attributeSource = pAttribute->getSource();
+
+      asynPrint(this->pasynUserSelf, ASYN_TRACE_FLOW,
+		"%s:%s : attribute: %s, source: %s\n",
+		driverName, functionName, attributeName, attributeSource);
+
+      NDAttrDataType_t attrDataType;
+      size_t attrSize;
+      NDAttrValue value;
+      pAttribute->getValueInfo(&attrDataType, &attrSize);
+      memset(tagString, 0, MAX_ATTRIBUTE_STRING_SIZE);
+
+      switch (attrDataType) {
+        case NDAttrInt8:
+        case NDAttrUInt8:
+        case NDAttrInt16:
+        case NDAttrUInt16:
+        case NDAttrInt32:
+        case NDAttrUInt32:
+	  {
+	    pAttribute->getValue(attrDataType, &value.i32);
+	    snprintf(tagString, MAX_ATTRIBUTE_STRING_SIZE, "%s:%d", attributeName, value.i32);
+	    break;
+	  }
+        case NDAttrFloat32:
+	  {
+	    pAttribute->getValue(attrDataType, &value.f32);
+	    snprintf(tagString, MAX_ATTRIBUTE_STRING_SIZE, "%s:%f", attributeName, value.f32);
+	    break;
+	  }
+        case NDAttrFloat64:
+	  {
+	    pAttribute->getValue(attrDataType, &value.f64);
+	    snprintf(tagString, MAX_ATTRIBUTE_STRING_SIZE, "%s:%f", attributeName, value.f64);
+	    break;
+	  }
+        case NDAttrString:
+	  {
+	    memset(attrString, 0, MAX_ATTRIBUTE_STRING_SIZE);
+	    pAttribute->getValue(attrDataType, attrString, MAX_ATTRIBUTE_STRING_SIZE);
+	    snprintf(tagString, MAX_ATTRIBUTE_STRING_SIZE, "%s:%s", attributeName, attrString);
+	    break;
+	  }
+        case NDAttrUndefined:
+	  break;
+        default:
+	  asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
+                    "%s:%s error, unknown attrDataType=%d\n",
+                    driverName, functionName, attrDataType);
+	  return asynError;
+	  break;
+      }
+	
+      if (attrDataType != NDAttrUndefined) {
+	asynPrint(this->pasynUserSelf, ASYN_TRACE_FLOW,
+		"%s:%s : tagId: %d, tagString: %s\n",
+		  driverName, functionName, tagId, tagString);
+	fieldInfo_[count] = (TIFFFieldInfo*) malloc(sizeof(TIFFFieldInfo));
+	populateAsciiFieldInfo(fieldInfo_[count], tagId, attributeName);
+	TIFFMergeFieldInfo(output, fieldInfo_[count], 1);
+	TIFFSetField(this->output, tagId, tagString);
+	++count;
+	++tagId;
+	if ((tagId == TIFFTAG_END_) || (count > numAttributes_)) {
+	  asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
+		    "%s:%s error, Too many tags/attributes for file. tagId: %d, count: %d\n",
+		    driverName, functionName, tagId, count);
+	  break;
+	}
+      }
+      
+      pAttribute = this->pFileAttributes->next(pAttribute);
+    }
     
     return(asynSuccess);
 }
+
+/**
+ * Populate a TIFFFieldInfo structure with fields suitable for 
+ * writing a ASCII TIFF custom tag.
+ * \param[in] fieldInfo Pointer to a TIFFFieldInfo structure.
+ * \param[in] fieldTag TIFF tag number to use.
+ * \param[in] tagName Pointer to a char array for the tag name.
+ */
+asynStatus NDFileTIFF::populateAsciiFieldInfo(TIFFFieldInfo *fieldInfo, int fieldTag, const char *tagName)
+{
+  asynStatus status = asynSuccess;
+
+  if (fieldInfo) {
+    fieldInfo->field_tag = fieldTag;
+    fieldInfo->field_readcount = 1;
+    fieldInfo->field_writecount = 1;
+    fieldInfo->field_type = TIFF_ASCII;
+    fieldInfo->field_bit = FIELD_CUSTOM;
+    fieldInfo->field_oktochange = 1;
+    fieldInfo->field_passcount = 0;
+    if (tagName) {
+      fieldInfo->field_name = (char *)tagName;
+    } else {
+      status = asynError;
+    }
+  } else {
+    status = asynError;
+  }
+  
+  return status;
+
+}
+
 
 /** Writes single NDArray to the TIFF file.
   * \param[in] pArray Pointer to the NDArray to be written
@@ -254,6 +431,11 @@ asynStatus NDFileTIFF::closeFile()
 
     TIFFClose(this->output);
 
+    for (int i=0; i<numAttributes_; ++i) {
+      free(fieldInfo_[i]);
+    }
+    free(fieldInfo_);
+
     return asynSuccess;
 }
 
@@ -288,6 +470,9 @@ NDFileTIFF::NDFileTIFF(const char *portName, int queueSize, int blockingCallback
     /* Set the plugin type string */    
     setStringParam(NDPluginDriverPluginType, "NDFileTIFF");
     this->supportsMultipleArrays = 0;
+
+    this->pAttributeId = NULL;
+    this->pFileAttributes = new NDAttributeList;
 }
 
 /* Configuration routine.  Called directly, or from the iocsh  */

--- a/ADApp/pluginSrc/NDFileTIFF.h
+++ b/ADApp/pluginSrc/NDFileTIFF.h
@@ -36,6 +36,16 @@ public:
 private:
     TIFF *output;
     NDColorMode_t colorMode;
+    int *pAttributeId;
+    NDAttributeList *pFileAttributes;
+    TIFFFieldInfo **fieldInfo_;
+    int numAttributes_;
+
+    static const int TIFFTAG_START_;
+    static const int TIFFTAG_END_;
+
+    asynStatus populateAsciiFieldInfo(TIFFFieldInfo *fieldInfo, int fieldTag, const char *tagName);
+
 };
 #define NUM_NDFILE_TIFF_PARAMS 0
 #endif


### PR DESCRIPTION
Add all NDAttributes as TIFF ASCII Tags. The attribute name is encoded in the ASCII tag value. Using tag number 65010 and up.

Removed hard coded 'Unknown' strings for the Manufacturer and Model tags.
