### PR TITLE
viewers: simplify notify and remove dead code in ImageJ viewer

### DIFF
--- a/Viewers/ImageJ/EPICS_areaDetector/EPICS_AD_Viewer.java
+++ b/Viewers/ImageJ/EPICS_areaDetector/EPICS_AD_Viewer.java
@@ -292,16 +292,9 @@ public class EPICS_AD_Viewer implements PlugIn
             isNewImageAvailable = true;
             DBR_Int x = (DBR_Int)ev.getDBR();
             UniqueId = (x.getIntValue())[0];
-            // I'd like to just do the synchronized notify here, but how do I get "this"?
-            newUniqueId(ev);
-        }
-    }
-
-    public void newUniqueId(MonitorEvent ev)
-    {
-        synchronized (this)
-        {
-            notify();
+            synchronized (EPICS_AD_Viewer.this) {
+                EPICS_AD_Viewer.this.notify();
+            }
         }
     }
 
@@ -443,20 +436,17 @@ public class EPICS_AD_Viewer implements PlugIn
             {
                 if (dataType.isBYTE())
                 {
-                    byte[] pixels = (byte[])img.getProcessor().getPixels();
-                    pixels = epicsGetByteArray(ch_image, getsize);
+                    byte[] pixels = epicsGetByteArray(ch_image, getsize);
                     img.getProcessor().setPixels(pixels);
                 }
                 else if (dataType.isSHORT())
                 {
-                    short[] pixels = (short[])img.getProcessor().getPixels();
-                    pixels = epicsGetShortArray(ch_image, getsize);
+                    short[] pixels = epicsGetShortArray(ch_image, getsize);
                     img.getProcessor().setPixels(pixels);
                 }
                 else if (dataType.isINT() || dataType.isFLOAT() || dataType.isDOUBLE())
                 {
-                    float[] pixels = (float[])img.getProcessor().getPixels();
-                    pixels = epicsGetFloatArray(ch_image, getsize);
+                    float[] pixels = epicsGetFloatArray(ch_image, getsize);
                     img.getProcessor().setPixels(pixels);
                 }
             }
@@ -769,7 +759,6 @@ public class EPICS_AD_Viewer implements PlugIn
         {
             String fileSep = System.getProperty("file.separator");
             path = System.getProperty("user.home") + fileSep + propertyFile;
-            if (path == null) throw new Exception("No such file: " + path);
             FileInputStream file = new FileInputStream(path);
             properties.load(file);
             file.close();


### PR DESCRIPTION
The ImageJ viewer newUniqueIdCallback inner class had a comment saying
it would prefer to do the synchronized notify in the monitorChanged
method.  This commit does that and removes the newUniqueId() method
which is no longer used.

The ImageJ viewer had three places in its updateImage() method
where it would assign to a variable the return value of
img.getProcessor().getPixels() but then immediately assign the return
value of epicsGet{Byte,Short,Float}Array() to the same variable.  The
value assigned to the variable from the img.getProcessor().getPixels()
call is overwritten and never used, therefore the first call and
assignment does nothing and can be removed.

The ImageJ viewer had dead code in its readProperties() method where it
assigned a value to the path variable and then checked whether the path
variable was null.  Since the propertyFile variable is never null, the
path variable can never be null, hence the null check can be removed.