### PR TITLE
Add support for setting the width of the overlay crosshair and rectangle...

### DIFF
--- a/ADApp/Db/NDOverlayN.template
+++ b/ADApp/Db/NDOverlayN.template
@@ -51,7 +51,7 @@ record(bi, "$(P)$(R)Use_RBV")
 
 record(longout, "$(P)$(R)PositionXLink")
 {
-    field(DOL,  "$(XPOS) CP MS")
+    field(DOL,  "$(XPOS="") CP MS")
     field(OMSL, "closed_loop")
     field(OUT, "$(P)$(R)PositionX PP")
 }
@@ -75,7 +75,7 @@ record(longin, "$(P)$(R)PositionX_RBV")
 
 record(longout, "$(P)$(R)PositionYLink")
 {
-    field(DOL,  "$(YPOS) CP MS")
+    field(DOL,  "$(YPOS="") CP MS")
     field(OMSL, "closed_loop")
     field(OUT, "$(P)$(R)PositionY PP")
 }
@@ -99,7 +99,7 @@ record(longin, "$(P)$(R)PositionY_RBV")
 
 record(longout, "$(P)$(R)SizeXLink")
 {
-    field(DOL,  "$(XSIZE) CP MS")
+    field(DOL,  "$(XSIZE="") CP MS")
     field(OMSL, "closed_loop")
     field(OUT, "$(P)$(R)SizeX PP")
 }
@@ -123,7 +123,7 @@ record(longin, "$(P)$(R)SizeX_RBV")
 
 record(longout, "$(P)$(R)SizeYLink")
 {
-    field(DOL,  "$(YSIZE) CP MS")
+    field(DOL,  "$(YSIZE="") CP MS")
     field(OMSL, "closed_loop")
     field(OUT, "$(P)$(R)SizeY PP")
 }
@@ -142,6 +142,54 @@ record(longin, "$(P)$(R)SizeY_RBV")
 {
     field(DTYP, "asynInt32")
     field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))OVERLAY_SIZE_Y")
+    field(SCAN, "I/O Intr")
+}
+
+record(longout, "$(P)$(R)WidthXLink")
+{
+    field(DOL,  "$(XWIDTH="") CP MS")
+    field(OMSL, "closed_loop")
+    field(OUT, "$(P)$(R)WidthX PP")
+}
+
+record(longout, "$(P)$(R)WidthX")
+{
+    field(PINI, "YES")
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))OVERLAY_WIDTH_X")
+    field(LOPR, "1")
+    field(HOPR, "1024")
+    field(VAL,  "1")
+}
+
+record(longin, "$(P)$(R)WidthX_RBV")
+{
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))OVERLAY_WIDTH_X")
+    field(SCAN, "I/O Intr")
+}
+
+record(longout, "$(P)$(R)WidthYLink")
+{
+    field(DOL,  "$(YWIDTH="") CP MS")
+    field(OMSL, "closed_loop")
+    field(OUT, "$(P)$(R)WidthY PP")
+}
+
+record(longout, "$(P)$(R)WidthY")
+{
+    field(PINI, "YES")
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))OVERLAY_WIDTH_Y")
+    field(LOPR, "1")
+    field(HOPR, "1024")
+    field(VAL,  "1")
+}
+
+record(longin, "$(P)$(R)WidthY_RBV")
+{
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))OVERLAY_WIDTH_Y")
     field(SCAN, "I/O Intr")
 }
 

--- a/ADApp/Db/NDOverlayN_settings.req
+++ b/ADApp/Db/NDOverlayN_settings.req
@@ -8,6 +8,10 @@ $(P)$(R)SizeXLink.DOL
 $(P)$(R)SizeX
 $(P)$(R)SizeYLink.DOL
 $(P)$(R)SizeY
+$(P)$(R)WidthXLink.DOL
+$(P)$(R)WidthX
+$(P)$(R)WidthYLink.DOL
+$(P)$(R)WidthY
 $(P)$(R)DrawMode
 $(P)$(R)Shape
 $(P)$(R)Red

--- a/ADApp/pluginSrc/NDPluginOverlay.cpp
+++ b/ADApp/pluginSrc/NDPluginOverlay.cpp
@@ -60,6 +60,7 @@ template <typename epicsType>
 void NDPluginOverlay::doOverlayT(NDArray *pArray, NDOverlay_t *pOverlay)
 {
     size_t xmin, xmax, ymin, ymax, ix, iy, ii, jj, ib;
+    size_t xwide, ywide, xwidemax_line, xwidemin_line;
     epicsType *pRow;
     char textOutStr[512];                    // our string, maybe with a time stamp, to place into the image array
     char *cp;                                // character pointer to current character being rendered
@@ -87,12 +88,23 @@ void NDPluginOverlay::doOverlayT(NDArray *pArray, NDOverlay_t *pOverlay)
                 ymin = pOverlay->PositionY - pOverlay->SizeY;
             ymax = pOverlay->PositionY + pOverlay->SizeY;
             ymax = MIN(ymax, this->arrayInfo.ySize-1);
+            xwide = (pOverlay->WidthX == 1) ? 0 : pOverlay->WidthX / 2;
+            ywide = (pOverlay->WidthY == 1) ? 0 : pOverlay->WidthY / 2;
+            xwide = MIN(xwide, pOverlay->SizeX-1);
+            ywide = MIN(ywide, pOverlay->SizeY);
+
             for (iy=ymin; iy<ymax; iy++) {
                 pRow = (epicsType *)pArray->pData + iy*this->arrayInfo.yStride;
-                if (iy == pOverlay->PositionY) {
-                    for (ix=xmin; ix<xmax; ix++) setPixel<epicsType>(&pRow[ix*this->arrayInfo.xStride], pOverlay);
+                if ((iy >= (pOverlay->PositionY - ywide)) && (iy <= (pOverlay->PositionY + ywide))) {
+                    for (ix=xmin; ix<xmax; ++ix) {
+                        setPixel(&pRow[ix*this->arrayInfo.xStride], pOverlay);
+                    }
                 } else {
-                    setPixel<epicsType>(&pRow[pOverlay->PositionX * this->arrayInfo.xStride], pOverlay);
+                    xwidemin_line = (pOverlay->PositionX - xwide)*this->arrayInfo.xStride;
+                    xwidemax_line = (pOverlay->PositionX + xwide)*this->arrayInfo.xStride;
+                    for (epicsUInt32 line=xwidemin_line; line<=xwidemax_line; ++line) {
+                        setPixel<epicsType>(&pRow[line], pOverlay);
+                    }
                 }
             }
             break;
@@ -106,13 +118,25 @@ void NDPluginOverlay::doOverlayT(NDArray *pArray, NDOverlay_t *pOverlay)
             ymin = MAX(ymin, 0);
             ymax = pOverlay->PositionY + pOverlay->SizeY;
             ymax = MIN(ymax, this->arrayInfo.ySize);
+            xwide = (pOverlay->WidthX == 1) ? 0 : pOverlay->WidthX / 2;
+            ywide = (pOverlay->WidthY == 1) ? 0 : pOverlay->WidthY / 2;
+            xwide = MIN(xwide, pOverlay->SizeX-1);
+            ywide = MIN(ywide, pOverlay->SizeY);
+
+            //For non-zero width, grow the rectangle towards the center.
             for (iy=ymin; iy<ymax; iy++) {
                 pRow = (epicsType *)pArray->pData + iy*arrayInfo.yStride;
-                if ((iy == ymin) || (iy == ymax-1)) {
-                    for (ix=xmin; ix<xmax; ix++) setPixel<epicsType>(&pRow[ix*this->arrayInfo.xStride], pOverlay);
+                if ((iy >= ymin) && (iy <= (ymin + ywide))) {
+                    for (ix=xmin; ix<xmax; ix++) setPixel(&pRow[ix*this->arrayInfo.xStride], pOverlay);
+                } else if ((iy >= (ymax-1 - ywide)) && (iy <= ymax-1)) {
+                    for (ix=xmin; ix<xmax; ix++) setPixel(&pRow[ix*this->arrayInfo.xStride], pOverlay);
                 } else {
-                    setPixel<epicsType>(&pRow[xmin*this->arrayInfo.xStride], pOverlay);
-                    setPixel<epicsType>(&pRow[(xmax-1)*this->arrayInfo.xStride], pOverlay);
+                    for (epicsUInt32 line=xmin; line<=xmin+xwide; ++line) {
+                        setPixel(&pRow[line*this->arrayInfo.xStride], pOverlay);
+                    }
+                    for (epicsUInt32 line=(xmax-xwide); line<=xmax; ++line) {
+                        setPixel(&pRow[(line-1)*this->arrayInfo.xStride], pOverlay);
+                    }
                 }
             }
             break;
@@ -269,6 +293,8 @@ void NDPluginOverlay::processCallbacks(NDArray *pArray)
         pOverlay->PositionY = MIN(pOverlay->PositionY, this->arrayInfo.ySize-1);
         getIntegerParam(overlay, NDPluginOverlaySizeX,      &itemp); pOverlay->SizeX = itemp;
         getIntegerParam(overlay, NDPluginOverlaySizeY,      &itemp); pOverlay->SizeY = itemp;
+        getIntegerParam(overlay, NDPluginOverlayWidthX,     &itemp); pOverlay->WidthX = itemp;
+        getIntegerParam(overlay, NDPluginOverlayWidthY,     &itemp); pOverlay->WidthY = itemp;
         getIntegerParam(overlay, NDPluginOverlayShape,      &itemp); pOverlay->shape = (NDOverlayShape_t)itemp;
         getIntegerParam(overlay, NDPluginOverlayDrawMode,   &itemp); pOverlay->drawMode = (NDOverlayDrawMode_t)itemp;
         getIntegerParam(overlay, NDPluginOverlayRed,        &pOverlay->red);
@@ -343,6 +369,8 @@ NDPluginOverlay::NDPluginOverlay(const char *portName, int queueSize, int blocki
     createParam(NDPluginOverlayPositionYString,     asynParamInt32, &NDPluginOverlayPositionY);
     createParam(NDPluginOverlaySizeXString,         asynParamInt32, &NDPluginOverlaySizeX);
     createParam(NDPluginOverlaySizeYString,         asynParamInt32, &NDPluginOverlaySizeY);
+    createParam(NDPluginOverlayWidthXString,        asynParamInt32, &NDPluginOverlayWidthX);
+    createParam(NDPluginOverlayWidthYString,        asynParamInt32, &NDPluginOverlayWidthY);
     createParam(NDPluginOverlayShapeString,         asynParamInt32, &NDPluginOverlayShape);
     createParam(NDPluginOverlayDrawModeString,      asynParamInt32, &NDPluginOverlayDrawMode);
     createParam(NDPluginOverlayRedString,           asynParamInt32, &NDPluginOverlayRed);

--- a/ADApp/pluginSrc/NDPluginOverlay.h
+++ b/ADApp/pluginSrc/NDPluginOverlay.h
@@ -23,6 +23,8 @@ typedef struct NDOverlay {
     size_t PositionY;
     size_t SizeX;
     size_t SizeY;
+    size_t WidthX;
+    size_t WidthY;
     NDOverlayShape_t shape;
     NDOverlayDrawMode_t drawMode;
     int red;
@@ -38,10 +40,12 @@ typedef struct NDOverlay {
 #define NDPluginOverlayMaxSizeYString           "MAX_SIZE_Y"            /* (asynInt32,   r/o) Maximum size of overlay in Y dimension */
 #define NDPluginOverlayNameString               "NAME"                  /* (asynOctet,   r/w) Name of this overlay */
 #define NDPluginOverlayUseString                "USE"                   /* (asynInt32,   r/w) Use this overlay? */
-#define NDPluginOverlayPositionXString          "OVERLAY_POSITION_X"    /* (asynInt32,   r/o) X positoin of overlay */
-#define NDPluginOverlayPositionYString          "OVERLAY_POSITION_Y"    /* (asynInt32,   r/w) X position of overlay */
+#define NDPluginOverlayPositionXString          "OVERLAY_POSITION_X"    /* (asynInt32,   r/o) X position of overlay */
+#define NDPluginOverlayPositionYString          "OVERLAY_POSITION_Y"    /* (asynInt32,   r/w) Y position of overlay */
 #define NDPluginOverlaySizeXString              "OVERLAY_SIZE_X"        /* (asynInt32,   r/o) X size of overlay */
-#define NDPluginOverlaySizeYString              "OVERLAY_SIZE_Y"        /* (asynInt32,   r/w) X size of overlay */
+#define NDPluginOverlaySizeYString              "OVERLAY_SIZE_Y"        /* (asynInt32,   r/w) Y size of overlay */
+#define NDPluginOverlayWidthXString             "OVERLAY_WIDTH_X"       /* (asynInt32,   r/o) X width of overlay */
+#define NDPluginOverlayWidthYString             "OVERLAY_WIDTH_Y"       /* (asynInt32,   r/w) Y width of overlay */
 #define NDPluginOverlayShapeString              "OVERLAY_SHAPE"         /* (asynInt32,   r/w) Shape of overlay */
 #define NDPluginOverlayDrawModeString           "OVERLAY_DRAW_MODE"     /* (asynInt32,   r/w) Drawing mode for overlay */
 #define NDPluginOverlayRedString                "OVERLAY_RED"           /* (asynInt32,   r/w) Red value for overlay */
@@ -74,6 +78,8 @@ protected:
     int NDPluginOverlayPositionY;
     int NDPluginOverlaySizeX;
     int NDPluginOverlaySizeY;
+    int NDPluginOverlayWidthX;
+    int NDPluginOverlayWidthY;
     int NDPluginOverlayShape;
     int NDPluginOverlayDrawMode;
     int NDPluginOverlayRed;


### PR DESCRIPTION
.... The default is 1, and can be increased in steps of 2 up until the size of the overlay. Add the Width records to the autosave req files. Make the Position and Size link fields optional.

More detail:

This only affects the cross-hair and rectangle, and has no change in behavior if the WidthX and WidthY are left at 1. In the template file I added the supporting records, and also changed the existing Position and Size DOL fields to be optional. I also fixed a couple of typos in the comments in the overlay header file.
