### PR TITLE
replace ImageJ viewer boolean bitwise-and with conditional-and

### DIFF
--- a/Viewers/ImageJ/EPICS_areaDetector/EPICS_AD_Viewer.java
+++ b/Viewers/ImageJ/EPICS_areaDetector/EPICS_AD_Viewer.java
@@ -316,7 +316,7 @@ public class EPICS_AD_Viewer implements PlugIn
                          ch_colorMode != null && ch_colorMode.getConnectionState() == Channel.ConnectionState.CONNECTED &&
                          ch_image != null && ch_image.getConnectionState() == Channel.ConnectionState.CONNECTED &&
                          ch_image_id != null && ch_image_id.getConnectionState() == Channel.ConnectionState.CONNECTED);
-            if (connected & !isConnected)
+            if (connected && !isConnected)
             {
                 isConnected = true;
                 logMessage("Connected to EPICS PVs OK", true, true);


### PR DESCRIPTION
The ImageJ viewer tests the value of a bitwise-and expression on two
boolean values: "connected & !isConnected".  This is unusual.  It is
very likely the intention was to use a conditional-and: "connected &&
!isConnected".  Change this expression to use a conditional-and.

A conditional-and will short-circuit, whereas a bitwise-and will not.
In this particular case, the resulting value of the expressions will be
the same, but a conditional-and is the more appropriate operation.
