### PR TITLE
fix typos and troubleshooting in areaDetector viewers doc

### DIFF
--- a/documentation/areaDetectorViewers.html
+++ b/documentation/areaDetectorViewers.html
@@ -55,7 +55,7 @@
     <li>Install ImageJ from <a href="http://rsbweb.nih.gov/ij/download.html">ImageJ download
       site</a>. If installing on Windows I recommend installing the version bundled with
       Java.</li>
-    <li>Copy the the entire directory Viewers/ImageJ/EPICS_areaDetector to the plugins/
+    <li>Copy the entire directory Viewers/ImageJ/EPICS_areaDetector to the plugins/
       directory in the ImageJ installation location. On OS X this can be done with the
       command:<br />
       <pre>    cp -r Viewers/ImageJ/EPICS_areaDetector /Applications/ImageJ/plugins
@@ -71,13 +71,13 @@
       the EPICS Channel Access settings using a JCALibrary.properties file. This was often
       confusing because it uses a different mechanism than all C-based Channel Access
       clients, and because multiple JCALibrary.Properties files might be found in the
-      Java search path, making it hard figure out where a setting was coming from. Starting
+      Java search path, making it hard to figure out where a setting was coming from. Starting
       with areaDetector R1-9 the ImageJ plugin uses the same EPICS environment variables
       as Channel Access clients that use the C Channel Access library. Note that the environment
       variable EPICS_CA_MAX_ARRAY_BYTES almost always needs to be set, because the default
       value of 16KB is rarely large enough for images. EPICS_CA_MAX_ARRAY_BYTES must be
       at least as large as the largest image size in bytes that you want to display. However,
-      it is important not to set EPICS_CA_MAX_ARRAY_BYTES to an unneccessarily large value
+      it is important not to set EPICS_CA_MAX_ARRAY_BYTES to an unnecessarily large value
       like 100 MB, because the EPICS CA library allocates buffers of size EPICS_CA_MAX_ARRAY_BYTES
       whenever the required buffer size is larger than 16KB. Remember also that EPICS_CA_MAX_ARRAY_BYTES
       must be set for both the IOC process and for the ImageJ client process.</li>
@@ -180,7 +180,7 @@
   <p>
     to add a new environment variable EZCA_IDL_SHARE to point to the location of ezcaIDL.dll
     on your system. To run the standalone IDL epics_ad_display.sav file without an IDL
-    license exectute the following on Linux:</p>
+    license execute the following on Linux:</p>
   <pre>idl -32 -vm=epics_ad_display.sav 
   </pre>
   <p>
@@ -274,8 +274,8 @@
         <li>The environment variable EPICS_CA_MAX_ARRAY_BYTES is set to a value at least as
           large as the size of the arrays to be sent to the viewer. This environment variable
           must be set on the machine that the IOC is running on before the IOC is started.
-          It must also be set on the machine that the IDL client is running on before IDL
-          is started. It is not used by the ImageJ client, as discussed above.</li>
+          It must also be set on the machine that the ImageJ or IDL viewer is running on
+          before ImageJ or IDL is started.</li>
       </ul>
     </li>
   </ul>


### PR DESCRIPTION
Fix a few typos in the areaDetector viewers documentation.

Remove from the areaDetector viewers documentation troubleshooting
section the statement that the EPICS_CA_MAX_ARRAY_BYTES environment
variable is not used by the ImageJ viewer.  This used to be true, but
it's no longer true as of areaDetector R1-9.
