### PR TITLE
Added support for BitsPerPixel and BytesPerPixel in ADBase

### DIFF
--- a/ADApp/ADSrc/NDArray.cpp
+++ b/ADApp/ADSrc/NDArray.cpp
@@ -30,7 +30,7 @@
 NDArray::NDArray()
   : referenceCount(0), pNDArrayPool(NULL),  
     uniqueId(0), timeStamp(0.0), ndims(0), dataType(NDInt8),
-    dataSize(0),  pData(NULL)
+    dataSize(0), bitsPerElement(0), pData(NULL)
 {
   this->epicsTS.secPastEpoch = 0;
   this->epicsTS.nsec = 0;
@@ -148,6 +148,7 @@ int NDArray::getInfo(NDArrayInfo_t *pInfo)
     pInfo->ySize     = this->dims[pInfo->yDim].size;
     pInfo->colorSize = this->dims[pInfo->colorDim].size;
   }
+  pInfo->bitsPerElement = this->bitsPerElement;
   return(ND_SUCCESS);
 }
 
@@ -201,8 +202,8 @@ int NDArray::report(FILE *fp, int details)
     this->ndims);
   for (dim=0; dim<this->ndims; dim++) fprintf(fp, "%d ", (int)this->dims[dim].size);
   fprintf(fp, "]\n");
-  fprintf(fp, "  dataType=%d, dataSize=%d, pData=%p\n",
-        this->dataType, (int)this->dataSize, this->pData);
+  fprintf(fp, "  dataType=%d, nBitsPerPixel=%d, dataSize=%d, pData=%p\n",
+        this->dataType, this->bitsPerElement, (int)this->dataSize, this->pData);
   fprintf(fp, "  uniqueId=%d, timeStamp=%f\n",
         this->uniqueId, this->timeStamp);
   fprintf(fp, "  number of attributes=%d\n", this->pAttributeList->count());

--- a/ADApp/ADSrc/NDArray.h
+++ b/ADApp/ADSrc/NDArray.h
@@ -68,7 +68,8 @@ typedef struct NDDimension {
 /** Structure returned by NDArray::getInfo */
 typedef struct NDArrayInfo {
     size_t nElements;       /**< The total number of elements in the array */
-    int bytesPerElement;    /**< The number of bytes per element in the array */
+    int    bitsPerElement;  /**< The number of bits   per element in the array */
+    int    bytesPerElement; /**< The number of bytes per element in the array */
     size_t totalBytes;      /**< The total number of bytes required to hold the array;
                               *  this may be less than NDArray::dataSize. */
                             /**< The following are mostly useful for color images (RGB1, RGB2, RGB3) */
@@ -115,6 +116,7 @@ public:
     NDDataType_t  dataType;     /**< Data type for this array. */
     size_t        dataSize;     /**< Data size for this array; actual amount of memory allocated for *pData, may be more than
                                   * required to hold the array*/
+    int           bitsPerElement; /**< The number of bits   per element in the array */
     void          *pData;       /**< Pointer to the array data.
                                   * The data is assumed to be stored in the order of dims[0] changing fastest, and 
                                   * dims[ndims-1] changing slowest. */

--- a/ADApp/ADSrc/NDArrayPool.cpp
+++ b/ADApp/ADSrc/NDArrayPool.cpp
@@ -89,6 +89,7 @@ NDArray* NDArrayPool::alloc(int ndims, size_t *dims, NDDataType_t dataType, size
     /* Initialize fields */
     pArray->pNDArrayPool = this;
     pArray->dataType = dataType;
+    pArray->bitsPerElement = GetNDDataTypeBits(dataType);
     pArray->ndims = ndims;
     memset(pArray->dims, 0, sizeof(pArray->dims));
     for (i=0; i<ndims && i<ND_ARRAY_MAX_DIMS; i++) {
@@ -191,6 +192,7 @@ NDArray* NDArrayPool::copy(NDArray *pIn, NDArray *pOut, int copyData)
     pOut = this->alloc(pIn->ndims, dimSizeOut, pIn->dataType, 0, NULL);
     if(NULL==pOut) return NULL;
   }
+  pOut->bitsPerElement = pIn->bitsPerElement;
   pOut->uniqueId = pIn->uniqueId;
   pOut->timeStamp = pIn->timeStamp;
   pOut->epicsTS = pIn->epicsTS;
@@ -479,7 +481,6 @@ int NDArrayPool::convert(NDArray *pIn,
   NDDimension_t dimsOutCopy[ND_ARRAY_MAX_DIMS];
   int i;
   NDArray *pOut;
-  NDArrayInfo_t arrayInfo;
   NDAttribute *pAttribute;
   int colorMode, colorModeMono = NDColorModeMono;
   const char *functionName = "convert";
@@ -516,20 +517,25 @@ int NDArrayPool::convert(NDArray *pIn,
     return(ND_ERROR);
   }
   /* Copy fields from input to output */
-  pOut->timeStamp = pIn->timeStamp;
-  pOut->epicsTS = pIn->epicsTS;
-  pOut->uniqueId = pIn->uniqueId;
+  pOut->bitsPerElement  = pIn->bitsPerElement;
+  if( pOut->bitsPerElement > GetNDDataTypeBits(pOut->dataType) )
+      pOut->bitsPerElement = GetNDDataTypeBits(pOut->dataType);
+  pOut->timeStamp       = pIn->timeStamp;
+  pOut->epicsTS         = pIn->epicsTS;
+  pOut->uniqueId        = pIn->uniqueId;
   /* Replace the dimensions with those passed to this function */
   memcpy(pOut->dims, dimsOutCopy, pIn->ndims*sizeof(NDDimension_t));
   pIn->pAttributeList->copy(pOut->pAttributeList);
 
-  pOut->getInfo(&arrayInfo);
-
+  NDArrayInfo_t arrayInfoIn;
+  NDArrayInfo_t arrayInfoOut;
+  pIn->getInfo( &arrayInfoIn );
+  pOut->getInfo(&arrayInfoOut);
   if (dimsUnchanged) {
     if (pIn->dataType == pOut->dataType) {
       /* The dimensions are the same and the data type is the same,
        * then just copy the input image to the output image */
-      memcpy(pOut->pData, pIn->pData, arrayInfo.totalBytes);
+      memcpy(pOut->pData, pIn->pData, arrayInfoOut.totalBytes);
       return ND_SUCCESS;
     } else {
       /* We need to convert data types */
@@ -567,7 +573,7 @@ int NDArrayPool::convert(NDArray *pIn,
     /* The input and output dimensions are not the same, so we are extracting a region
      * and/or binning */
     /* Clear entire output array */
-    memset(pOut->pData, 0, arrayInfo.totalBytes);
+    memset(pOut->pData, 0, arrayInfoOut.totalBytes);
     convertDimension(pIn, pOut, pIn->pData, pOut->pData, pIn->ndims-1);
   }
 

--- a/ADApp/ADSrc/NDAttribute.cpp
+++ b/ADApp/ADSrc/NDAttribute.cpp
@@ -388,4 +388,25 @@ int NDAttribute::report(FILE *fp, int details)
   return ND_SUCCESS;
 }
 
+/** Get the max number of bits per pixel for the specified data type
+  * \param[in] NDDataType_t  Data type
+  */
+int GetNDDataTypeBits( NDDataType_t tyData )
+{
+    int nBits;
+    switch ( tyData )
+    {
+    // Default to large number so conversions to
+    // integer data types will be clipped to max
+    default:        nBits   = 99;   break;
+    case NDInt8:    nBits   = 8;    break;
+    case NDUInt8:   nBits   = 8;    break;
+    case NDInt16:   nBits   = 16;   break;
+    case NDUInt16:  nBits   = 16;   break;
+    case NDInt32:   nBits   = 32;   break;
+    case NDUInt32:  nBits   = 32;   break;
+    }
+    return nBits;
+}
+
 

--- a/ADApp/ADSrc/NDAttribute.h
+++ b/ADApp/ADSrc/NDAttribute.h
@@ -36,6 +36,8 @@ typedef enum
     NDFloat64   /**< 64-bit float */
 } NDDataType_t;
 
+extern int GetNDDataTypeBits( NDDataType_t );
+
 /** Enumeration of NDAttribute attribute data types */
 typedef enum
 {

--- a/ADApp/ADSrc/asynNDArrayDriver.cpp
+++ b/ADApp/ADSrc/asynNDArrayDriver.cpp
@@ -516,6 +516,8 @@ asynNDArrayDriver::asynNDArrayDriver(const char *portName, int maxAddr, int numP
     createParam(NDNDimensionsString,          asynParamInt32,           &NDNDimensions);
     createParam(NDDimensionsString,           asynParamInt32,           &NDDimensions);
     createParam(NDDataTypeString,             asynParamInt32,           &NDDataType);
+    createParam(NDBitsPerPixelString,         asynParamInt32,           &NDBitsPerPixel);
+    createParam(NDBytesPerPixelString,        asynParamInt32,           &NDBytesPerPixel);
     createParam(NDColorModeString,            asynParamInt32,           &NDColorMode);
     createParam(NDUniqueIdString,             asynParamInt32,           &NDUniqueId);
     createParam(NDTimeStampString,            asynParamFloat64,         &NDTimeStamp);
@@ -566,6 +568,8 @@ asynNDArrayDriver::asynNDArrayDriver(const char *portName, int maxAddr, int numP
     setIntegerParam(NDArraySize,    0);
     setIntegerParam(NDNDimensions,  0);
     setIntegerParam(NDDataType,     NDUInt8);
+    setIntegerParam(NDBitsPerPixel, 8);
+    setIntegerParam(NDBytesPerPixel,1);
     setIntegerParam(NDColorMode,    NDColorModeMono);
     setIntegerParam(NDUniqueId,     0);
     setDoubleParam (NDTimeStamp,    0.);

--- a/ADApp/ADSrc/asynNDArrayDriver.h
+++ b/ADApp/ADSrc/asynNDArrayDriver.h
@@ -37,6 +37,8 @@ typedef enum {
 #define NDNDimensionsString     "ARRAY_NDIMENSIONS" /**< (asynInt32,    r/o) Number of dimensions in array */
 #define NDDimensionsString      "ARRAY_DIMENSIONS"  /**< (asynInt32Array, r/o) Array dimensions */
 #define NDDataTypeString        "DATA_TYPE"         /**< (asynInt32,    r/w) Data type (NDDataType_t) */
+#define NDBitsPerPixelString    "BITS_PER_PIXEL"    /**< (asynInt32,    r/w) Number of bits per pixel */
+#define NDBytesPerPixelString   "BYTES_PER_PIXEL"   /**< (asynInt32,    r/w) Number of bytes per pixel */
 #define NDColorModeString       "COLOR_MODE"        /**< (asynInt32,    r/w) Color mode (NDColorMode_t) */
 #define NDUniqueIdString        "UNIQUE_ID"         /**< (asynInt32,    r/o) Unique ID number of array */
 #define NDTimeStampString       "TIME_STAMP"        /**< (asynFloat64,  r/o) Time stamp of array */
@@ -125,6 +127,8 @@ protected:
     int NDNDimensions;
     int NDDimensions;
     int NDDataType;
+    int NDBitsPerPixel;
+    int NDBytesPerPixel;
     int NDColorMode;
     int NDUniqueId;
     int NDTimeStamp;

--- a/ADApp/Db/ADBase.template
+++ b/ADApp/Db/ADBase.template
@@ -508,6 +508,8 @@ record(longin, "$(P)$(R)NumExposuresCounter_RBV")
    field(DTYP, "asynInt32")
    field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))NEXPOSURES_COUNTER")
    field(SCAN, "I/O Intr")
+   field(TSE,  "$(TSE=-2)")
+   info(autosaveFields, "TSE")
 }
 record(longout, "$(P)$(R)NumImages")
 {
@@ -523,6 +525,8 @@ record(longin, "$(P)$(R)NumImages_RBV")
    field(DTYP, "asynInt32")
    field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))NIMAGES")
    field(SCAN, "I/O Intr")
+   field(TSE,  "$(TSE=-2)")
+   info(autosaveFields, "TSE")
 }
 
 record(longin, "$(P)$(R)NumImagesCounter_RBV")
@@ -530,6 +534,8 @@ record(longin, "$(P)$(R)NumImagesCounter_RBV")
    field(DTYP, "asynInt32")
    field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))NIMAGES_COUNTER")
    field(SCAN, "I/O Intr")
+   field(TSE,  "$(TSE=-2)")
+   info(autosaveFields, "TSE")
 }
 
 ###################################################################
@@ -570,6 +576,8 @@ record(longin, "$(P)$(R)ArrayCounter_RBV")
     field(DTYP, "asynInt32")
     field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ARRAY_COUNTER")
     field(SCAN, "I/O Intr")
+    field(TSE,  "$(TSE=-2)")
+    info(autosaveFields, "TSE")
 }
 
 # Updated rate calculation to use a smoothing factor w/ guard against negative values

--- a/ADApp/Db/ADBase.template
+++ b/ADApp/Db/ADBase.template
@@ -100,6 +100,20 @@ record(mbbi, "$(P)$(R)DataType_RBV")
    field(SCAN, "I/O Intr")
 }
 
+record( longin, "$(P)$(R)BytesPerPixel_RBV" )
+{
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))BYTES_PER_PIXEL")
+    field(SCAN, "I/O Intr")
+}
+
+record(longin, "$(P)$(R)BitsPerPixel_RBV")
+{
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))BITS_PER_PIXEL")
+    field(SCAN, "I/O Intr")
+}
+
 ###################################################################
 #  These records control the color mode                           #
 #  These choices must agree with NDColorMode_t in NDArray.h       # 

--- a/ADApp/Db/NDPluginBase.template
+++ b/ADApp/Db/NDPluginBase.template
@@ -150,6 +150,8 @@ record(longin, "$(P)$(R)ArrayCounter_RBV")
     field(DTYP, "asynInt32")
     field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ARRAY_COUNTER")
     field(SCAN, "I/O Intr")
+    field(TSE,  "$(TSE=-2)")
+    info(autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV TSE")
 }
 
 # Updated rate calculation to use a smoothing factor w/ guard against negative values
@@ -377,6 +379,8 @@ record(longin, "$(P)$(R)UniqueId_RBV")
     field(DTYP, "asynInt32")
     field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))UNIQUE_ID")
     field(SCAN, "I/O Intr")
+    field(TSE,  "$(TSE=-2)")
+    info(autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE")
 }
 
 record(ai, "$(P)$(R)TimeStamp_RBV")
@@ -385,6 +389,8 @@ record(ai, "$(P)$(R)TimeStamp_RBV")
     field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))TIME_STAMP")
     field(PREC, "3")
     field(SCAN, "I/O Intr")
+    field(TSE,  "$(TSE=-2)")
+    info(autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU PREC TSE")
 }
 
 record(longin, "$(P)$(R)EpicsTSSec_RBV")
@@ -392,6 +398,8 @@ record(longin, "$(P)$(R)EpicsTSSec_RBV")
     field(DTYP, "asynInt32")
     field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))EPICS_TS_SEC")
     field(SCAN, "I/O Intr")
+    field(TSE,  "$(TSE=-2)")
+    info(autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE")
 }
 
 record(longin, "$(P)$(R)EpicsTSNsec_RBV")
@@ -399,6 +407,8 @@ record(longin, "$(P)$(R)EpicsTSNsec_RBV")
     field(DTYP, "asynInt32")
     field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))EPICS_TS_NSEC")
     field(SCAN, "I/O Intr")
+    field(TSE,  "$(TSE=-2)")
+    info(autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU TSE")
 }
 
 ###################################################################

--- a/ADApp/pluginSrc/NDFileHDF5.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5.cpp
@@ -98,7 +98,7 @@ asynStatus NDFileHDF5::openFile(const char *fileName, NDFileOpenMode_t openMode,
   NDArrayInfo_t info;
   pArray->getInfo(&info);
   this->frameSize = (8.0 * info.totalBytes)/(1024.0 * 1024.0);
-  this->bytesPerElement = info.bytesPerElement;
+  this->bytesPerPixel = info.bytesPerElement;
 
   // Construct an attribute list. We use a separate attribute list from the one in pArray
   // to avoid the need to copy the array.

--- a/ADApp/pluginSrc/NDPluginDriver.cpp
+++ b/ADApp/pluginSrc/NDPluginDriver.cpp
@@ -36,31 +36,37 @@ static const char *driverName="NDPluginDriver";
   * This method takes care of some bookkeeping for callbacks, updating parameters
   * from data in the class and in the NDArray.  It does asynInt32Array callbacks
   * for the dimensions array if the dimensions of the NDArray data have changed. */ 
-    void NDPluginDriver::processCallbacks(NDArray *pArray)
+void NDPluginDriver::processCallbacks(NDArray *pArray)
 {
     int arrayCounter;
     int i, dimsChanged;
     int size;
     NDAttribute *pAttribute;
     int colorMode=NDColorModeMono, bayerPattern=NDBayerRGGB;
-    
+  
     pAttribute = pArray->pAttributeList->find("ColorMode");
     if (pAttribute) pAttribute->getValue(NDAttrInt32, &colorMode);
     pAttribute = pArray->pAttributeList->find("BayerPattern");
     if (pAttribute) pAttribute->getValue(NDAttrInt32, &bayerPattern);
-    
+
     getIntegerParam(NDArrayCounter, &arrayCounter);
     arrayCounter++;
-    setIntegerParam(NDArrayCounter, arrayCounter);
-    setIntegerParam(NDNDimensions, pArray->ndims);
-    setIntegerParam(NDDataType, pArray->dataType);
-    setIntegerParam(NDColorMode, colorMode);
-    setIntegerParam(NDBayerPattern, bayerPattern);
-    setIntegerParam(NDUniqueId, pArray->uniqueId);
+    setIntegerParam(NDArrayCounter,  arrayCounter);
+    setIntegerParam(NDNDimensions,   pArray->ndims);
+    setIntegerParam(NDDataType,      pArray->dataType);
+
+    NDArrayInfo_t arrayInfo;
+    pArray->getInfo(&arrayInfo);
+    setIntegerParam(NDBitsPerPixel, arrayInfo.bitsPerElement);
+    setIntegerParam(NDBytesPerPixel,arrayInfo.bytesPerElement);
+
+    setIntegerParam(NDColorMode,     colorMode);
+    setIntegerParam(NDBayerPattern,  bayerPattern);
+    setIntegerParam(NDUniqueId,      pArray->uniqueId);
     setTimeStamp(&pArray->epicsTS);
-    setDoubleParam(NDTimeStamp, pArray->timeStamp);
-    setIntegerParam(NDEpicsTSSec, pArray->epicsTS.secPastEpoch);
-    setIntegerParam(NDEpicsTSNsec, pArray->epicsTS.nsec);
+    setDoubleParam(NDTimeStamp,      pArray->timeStamp);
+    setIntegerParam(NDEpicsTSSec,    pArray->epicsTS.secPastEpoch);
+    setIntegerParam(NDEpicsTSNsec,   pArray->epicsTS.nsec);
     /* See if the array dimensions have changed.  If so then do callbacks on them. */
     for (i=0, dimsChanged=0; i<ND_ARRAY_MAX_DIMS; i++) {
         size = (int)pArray->dims[i].size;

--- a/ADApp/pluginSrc/NDPluginROI.cpp
+++ b/ADApp/pluginSrc/NDPluginROI.cpp
@@ -152,7 +152,9 @@ void NDPluginROI::processCallbacks(NDArray *pArray)
 
     /* Extract this ROI from the input array.  The convert() function allocates
      * a new array and it is reserved (reference count = 1) */
-    if (dataType == -1) dataType = (int)pArray->dataType;
+    if (dataType == -1) {
+        dataType = (int)pArray->dataType;
+    }
     /* We treat the case of RGB1 data specially, so that NX and NY are the X and Y dimensions of the
      * image, not the first 2 dimensions.  This makes it much easier to switch back and forth between
      * RGB1 and mono mode when using an ROI. */
@@ -213,6 +215,12 @@ void NDPluginROI::processCallbacks(NDArray *pArray)
         pOutput->pAttributeList->add("ColorMode", "Color mode", NDAttrInt32, &colorMode);
     }
     this->lock();
+    NDArrayInfo arrayInfoOut;
+    pOutput->getInfo(&arrayInfoOut);
+
+    /* Set the image size of the ROI image data */
+    setIntegerParam(NDBitsPerPixel,     arrayInfo.bitsPerElement);
+    setIntegerParam(NDBytesPerPixel,    arrayInfo.bytesPerElement);
 
     /* Set the image size of the ROI image data */
     setIntegerParam(NDArraySizeX, 0);


### PR DESCRIPTION
These PV's are useful for determining how to view the images, particularly via edm where different video widgets need to be used depending on these values.