### PR TITLE
fix ImageJ viewer NullPointerException on Snap button press

### DIFF
--- a/Viewers/ImageJ/EPICS_areaDetector/EPICS_AD_Viewer.java
+++ b/Viewers/ImageJ/EPICS_areaDetector/EPICS_AD_Viewer.java
@@ -169,8 +169,9 @@ public class EPICS_AD_Viewer implements PlugIn
 
     public void makeImageCopy()
     {
-        ImageProcessor dipcopy = img.getProcessor().duplicate();
-        ImagePlus imgcopy = new ImagePlus(PVPrefix + ":" + UniqueId, dipcopy);
+        ImageProcessor ip = img.getProcessor();
+        if (ip == null) return;
+        ImagePlus imgcopy = new ImagePlus(PVPrefix + ":" + UniqueId, ip.duplicate());
         imgcopy.show();
     }
 


### PR DESCRIPTION
ImagePlus.getProcessor() will return null if the ImagePlus
instance has no ImageProcessor nor AWT Image.  This can occur in
EPICS_AD_Viewer.makeImageCopy(), so it needs to handle this case to
avoid a NullPointerException.

One way to reproduce this problem is to start the areaDetector
Simulator, but don't acquire any frames.  Then in the ImageJ viewer,
connect to the AD simulator Image1 plug-in (i.e. 13SIM1:image1:),
press "Start", and then press "Snap".  This will produce a
NullPointerException.  There are likely other ways to reproduce this
problem probably involving closing the image window and pressing the
"Snap" button.
