### PR TITLE
Add autosave info tags to all the set records in ADBase and the various ...

### DIFF
--- a/ADApp/Db/ADBase.template
+++ b/ADApp/Db/ADBase.template
@@ -74,6 +74,7 @@ record(mbbo, "$(P)$(R)DataType")
    field(SXVL, "6")
    field(SVST, "Float64")
    field(SVVL, "7")
+   info(autosaveFields, "VAL")
 }
 
 record(mbbi, "$(P)$(R)DataType_RBV")
@@ -125,6 +126,7 @@ record(mbbo, "$(P)$(R)ColorMode")
    field(SXVL, "6")
    field(SVST, "YUV421")
    field(SVVL, "7")
+   info(autosaveFields, "VAL")
 }
 
 record(mbbi, "$(P)$(R)ColorMode_RBV")
@@ -161,6 +163,7 @@ record(longout, "$(P)$(R)BinX")
    field(DTYP, "asynInt32")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))BIN_X")
    field(VAL,  "1")
+   info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)BinX_RBV")
@@ -176,6 +179,7 @@ record(longout, "$(P)$(R)BinY")
    field(DTYP, "asynInt32")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))BIN_Y")
    field(VAL,  "1")
+   info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)BinY_RBV")
@@ -191,6 +195,7 @@ record(longout, "$(P)$(R)MinX")
    field(DTYP, "asynInt32")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))MIN_X")
    field(VAL,  "0")
+   info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)MinX_RBV")
@@ -206,6 +211,7 @@ record(longout, "$(P)$(R)MinY")
    field(DTYP, "asynInt32")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))MIN_Y")
    field(VAL,  "0")
+   info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)MinY_RBV")
@@ -221,6 +227,7 @@ record(longout, "$(P)$(R)SizeX")
    field(DTYP, "asynInt32")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))SIZE_X")
    field(VAL,  "1")
+   info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)SizeX_RBV")
@@ -236,6 +243,7 @@ record(longout, "$(P)$(R)SizeY")
    field(DTYP, "asynInt32")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))SIZE_Y")
    field(VAL,  "1")
+   info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)SizeY_RBV")
@@ -253,6 +261,7 @@ record(bo, "$(P)$(R)ReverseX")
    field(ZNAM, "No")
    field(ONAM, "Yes")
    field(VAL,  "0")
+   info(autosaveFields, "VAL")
 }
 
 record(bi, "$(P)$(R)ReverseX_RBV")
@@ -272,6 +281,7 @@ record(bo, "$(P)$(R)ReverseY")
    field(ZNAM, "No")
    field(ONAM, "Yes")
    field(VAL,  "0")
+   info(autosaveFields, "VAL")
 }
 
 record(bi, "$(P)$(R)ReverseY_RBV")
@@ -322,6 +332,7 @@ record(ao, "$(P)$(R)AcquireTime")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ACQ_TIME")
    field(PREC, "3")
    field(VAL,  "1.0")
+   info(autosaveFields, "VAL")
 }
 
 record(ai, "$(P)$(R)AcquireTime_RBV")
@@ -339,6 +350,7 @@ record(ao, "$(P)$(R)AcquirePeriod")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ACQ_PERIOD")
    field(PREC, "3")
    field(VAL,  "0")
+   info(autosaveFields, "VAL")
 }
 
 record(ai, "$(P)$(R)AcquirePeriod_RBV")
@@ -367,6 +379,7 @@ record(ao, "$(P)$(R)Gain")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))GAIN")
    field(VAL,  "1.0")
    field(PREC, "3")
+   info(autosaveFields, "VAL")
 }
 
 record(ai, "$(P)$(R)Gain_RBV")
@@ -394,6 +407,7 @@ record(mbbo, "$(P)$(R)FrameType")
    field(THST, "DblCorrelation")
    field(THVL, "3")
    field(VAL,  "0")
+   info(autosaveFields, "VAL")
 }
 
 record(mbbi, "$(P)$(R)FrameType_RBV")
@@ -426,6 +440,7 @@ record(mbbo, "$(P)$(R)ImageMode")
    field(TWST, "Continuous")
    field(TWVL, "2")
    field(VAL,  "2")
+   info(autosaveFields, "VAL")
 }
 
 record(mbbi, "$(P)$(R)ImageMode_RBV")
@@ -454,6 +469,7 @@ record(mbbo, "$(P)$(R)TriggerMode")
    field(ONST, "External")
    field(ONVL, "1")
    field(VAL,  "0")
+   info(autosaveFields, "VAL")
 }
 
 record(mbbi, "$(P)$(R)TriggerMode_RBV")
@@ -477,6 +493,7 @@ record(longout, "$(P)$(R)NumExposures")
    field(DTYP, "asynInt32")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))NEXPOSURES")
    field(VAL,  "1")
+   info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)NumExposures_RBV")
@@ -498,6 +515,7 @@ record(longout, "$(P)$(R)NumImages")
    field(DTYP, "asynInt32")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))NIMAGES")
    field(VAL,  "1")
+   info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)NumImages_RBV")
@@ -619,6 +637,7 @@ record(bo, "$(P)$(R)ArrayCallbacks")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ARRAY_CALLBACKS")
     field(ZNAM, "Disable")
     field(ONAM, "Enable")
+    info(autosaveFields, "VAL")
 }
 
 record(bi, "$(P)$(R)ArrayCallbacks_RBV")
@@ -641,6 +660,7 @@ record(waveform, "$(P)$(R)NDAttributesFile")
     field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ND_ATTRIBUTES_FILE")
     field(FTVL, "CHAR")
     field(NELM, "256")
+    info(autosaveFields, "VAL")
 }
 
 ###################################################################
@@ -683,6 +703,7 @@ record(bo,"$(P)$(R)ReadStatus") {
     field(OUT, "@asyn($(PORT),$(ADDR),$(TIMEOUT))READ_STATUS")
     field(VAL, "1")
     field(SCAN,"Passive")
+    info(autosaveFields, "SCAN")
 }
 
 ###################################################################
@@ -701,6 +722,7 @@ record(mbbo, "$(P)$(R)ShutterMode")
     field(TWST, "Detector output")
     field(TWVL, "2")
     field(VAL,  "0")
+    info(autosaveFields, "VAL")
 }
 
 record(mbbi, "$(P)$(R)ShutterMode_RBV")
@@ -753,6 +775,7 @@ record(ao, "$(P)$(R)ShutterOpenDelay")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))SHUTTER_OPEN_DELAY")
    field(PREC, "3")
    field(VAL,  "0.0")
+   info(autosaveFields, "VAL")
 }
 
 record(ai, "$(P)$(R)ShutterOpenDelay_RBV")
@@ -770,6 +793,7 @@ record(ao, "$(P)$(R)ShutterCloseDelay")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))SHUTTER_CLOSE_DELAY")
    field(PREC, "3")
    field(VAL,  "0.0")
+   info(autosaveFields, "VAL")
 }
 
 record(ai, "$(P)$(R)ShutterCloseDelay_RBV")
@@ -807,6 +831,7 @@ record(calcout, "$(P)$(R)ShutterOpenEPICS")
     field(DOPT, "Use OCAL")
     field(OCAL, "1")
     field(OUT,  "")
+    info(autosaveFields, "OUT OCAL")
 }
 
 record(calcout, "$(P)$(R)ShutterCloseEPICS")
@@ -817,6 +842,7 @@ record(calcout, "$(P)$(R)ShutterCloseEPICS")
     field(DOPT, "Use OCAL")
     field(OCAL, "0")
     field(OUT,  "")
+    info(autosaveFields, "OUT OCAL")
 }
 
 record(mbbi, "$(P)$(R)ShutterStatusEPICS_RBV")
@@ -829,6 +855,7 @@ record(mbbi, "$(P)$(R)ShutterStatusEPICS_RBV")
     field(ONVL, "1")
     field(ONST, "Open")
     field(ONSV, "MINOR")
+    info(autosaveFields, "INP ZRVL ONVL")
 }
 
 ###################################################################
@@ -843,6 +870,7 @@ record(ao, "$(P)$(R)Temperature")
    field(PREC, "1")
    field(EGU,  "C")
    field(VAL,  "25.0")
+   info(autosaveFields, "VAL")
 }
 
 record(ai, "$(P)$(R)Temperature_RBV")
@@ -894,6 +922,7 @@ record(ai, "$(P)$(R)PoolUsedMem")
    field(EGU,  "MB")
    field(SCAN, "1 second")
    field(FLNK, "$(P)$(R)PoolAllocBuffers")
+   info(autosaveFields, "SCAN")
 }
 
 record(longin, "$(P)$(R)PoolAllocBuffers")

--- a/ADApp/Db/NDColorConvert.template
+++ b/ADApp/Db/NDColorConvert.template
@@ -28,6 +28,7 @@ record(mbbo, "$(P)$(R)ColorModeOut")
    field(SXVL, "6")
    field(SVST, "YUV421")
    field(SVVL, "7")
+   info(autosaveFields, "VAL")
 }
 
 record(mbbi, "$(P)$(R)ColorModeOut_RBV")
@@ -64,6 +65,7 @@ record(mbbo, "$(P)$(R)FalseColor")
    field(ONVL, "1")
    field(TWST, "Iron")
    field(TWVL, "2")
+   info(autosaveFields, "VAL")
 }
 
 record(mbbi, "$(P)$(R)FalseColor_RBV")

--- a/ADApp/Db/NDFile.template
+++ b/ADApp/Db/NDFile.template
@@ -14,6 +14,7 @@ record(waveform, "$(P)$(R)FilePath")
     field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))FILE_PATH")
     field(FTVL, "CHAR")
     field(NELM, "256")
+    info(autosaveFields, "VAL")
 }
 
 record(waveform, "$(P)$(R)FilePath_RBV")
@@ -44,6 +45,7 @@ record(waveform, "$(P)$(R)FileName")
     field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))FILE_NAME")
     field(FTVL, "CHAR")
     field(NELM, "256")
+    info(autosaveFields, "VAL")
 }
 
 record(waveform, "$(P)$(R)FileName_RBV")
@@ -60,6 +62,7 @@ record(longout, "$(P)$(R)FileNumber")
     field(PINI, "YES")
     field(OUT, "$(P)$(R)FileNumber_write PP")
     field(VAL, "1")
+    info(autosaveFields, "VAL")
 }
 
 record(longout, "$(P)$(R)FileNumber_write")
@@ -94,6 +97,7 @@ record(bo, "$(P)$(R)AutoIncrement")
     field(VAL,  "1")
     field(ZNAM, "No")
     field(ONAM, "Yes")
+    info(autosaveFields, "VAL")
 }
 
 record(bi, "$(P)$(R)AutoIncrement_RBV")
@@ -113,6 +117,7 @@ record(waveform, "$(P)$(R)FileTemplate")
     field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))FILE_TEMPLATE")
     field(FTVL, "CHAR")
     field(NELM, "256")
+    info(autosaveFields, "VAL")
 }
 
 record(waveform, "$(P)$(R)FileTemplate_RBV")
@@ -142,6 +147,7 @@ record(bo, "$(P)$(R)AutoSave")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))AUTO_SAVE")
     field(ZNAM, "No")
     field(ONAM, "Yes")
+    info(autosaveFields, "VAL")
 }
 
 record(bi, "$(P)$(R)AutoSave_RBV")
@@ -205,6 +211,7 @@ record(mbbo, "$(P)$(R)FileFormat")
     field(ZRVL, "0")
     field(ONST, "Invalid")
     field(ONVL, "1")
+    info(autosaveFields, "VAL")
 }
 
 record(mbbi, "$(P)$(R)FileFormat_RBV")
@@ -231,6 +238,7 @@ record(mbbo, "$(P)$(R)FileWriteMode")
     field(ONVL, "1")
     field(TWST, "Stream")
     field(TWVL, "2")
+    info(autosaveFields, "VAL")
 }
 
 record(mbbi, "$(P)$(R)FileWriteMode_RBV")
@@ -272,6 +280,7 @@ record(longout, "$(P)$(R)NumCapture")
     field(DTYP, "asynInt32")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))NUM_CAPTURE")
     field(VAL,  "1")
+    info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)NumCapture_RBV")
@@ -297,6 +306,7 @@ record(bo, "$(P)$(R)DeleteDriverFile")
     field(VAL,  "0")
     field(ZNAM, "No")
     field(ONAM, "Yes")
+    info(autosaveFields, "VAL")
 }
 
 record(bi, "$(P)$(R)DeleteDriverFile_RBV")
@@ -336,6 +346,7 @@ record(bo, "$(P)$(R)LazyOpen")
     field(VAL,  "0")
     field(ZNAM, "No")
     field(ONAM, "Yes")
+    info(autosaveFields, "VAL")
 }
 
 record(bi, "$(P)$(R)LazyOpen_RBV")

--- a/ADApp/Db/NDFileHDF5.template
+++ b/ADApp/Db/NDFileHDF5.template
@@ -34,6 +34,7 @@ record(longout, "$(P)$(R)NumRowChunks")
     field(DTYP, "asynInt32")
     field(OUT, "@asyn($(PORT),0)HDF5_nRowChunks")
     field(PINI, "YES")
+    info(autosaveFields, "VAL")
 }
 
 # % gdatag, pv, ro, $(PORT)_NDFileHDF5, NumRowChunks_RBV, Readback of number of rows to use per chunk
@@ -51,6 +52,7 @@ record(longout, "$(P)$(R)NumColChunks")
     field(DTYP, "asynInt32")
     field(OUT, "@asyn($(PORT),0)HDF5_nColChunks")
     field(PINI, "YES")
+    info(autosaveFields, "VAL")
 }
 
 # % gdatag, pv, ro, $(PORT)_NDFileHDF5, NumColChunks_RBV, Readback of number of columns to use per chunk
@@ -68,6 +70,7 @@ record(longout, "$(P)$(R)NumFramesChunks")
     field(DTYP, "asynInt32")
     field(OUT, "@asyn($(PORT),0)HDF5_nFramesChunks")
     field(PINI, "YES")
+    info(autosaveFields, "VAL")
 }
 
 # % gdatag, pv, ro, $(PORT)_NDFileHDF5, NumFramesChunks_RBV, Readback of number of frames to use and cache per chunk
@@ -86,6 +89,7 @@ record(longout, "$(P)$(R)BoundaryAlign")
     field(PINI, "YES")
     field(VAL, "0")
     field(EGU, "bytes")
+    info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)BoundaryAlign_RBV")
@@ -104,6 +108,7 @@ record(longout, "$(P)$(R)BoundaryThreshold")
     field(PINI, "YES")
     field(VAL, "1")
     field(EGU, "bytes")
+    info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)BoundaryThreshold_RBV")
@@ -121,6 +126,7 @@ record(longout, "$(P)$(R)NumExtraDims")
     field(DTYP, "asynInt32")
     field(OUT, "@asyn($(PORT),0)HDF5_nExtraDims")
     field(PINI, "YES")
+    info(autosaveFields, "VAL")
 }
 
 # % gdatag, pv, ro, $(PORT)_NDFileHDF5, NumExtraDims_RBV, Readback number of extra dimensions
@@ -138,6 +144,7 @@ record(longout, "$(P)$(R)ExtraDimSizeN")
     field(DTYP, "asynInt32")
     field(OUT, "@asyn($(PORT),0)HDF5_extraDimSizeN")
     field(PINI, "YES")
+    info(autosaveFields, "VAL")
 }
 
 # % gdatag, pv, ro, $(PORT)_NDFileHDF5, ExtraDimSizeN_RBV, Readback size of extra dimension N (no. of frames per point)
@@ -163,6 +170,7 @@ record(longout, "$(P)$(R)ExtraDimSizeX")
     field(DTYP, "asynInt32")
     field(OUT, "@asyn($(PORT),0)HDF5_extraDimSizeX")
     field(PINI, "YES")
+    info(autosaveFields, "VAL")
 }
 
 # % gdatag, pv, ro, $(PORT)_NDFileHDF5, ExtraDimSizeX_RBV, Readback size of extra dimension X
@@ -188,6 +196,7 @@ record(longout, "$(P)$(R)ExtraDimSizeY")
     field(DTYP, "asynInt32")
     field(OUT, "@asyn($(PORT),0)HDF5_extraDimSizeY")
     field(PINI, "YES")
+    info(autosaveFields, "VAL")
 }
 
 # % gdatag, pv, ro, $(PORT)_NDFileHDF5, ExtraDimSizeY_RBV, Readback size of extra dimension Y
@@ -214,6 +223,7 @@ record(bo, "$(P)$(R)StoreAttr")
     field(PINI, "NO")
     field(ZNAM, "No")
     field(ONAM, "Yes")
+    info(autosaveFields, "VAL")
 }
 
 record(bi, "$(P)$(R)StoreAttr_RBV")
@@ -233,6 +243,7 @@ record(bo, "$(P)$(R)StorePerform")
     field(PINI, "NO")
     field(ZNAM, "No")
     field(ONAM, "Yes")
+    info(autosaveFields, "VAL")
 }
 
 record(bi, "$(P)$(R)StorePerform_RBV")
@@ -273,6 +284,7 @@ record(longout, "$(P)$(R)NumFramesFlush")
     field(DTYP, "asynInt32")
     field(OUT, "@asyn($(PORT),0)HDF5_flushNthFrame")
     field(PINI, "NO")
+    info(autosaveFields, "VAL")
 }
 
 # % gdatag, pv, rw, $(PORT)_NDFileHDF5, NumFramesFlush_RBV, Readback the number of frames between file flush
@@ -297,6 +309,7 @@ record(mbbo, "$(P)$(R)Compression")
     field(TWVL, "2")
     field(THST, "zlib")
     field(THVL, "3")
+    info(autosaveFields, "VAL")
 }
 
 # % gdatag, mbbinary, ro, $(PORT)_NDFileHDF5, Compression_RBV, Readback selected compression filter
@@ -323,6 +336,7 @@ record(longout, "$(P)$(R)NumDataBits")
     field(OUT, "@asyn($(PORT),0)HDF5_nbitsPrecision")
     field(PINI, "NO")
     field(EGU,  "bit")
+    info(autosaveFields, "VAL")
 }
 
 # % gdatag, pv, ro, $(PORT)_NDFileHDF5, NumBitPrecision_RBV, Readback N-bit compression filter: number of data bits per pixel
@@ -342,6 +356,7 @@ record(longout, "$(P)$(R)DataBitsOffset")
     field(OUT, "@asyn($(PORT),0)HDF5_nbitsOffset")
     field(PINI, "NO")
     field(EGU,  "bit")
+    info(autosaveFields, "VAL")
 }
 
 # % gdatag, pv, ro, $(PORT)_NDFileHDF5, NumBitOffset_RBV, Readback N-bit compression filter: dataword bit-offset in pixel
@@ -361,6 +376,7 @@ record(longout, "$(P)$(R)SZipNumPixels")
     field(OUT, "@asyn($(PORT),0)HDF5_szipNumPixels")
     field(PINI, "NO")
     field(EGU,  "bit")
+    info(autosaveFields, "VAL")
 }
 
 # % gdatag, pv, ro, $(PORT)_NDFileHDF5, szipNumPixels_RBV, Readback szip compression filter: number of pixels in filter
@@ -379,6 +395,7 @@ record(longout, "$(P)$(R)ZLevel")
     field(DTYP, "asynInt32")
     field(OUT, "@asyn($(PORT),0)HDF5_zCompressLevel")
     field(PINI, "NO")
+    info(autosaveFields, "VAL")
 }
 
 # % gdatag, pv, ro, $(PORT)_NDFileHDF5, ZCompressLevel_RBV, Readback zlib compression filter: compression level
@@ -430,6 +447,7 @@ record(waveform, "$(P)$(R)XMLFileName")
     field(INP,  "@asyn($(PORT),0)HDF5_layoutFilename")
     field(FTVL, "CHAR")
     field(NELM, "1048576")
+    info(autosaveFields, "VAL")
 }
 
 record(waveform, "$(P)$(R)XMLFileName_RBV")

--- a/ADApp/Db/NDFileJPEG.template
+++ b/ADApp/Db/NDFileJPEG.template
@@ -32,6 +32,7 @@ record(longout, "$(P)$(R)JPEGQuality")
     field(DRVL, "0")
     field(HOPR, "100")
     field(DRVH, "100")
+    info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)JPEGQuality_RBV")

--- a/ADApp/Db/NDFileMagick.template
+++ b/ADApp/Db/NDFileMagick.template
@@ -29,6 +29,7 @@ record(longout, "$(P)$(R)Quality")
     field(DRVL, "0")
     field(HOPR, "100")
     field(DRVH, "100")
+    info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)Quality_RBV")
@@ -55,6 +56,7 @@ record(mbbo, "$(P)$(R)BitDepth")
    field(ONVL, "8")
    field(TWST, "16")
    field(TWVL, "16")
+   info(autosaveFields, "VAL")
 }
 
 record(mbbi, "$(P)$(R)BitDepth_RBV")
@@ -95,6 +97,7 @@ record(mbbo, "$(P)$(R)CompressType")
    field(SXVL, "6")
    field(SVST, "Zip")
    field(SVVL, "7")
+   info(autosaveFields, "VAL")
 }
 
 record(mbbi, "$(P)$(R)CompressType_RBV")

--- a/ADApp/Db/NDFileNexus.template
+++ b/ADApp/Db/NDFileNexus.template
@@ -28,6 +28,7 @@ record(waveform, "$(P)$(R)TemplateFilePath")
     field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))TEMPLATE_FILE_PATH")
     field(FTVL, "CHAR")
     field(NELM, "256")
+    info(autosaveFields, "VAL")
 }
 
 record(waveform, "$(P)$(R)TemplateFilePath_RBV")
@@ -47,6 +48,7 @@ record(waveform, "$(P)$(R)TemplateFileName")
     field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))TEMPLATE_FILE_NAME")
     field(FTVL, "CHAR")
     field(NELM, "256")
+    info(autosaveFields, "VAL")
 }
 
 record(waveform, "$(P)$(R)TemplateFileName_RBV")

--- a/ADApp/Db/NDOverlayN.template
+++ b/ADApp/Db/NDOverlayN.template
@@ -11,6 +11,7 @@ record(stringout, "$(P)$(R)Name")
     field(DTYP, "asynOctetWrite")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))NAME")
     field(VAL,  "$(NAME)")
+    info(autosaveFields, "VAL")
 }
 
 record(stringin, "$(P)$(R)Name_RBV")
@@ -32,6 +33,7 @@ record(bo, "$(P)$(R)Use")
     field(VAL,  "0")
     field(ZNAM, "No")
     field(ONAM, "Yes")
+    info(autosaveFields, "VAL")
 }
 
 record(bi, "$(P)$(R)Use_RBV")
@@ -54,6 +56,7 @@ record(longout, "$(P)$(R)PositionXLink")
     field(DOL,  "$(XPOS="") CP MS")
     field(OMSL, "closed_loop")
     field(OUT, "$(P)$(R)PositionX PP")
+    info(autosaveFields, "DOL")
 }
 
 record(longout, "$(P)$(R)PositionX")
@@ -64,6 +67,7 @@ record(longout, "$(P)$(R)PositionX")
     field(LOPR, "1")
     field(HOPR, "1024")
     field(VAL,  "1")
+    info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)PositionX_RBV")
@@ -78,6 +82,7 @@ record(longout, "$(P)$(R)PositionYLink")
     field(DOL,  "$(YPOS="") CP MS")
     field(OMSL, "closed_loop")
     field(OUT, "$(P)$(R)PositionY PP")
+    info(autosaveFields, "DOL")
 }
 
 record(longout, "$(P)$(R)PositionY")
@@ -88,6 +93,7 @@ record(longout, "$(P)$(R)PositionY")
     field(LOPR, "1")
     field(HOPR, "1024")
     field(VAL,  "1")
+    info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)PositionY_RBV")
@@ -102,6 +108,7 @@ record(longout, "$(P)$(R)SizeXLink")
     field(DOL,  "$(XSIZE="") CP MS")
     field(OMSL, "closed_loop")
     field(OUT, "$(P)$(R)SizeX PP")
+    info(autosaveFields, "DOL")
 }
 
 record(longout, "$(P)$(R)SizeX")
@@ -112,6 +119,7 @@ record(longout, "$(P)$(R)SizeX")
     field(LOPR, "1")
     field(HOPR, "1024")
     field(VAL,  "1")
+    info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)SizeX_RBV")
@@ -126,6 +134,7 @@ record(longout, "$(P)$(R)SizeYLink")
     field(DOL,  "$(YSIZE="") CP MS")
     field(OMSL, "closed_loop")
     field(OUT, "$(P)$(R)SizeY PP")
+    info(autosaveFields, "DOL")
 }
 
 record(longout, "$(P)$(R)SizeY")
@@ -136,6 +145,7 @@ record(longout, "$(P)$(R)SizeY")
     field(LOPR, "1")
     field(HOPR, "1024")
     field(VAL,  "1")
+    info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)SizeY_RBV")
@@ -150,6 +160,7 @@ record(longout, "$(P)$(R)WidthXLink")
     field(DOL,  "$(XWIDTH="") CP MS")
     field(OMSL, "closed_loop")
     field(OUT, "$(P)$(R)WidthX PP")
+    info(autosaveFields, "DOL")
 }
 
 record(longout, "$(P)$(R)WidthX")
@@ -160,6 +171,7 @@ record(longout, "$(P)$(R)WidthX")
     field(LOPR, "1")
     field(HOPR, "1024")
     field(VAL,  "1")
+    info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)WidthX_RBV")
@@ -174,6 +186,7 @@ record(longout, "$(P)$(R)WidthYLink")
     field(DOL,  "$(YWIDTH="") CP MS")
     field(OMSL, "closed_loop")
     field(OUT, "$(P)$(R)WidthY PP")
+    info(autosaveFields, "DOL")
 }
 
 record(longout, "$(P)$(R)WidthY")
@@ -184,6 +197,7 @@ record(longout, "$(P)$(R)WidthY")
     field(LOPR, "1")
     field(HOPR, "1024")
     field(VAL,  "1")
+    info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)WidthY_RBV")
@@ -205,6 +219,7 @@ record(mbbo, "$(P)$(R)Shape")
     field(TWST, "Text")
     field(TWVL, "2")
     field(VAL,  "$(SHAPE)")
+    info(autosaveFields, "VAL")
 }
 
 record(mbbi, "$(P)$(R)Shape_RBV")
@@ -229,6 +244,7 @@ record(mbbo, "$(P)$(R)DrawMode")
     field(ZRVL, "0")
     field(ONST, "XOR")
     field(ONVL, "1")
+    info(autosaveFields, "VAL")
 }
 
 record(mbbi, "$(P)$(R)DrawMode_RBV")
@@ -248,6 +264,7 @@ record(longout, "$(P)$(R)Red")
     field(DTYP, "asynInt32")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))OVERLAY_RED")
     field(VAL,  "1")
+    info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)Red_RBV")
@@ -263,6 +280,7 @@ record(longout, "$(P)$(R)Green")
     field(DTYP, "asynInt32")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))OVERLAY_GREEN")
     field(VAL,  "1")
+    info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)Green_RBV")
@@ -278,6 +296,7 @@ record(longout, "$(P)$(R)Blue")
     field(DTYP, "asynInt32")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))OVERLAY_BLUE")
     field(VAL,  "1")
+    info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)Blue_RBV")
@@ -331,6 +350,7 @@ record(waveform, "$(P)$(R)DisplayText")
     field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))OVERLAY_DISPLAY_TEXT")
     field(FTVL, "CHAR")
     field(NELM, "256")
+    info(autosaveFields, "VAL")
 }
 
 record(waveform, "$(P)$(R)DisplayText_RBV")
@@ -348,6 +368,7 @@ record(stringout, "$(P)$(R)TimeStampFormat")
     field(DTYP, "asynOctetWrite")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))OVERLAY_TIMESTAMP_FORMAT")
     field(VAL,  "%Y-%m-%d %H:%M:%S.%03f")
+    info(autosaveFields, "VAL")
 }
 
 record(stringin, "$(P)$(R)TimeStampFormat_RBV")
@@ -370,6 +391,7 @@ record(mbbo, "$(P)$(R)Font")
     field(TWVL, "2")
     field(THST, "9x15 Bold")
     field(THVL, "3")
+    info(autosaveFields, "VAL")
 }
 
 record(mbbi, "$(P)$(R)Font_RBV")

--- a/ADApp/Db/NDPluginBase.template
+++ b/ADApp/Db/NDPluginBase.template
@@ -37,6 +37,7 @@ record(stringout, "$(P)$(R)NDArrayPort")
     field(DTYP, "asynOctetWrite")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))NDARRAY_PORT")
     field(VAL,  "$(NDARRAY_PORT)")
+    info(autosaveFields, "VAL")
 }
 
 record(stringin, "$(P)$(R)NDArrayPort_RBV")
@@ -52,6 +53,7 @@ record(longout, "$(P)$(R)NDArrayAddress")
     field(DTYP, "asynInt32")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))NDARRAY_ADDR")
     field(VAL,  "$(NDARRAY_ADDR)")
+    info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)NDArrayAddress_RBV")
@@ -73,6 +75,7 @@ record(bo, "$(P)$(R)EnableCallbacks")
     field(ZNAM, "Disable")
     field(ONAM, "Enable")
     field(VAL,  "0")
+    info(autosaveFields, "VAL")
 }
 
 record(bi, "$(P)$(R)EnableCallbacks_RBV")
@@ -94,6 +97,7 @@ record(ao, "$(P)$(R)MinCallbackTime")
     field(EGU,  "s")
     field(PREC, "3")
     field(VAL,  "0.0")
+    info(autosaveFields, "VAL")
 }
 
 record(ai, "$(P)$(R)MinCallbackTime_RBV")
@@ -116,6 +120,7 @@ record(bo, "$(P)$(R)BlockingCallbacks")
     field(ZNAM, "No")
     field(ONAM, "Yes")
     field(VAL,  "0")
+    info(autosaveFields, "VAL")
 }
 
 record(bi, "$(P)$(R)BlockingCallbacks_RBV")
@@ -404,6 +409,7 @@ record(waveform, "$(P)$(R)NDAttributesFile")
     field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ND_ATTRIBUTES_FILE")
     field(FTVL, "CHAR")
     field(NELM, "256")
+    info(autosaveFields, "VAL")
 }
 
 

--- a/ADApp/Db/NDProcess.template
+++ b/ADApp/Db/NDProcess.template
@@ -32,6 +32,7 @@ record(mbbo, "$(P)$(R)DataTypeOut")
     field(EIST, "Automatic")
     field(EIVL, "-1")
     field(VAL,  "8")
+    info(autosaveFields, "VAL")
 }
 
 record(mbbi, "$(P)$(R)DataTypeOut_RBV")
@@ -87,6 +88,7 @@ record(bo, "$(P)$(R)EnableBackground")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ENABLE_BACKGROUND")
     field(ZNAM, "Disable")
     field(ONAM, "Enable")
+    info(autosaveFields, "VAL")
 }
 
 record(bi, "$(P)$(R)EnableBackground_RBV")
@@ -137,6 +139,7 @@ record(bo, "$(P)$(R)EnableFlatField")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ENABLE_FLAT_FIELD")
     field(ZNAM, "Disable")
     field(ONAM, "Enable")
+    info(autosaveFields, "VAL")
 }
 
 record(bi, "$(P)$(R)EnableFlatField_RBV")
@@ -165,6 +168,7 @@ record(ao, "$(P)$(R)ScaleFlatField")
     field(DTYP, "asynFloat64")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))SCALE_FLAT_FIELD")
     field(VAL,  "255.")
+    info(autosaveFields, "VAL")
 }
 
 record(ai, "$(P)$(R)ScaleFlatField_RBV")
@@ -184,6 +188,7 @@ record(bo, "$(P)$(R)EnableOffsetScale")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ENABLE_OFFSET_SCALE")
     field(ZNAM, "Disable")
     field(ONAM, "Enable")
+    info(autosaveFields, "VAL")
 }
 
 # Oneshot record for calculating scale and offset
@@ -213,6 +218,7 @@ record(ao, "$(P)$(R)Offset")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))OFFSET")
     field(PREC, "2")
     field(VAL,  "0.0")
+    info(autosaveFields, "VAL")
 }
 
 record(ai, "$(P)$(R)Offset_RBV")
@@ -230,6 +236,7 @@ record(ao, "$(P)$(R)Scale")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))SCALE")
     field(PREC, "2")
     field(VAL,  "1.0")
+    info(autosaveFields, "VAL")
 }
 
 record(ai, "$(P)$(R)Scale_RBV")
@@ -250,6 +257,7 @@ record(bo, "$(P)$(R)EnableLowClip")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ENABLE_LOW_CLIP")
     field(ZNAM, "Disable")
     field(ONAM, "Enable")
+    info(autosaveFields, "VAL")
 }
 
 record(bi, "$(P)$(R)EnableLowClip_RBV")
@@ -269,6 +277,7 @@ record(ao, "$(P)$(R)LowClip")
     field(DTYP, "asynFloat64")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))LOW_CLIP")
     field(VAL,  "0.0")
+    info(autosaveFields, "VAL")
 }
 
 record(ai, "$(P)$(R)LowClip_RBV")
@@ -285,6 +294,7 @@ record(bo, "$(P)$(R)EnableHighClip")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ENABLE_HIGH_CLIP")
     field(ZNAM, "Disable")
     field(ONAM, "Enable")
+    info(autosaveFields, "VAL")
 }
 
 record(bi, "$(P)$(R)EnableHighClip_RBV")
@@ -304,6 +314,7 @@ record(ao, "$(P)$(R)HighClip")
     field(DTYP, "asynFloat64")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))HIGH_CLIP")
     field(VAL,  "100.0")
+    info(autosaveFields, "VAL")
 }
 
 record(ai, "$(P)$(R)HighClip_RBV")
@@ -323,6 +334,7 @@ record(bo, "$(P)$(R)EnableFilter")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ENABLE_FILTER")
     field(ZNAM, "Disable")
     field(ONAM, "Enable")
+    info(autosaveFields, "VAL")
 }
 
 record(bi, "$(P)$(R)EnableFilter_RBV")
@@ -361,6 +373,7 @@ record(bo, "$(P)$(R)AutoResetFilter")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))AUTO_RESET_FILTER")
     field(ZNAM, "No")
     field(ONAM, "Yes")
+    info(autosaveFields, "VAL")
 }
 
 record(bi, "$(P)$(R)AutoResetFilter_RBV")
@@ -379,6 +392,7 @@ record(bo, "$(P)$(R)FilterCallbacks")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))FILTER_CALLBACKS")
     field(ZNAM, "Every array")
     field(ONAM, "Array N only")
+    info(autosaveFields, "VAL")
 }
 
 record(bi, "$(P)$(R)FilterCallbacks_RBV")
@@ -397,6 +411,7 @@ record(longout, "$(P)$(R)NumFilter")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))NUM_FILTER")
     field(VAL,  "1")
     field(FLNK, "$(P)$(R)NumFilterRecip.PROC PP")
+    info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)NumFilter_RBV")
@@ -429,6 +444,7 @@ record(ao, "$(P)$(R)OOffset")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))FILTER_OOFFSET")
     field(VAL,  "0.0")
     field(PREC, "2")
+    info(autosaveFields, "VAL")
 }
 record(ai, "$(P)$(R)OOffset_RBV")
 {
@@ -445,6 +461,7 @@ record(ao, "$(P)$(R)OScale")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))FILTER_OSCALE")
     field(VAL,  "1.0")
     field(PREC, "2")
+    info(autosaveFields, "VAL")
 }
 record(ai, "$(P)$(R)OScale_RBV")
 {
@@ -461,6 +478,7 @@ record(ao, "$(P)$(R)OC1")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))FILTER_OC1")
     field(VAL,  "1.0")
     field(PREC, "2")
+    info(autosaveFields, "VAL")
 }
 record(ai, "$(P)$(R)OC1_RBV")
 {
@@ -477,6 +495,7 @@ record(ao, "$(P)$(R)OC2")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))FILTER_OC2")
     field(VAL,  "-1.0")
     field(PREC, "2")
+    info(autosaveFields, "VAL")
 }
 record(ai, "$(P)$(R)OC2_RBV")
 {
@@ -493,6 +512,7 @@ record(ao, "$(P)$(R)OC3")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))FILTER_OC3")
     field(VAL,  "0.0")
     field(PREC, "2")
+    info(autosaveFields, "VAL")
 }
 record(ai, "$(P)$(R)OC3_RBV")
 {
@@ -509,6 +529,7 @@ record(ao, "$(P)$(R)OC4")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))FILTER_OC4")
     field(VAL,  "1.0")
     field(PREC, "2")
+    info(autosaveFields, "VAL")
 }
 record(ai, "$(P)$(R)OC4_RBV")
 {
@@ -525,6 +546,7 @@ record(ao, "$(P)$(R)FOffset")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))FILTER_FOFFSET")
     field(VAL,  "0.0")
     field(PREC, "2")
+    info(autosaveFields, "VAL")
 }
 record(ai, "$(P)$(R)FOffset_RBV")
 {
@@ -541,6 +563,7 @@ record(ao, "$(P)$(R)FScale")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))FILTER_FSCALE")
     field(VAL,  "1.0")
     field(PREC, "2")
+    info(autosaveFields, "VAL")
 }
 record(ai, "$(P)$(R)FScale_RBV")
 {
@@ -557,6 +580,7 @@ record(ao, "$(P)$(R)FC1")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))FILTER_FC1")
     field(VAL,  "1.0")
     field(PREC, "2")
+    info(autosaveFields, "VAL")
 }
 record(ai, "$(P)$(R)FC1_RBV")
 {
@@ -573,6 +597,7 @@ record(ao, "$(P)$(R)FC2")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))FILTER_FC2")
     field(VAL,  "-1.0")
     field(PREC, "2")
+    info(autosaveFields, "VAL")
 }
 record(ai, "$(P)$(R)FC2_RBV")
 {
@@ -588,6 +613,7 @@ record(ao, "$(P)$(R)FC3")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))FILTER_FC3")
     field(VAL,  "0.0")
     field(PREC, "2")
+    info(autosaveFields, "VAL")
 }
 record(ai, "$(P)$(R)FC3_RBV")
 {
@@ -604,6 +630,7 @@ record(ao, "$(P)$(R)FC4")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))FILTER_FC4")
     field(VAL,  "1.0")
     field(PREC, "2")
+    info(autosaveFields, "VAL")
 }
 record(ai, "$(P)$(R)FC4_RBV")
 {
@@ -619,6 +646,7 @@ record(ao, "$(P)$(R)ROffset")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))FILTER_ROFFSET")
     field(VAL,  "0.0")
     field(PREC, "2")
+    info(autosaveFields, "VAL")
 }
 record(ai, "$(P)$(R)ROffset_RBV")
 {
@@ -635,6 +663,7 @@ record(ao, "$(P)$(R)RC1")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))FILTER_RC1")
     field(VAL,  "1.0")
     field(PREC, "2")
+    info(autosaveFields, "VAL")
 }
 record(ai, "$(P)$(R)RC1_RBV")
 {
@@ -651,6 +680,7 @@ record(ao, "$(P)$(R)RC2")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))FILTER_RC2")
     field(VAL,  "1.0")
     field(PREC, "2")
+    info(autosaveFields, "VAL")
 }
 record(ai, "$(P)$(R)RC2_RBV")
 {
@@ -677,6 +707,7 @@ record(mbbo, "$(P)$(R)FilterType")
     field(FVST, "CopyToFilter")
     field(FVVL, "6")
     field(FLNK, "$(P)$(R)FilterTypeSeq PP MS")
+    info(autosaveFields, "VAL")
 }
 
 record(seq, "$(P)$(R)FilterTypeSeq")

--- a/ADApp/Db/NDROI.template
+++ b/ADApp/Db/NDROI.template
@@ -10,6 +10,7 @@ record(stringout, "$(P)$(R)Name")
    field(PINI, "YES")
    field(DTYP, "asynOctetWrite")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))NAME")
+   info(autosaveFields, "VAL")
 }
 
 record(stringin, "$(P)$(R)Name_RBV")
@@ -30,6 +31,7 @@ record(longout, "$(P)$(R)BinX")
    field(DTYP, "asynInt32")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))DIM0_BIN")
    field(VAL,  "1")
+   info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)BinX_RBV")
@@ -45,6 +47,7 @@ record(longout, "$(P)$(R)BinY")
    field(DTYP, "asynInt32")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))DIM1_BIN")
    field(VAL,  "1")
+   info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)BinY_RBV")
@@ -60,6 +63,7 @@ record(longout, "$(P)$(R)BinZ")
    field(DTYP, "asynInt32")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))DIM2_BIN")
    field(VAL,  "1")
+   info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)BinZ_RBV")
@@ -76,6 +80,7 @@ record(longout, "$(P)$(R)MinX")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))DIM0_MIN")
    field(LOPR, "0")
    field(VAL,  "0")
+   info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)MinX_RBV")
@@ -92,6 +97,7 @@ record(longout, "$(P)$(R)MinY")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))DIM1_MIN")
    field(LOPR, "0")
    field(VAL,  "0")
+   info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)MinY_RBV")
@@ -108,6 +114,7 @@ record(longout, "$(P)$(R)MinZ")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))DIM2_MIN")
    field(LOPR, "1")
    field(VAL,  "0")
+   info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)MinZ_RBV")
@@ -123,6 +130,7 @@ record(longout, "$(P)$(R)SizeX")
    field(DTYP, "asynInt32")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))DIM0_SIZE")
    field(VAL,  "1000000")
+   info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)SizeX_RBV")
@@ -138,6 +146,7 @@ record(longout, "$(P)$(R)SizeY")
    field(DTYP, "asynInt32")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))DIM1_SIZE")
    field(VAL,  "1000000")
+   info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)SizeY_RBV")
@@ -153,6 +162,7 @@ record(longout, "$(P)$(R)SizeZ")
    field(DTYP, "asynInt32")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))DIM2_SIZE")
    field(VAL,  "1000000")
+   info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)SizeZ_RBV")
@@ -170,6 +180,7 @@ record(bo, "$(P)$(R)AutoSizeX")
    field(VAL,  "0")
    field(ZNAM, "No")
    field(ONAM, "Yes")
+   info(autosaveFields, "VAL")
 }
 
 record(bi, "$(P)$(R)AutoSizeX_RBV")
@@ -189,6 +200,7 @@ record(bo, "$(P)$(R)AutoSizeY")
    field(VAL,  "0")
    field(ZNAM, "No")
    field(ONAM, "Yes")
+   info(autosaveFields, "VAL")
 }
 
 record(bi, "$(P)$(R)AutoSizeY_RBV")
@@ -208,6 +220,7 @@ record(bo, "$(P)$(R)AutoSizeZ")
    field(VAL,  "0")
    field(ZNAM, "No")
    field(ONAM, "Yes")
+   info(autosaveFields, "VAL")
 }
 
 record(bi, "$(P)$(R)AutoSizeZ_RBV")
@@ -248,6 +261,7 @@ record(bo, "$(P)$(R)ReverseX")
    field(VAL,  "0")
    field(ZNAM, "No")
    field(ONAM, "Yes")
+   info(autosaveFields, "VAL")
 }
 
 record(bi, "$(P)$(R)ReverseX_RBV")
@@ -267,6 +281,7 @@ record(bo, "$(P)$(R)ReverseY")
    field(VAL,  "0")
    field(ZNAM, "No")
    field(ONAM, "Yes")
+   info(autosaveFields, "VAL")
 }
 
 record(bi, "$(P)$(R)ReverseY_RBV")
@@ -286,6 +301,7 @@ record(bo, "$(P)$(R)ReverseZ")
    field(VAL,  "0")
    field(ZNAM, "No")
    field(ONAM, "Yes")
+   info(autosaveFields, "VAL")
 }
 
 record(bi, "$(P)$(R)ReverseZ_RBV")
@@ -326,6 +342,7 @@ record(bo, "$(P)$(R)EnableX")
    field(VAL,  "1")
    field(ZNAM, "Disable")
    field(ONAM, "Enable")
+   info(autosaveFields, "VAL")
 }
 
 record(bi, "$(P)$(R)EnableX_RBV")
@@ -347,6 +364,7 @@ record(bo, "$(P)$(R)EnableY")
    field(VAL,  "1")
    field(ZNAM, "Disable")
    field(ONAM, "Enable")
+   info(autosaveFields, "VAL")
 }
 
 record(bi, "$(P)$(R)EnableY_RBV")
@@ -368,6 +386,7 @@ record(bo, "$(P)$(R)EnableZ")
    field(VAL,  "1")
    field(ZNAM, "Disable")
    field(ONAM, "Enable")
+   info(autosaveFields, "VAL")
 }
 
 record(bi, "$(P)$(R)EnableZ_RBV")
@@ -395,6 +414,7 @@ record(bo, "$(P)$(R)EnableScale")
    field(VAL,  "0")
    field(ZNAM, "Disable")
    field(ONAM, "Enable")
+   info(autosaveFields, "VAL")
 }
 
 record(bi, "$(P)$(R)EnableScale_RBV")
@@ -412,9 +432,9 @@ record(ao, "$(P)$(R)Scale")
 {
    field(PINI, "YES")
    field(DTYP, "asynFloat64")
-   field(VAL,  "1")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))SCALE_VALUE")
    field(VAL,  "1")
+   info(autosaveFields, "VAL")
 }
 
 record(ai, "$(P)$(R)Scale_RBV")
@@ -455,6 +475,7 @@ record(mbbo, "$(P)$(R)DataTypeOut")
    field(EIST, "Automatic")
    field(EIVL, "-1")
    field(VAL,  "8")
+   info(autosaveFields, "VAL")
 }
 
 record(mbbi, "$(P)$(R)DataTypeOut_RBV")

--- a/ADApp/Db/NDStats.template
+++ b/ADApp/Db/NDStats.template
@@ -9,6 +9,7 @@ record(bo, "$(P)$(R)ComputeStatistics")
    field(VAL,  "1")
    field(ZNAM, "No")
    field(ONAM, "Yes")
+   info(autosaveFields, "VAL")
 }
 
 record(bi, "$(P)$(R)ComputeStatistics_RBV")
@@ -28,6 +29,7 @@ record(longout, "$(P)$(R)BgdWidth")
    field(DTYP, "asynInt32")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))BGD_WIDTH")
    field(VAL,  "1")
+   info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)BgdWidth_RBV")
@@ -119,6 +121,7 @@ record(bo, "$(P)$(R)ComputeCentroid")
    field(VAL,  "0")
    field(ZNAM, "No")
    field(ONAM, "Yes")
+   info(autosaveFields, "VAL")
 }
 
 record(bi, "$(P)$(R)ComputeCentroid_RBV")
@@ -141,6 +144,7 @@ record(ao, "$(P)$(R)CentroidThreshold")
     field(DTYP, "asynFloat64")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))CENTROID_THRESHOLD")
     field(VAL,  "1")
+    info(autosaveFields, "VAL")
 }
 record(ai, "$(P)$(R)CentroidThreshold_RBV")
 {
@@ -216,6 +220,7 @@ record(longout, "$(P)$(R)TSRead")
    field(OUT,  "$(P)$(R)TSControl PP MS")
    field(VAL,  "3")
    field(SCAN, "1 second")
+   info(autosaveFields, "SCAN")
 }
 
 record(longout, "$(P)$(R)TSNumPoints")
@@ -225,6 +230,7 @@ record(longout, "$(P)$(R)TSNumPoints")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))TS_NUM_POINTS")
    field(VAL,  "$(NCHANS)")
    field(DRVH, "$(NCHANS)")
+   info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)TSCurrentPoint")
@@ -392,6 +398,7 @@ record(bo, "$(P)$(R)ComputeProfiles")
    field(VAL,  "0")
    field(ZNAM, "No")
    field(ONAM, "Yes")
+   info(autosaveFields, "VAL")
 }
 
 record(bi, "$(P)$(R)ComputeProfiles_RBV")
@@ -425,6 +432,7 @@ record(longout, "$(P)$(R)CursorX")
    field(DTYP, "asynInt32")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))CURSOR_X")
    field(VAL,  "256")
+   info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)CursorX_RBV")
@@ -440,6 +448,7 @@ record(longout, "$(P)$(R)CursorY")
    field(DTYP, "asynInt32")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))CURSOR_Y")
    field(VAL,  "256")
+   info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)CursorY_RBV")
@@ -533,6 +542,7 @@ record(bo, "$(P)$(R)ComputeHistogram")
    field(VAL,  "0")
    field(ZNAM, "No")
    field(ONAM, "Yes")
+   info(autosaveFields, "VAL")
 }
 
 record(bi, "$(P)$(R)ComputeHistogram_RBV")
@@ -552,6 +562,7 @@ record(longout, "$(P)$(R)HistSize")
    field(DTYP, "asynInt32")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))HIST_SIZE")
    field(VAL,  "256")
+   info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)HistSize_RBV")
@@ -567,6 +578,7 @@ record(ao, "$(P)$(R)HistMin")
    field(DTYP, "asynFloat64")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))HIST_MIN")
    field(VAL,  "0")
+   info(autosaveFields, "VAL")
 }
 
 record(ai, "$(P)$(R)HistMin_RBV")
@@ -582,6 +594,7 @@ record(ao, "$(P)$(R)HistMax")
    field(DTYP, "asynFloat64")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))HIST_MAX")
    field(VAL,  "255")
+   info(autosaveFields, "VAL")
 }
 
 record(ai, "$(P)$(R)HistMax_RBV")

--- a/ADApp/Db/NDTransform.template
+++ b/ADApp/Db/NDTransform.template
@@ -19,4 +19,5 @@ record(mbbo, "$(P)$(R)Type")
    field(SXVL, "6")
    field(SVST, "Rot270Mirror")
    field(SVVL, "7")
+   info(autosaveFields, "VAL")
 }

--- a/ADApp/Db/simDetector.template
+++ b/ADApp/Db/simDetector.template
@@ -47,6 +47,7 @@ record(ao, "$(P)$(R)GainX")
    field(DTYP, "asynFloat64")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))SIM_GAIN_X")
    field(PREC, "2")
+   info(autosaveFields, "VAL")
 }
 
 record(ai, "$(P)$(R)GainX_RBV")
@@ -63,6 +64,7 @@ record(ao, "$(P)$(R)GainY")
    field(DTYP, "asynFloat64")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))SIM_GAIN_Y")
    field(PREC, "2")
+   info(autosaveFields, "VAL")
 }
 
 record(ai, "$(P)$(R)GainY_RBV")
@@ -79,6 +81,7 @@ record(ao, "$(P)$(R)GainRed")
    field(DTYP, "asynFloat64")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))SIM_GAIN_RED")
    field(PREC, "2")
+   info(autosaveFields, "VAL")
 }
 
 record(ai, "$(P)$(R)GainRed_RBV")
@@ -95,6 +98,7 @@ record(ao, "$(P)$(R)GainGreen")
    field(DTYP, "asynFloat64")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))SIM_GAIN_GREEN")
    field(PREC, "2")
+   info(autosaveFields, "VAL")
 }
 
 record(ai, "$(P)$(R)GainGreen_RBV")
@@ -111,6 +115,7 @@ record(ao, "$(P)$(R)GainBlue")
    field(DTYP, "asynFloat64")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))SIM_GAIN_BLUE")
    field(PREC, "2")
+   info(autosaveFields, "VAL")
 }
 
 record(ai, "$(P)$(R)GainBlue_RBV")
@@ -139,6 +144,7 @@ record(longout, "$(P)$(R)Noise")
    field(PINI, "YES")
    field(DTYP, "asynInt32")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))SIM_NOISE")
+   info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)Noise_RBV")
@@ -157,6 +163,7 @@ record(mbbo, "$(P)$(R)SimMode")
    field(ZRVL, "0")
    field(ONST, "Peaks")
    field(ONVL, "1")
+   info(autosaveFields, "VAL")
 }
 
 record(mbbi, "$(P)$(R)SimMode_RBV")
@@ -176,6 +183,7 @@ record(longout, "$(P)$(R)PeakStartX")
    field(PINI, "YES")
    field(DTYP, "asynInt32")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))SIM_PEAK_START_X")
+   info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)PeakStartX_RBV")
@@ -190,6 +198,7 @@ record(longout, "$(P)$(R)PeakStartY")
    field(PINI, "YES")
    field(DTYP, "asynInt32")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))SIM_PEAK_START_Y")
+   info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)PeakStartY_RBV")
@@ -204,6 +213,7 @@ record(longout, "$(P)$(R)PeakNumX")
    field(PINI, "YES")
    field(DTYP, "asynInt32")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))SIM_PEAK_NUM_X")
+   info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)PeakNumX_RBV")
@@ -218,6 +228,7 @@ record(longout, "$(P)$(R)PeakNumY")
    field(PINI, "YES")
    field(DTYP, "asynInt32")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))SIM_PEAK_NUM_Y")
+   info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)PeakNumY_RBV")
@@ -232,6 +243,7 @@ record(longout, "$(P)$(R)PeakStepX")
    field(PINI, "YES")
    field(DTYP, "asynInt32")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))SIM_PEAK_STEP_X")
+   info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)PeakStepX_RBV")
@@ -246,6 +258,7 @@ record(longout, "$(P)$(R)PeakStepY")
    field(PINI, "YES")
    field(DTYP, "asynInt32")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))SIM_PEAK_STEP_Y")
+   info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)PeakStepY_RBV")
@@ -260,6 +273,7 @@ record(longout, "$(P)$(R)PeakWidthX")
    field(PINI, "YES")
    field(DTYP, "asynInt32")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))SIM_PEAK_WIDTH_X")
+   info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)PeakWidthX_RBV")
@@ -274,6 +288,7 @@ record(longout, "$(P)$(R)PeakWidthY")
    field(PINI, "YES")
    field(DTYP, "asynInt32")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))SIM_PEAK_WIDTH_Y")
+   info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)PeakWidthY_RBV")
@@ -288,6 +303,7 @@ record(longout, "$(P)$(R)PeakVariation")
    field(PINI, "YES")
    field(DTYP, "asynInt32")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))SIM_PEAK_HEIGHT_VARIATION")
+   info(autosaveFields, "VAL")
 }
 
 record(longin, "$(P)$(R)PeakVariation_RBV")


### PR DESCRIPTION
...plugins.

This has been tested with an IOC using the ROI, Stats and Array plugins.

In the IOC startup file, to create an autosave .req file, do:

makeAutosaveFileFromDbInfo("$(SAVE_DIR)/$(IOCNAME).req", "autosaveFields")

after iocInit. This is documented in the autosave documentation.
