### PR TITLE
Updated xml root tag from xml to hdf5_layout.

### DIFF
--- a/iocBoot/hdf5_xml_layout_schema.xsd
+++ b/iocBoot/hdf5_xml_layout_schema.xsd
@@ -85,7 +85,7 @@
   </xs:complexType>
 
   <!-- The actual definition of the elements -->
-  <xs:element name="xml">
+  <xs:element name="hdf5_layout">
     <xs:complexType>
       <xs:choice minOccurs="0" maxOccurs="unbounded">
         <xs:element name="global" type="globalType" />

--- a/iocBoot/new_txm_sample.xml
+++ b/iocBoot/new_txm_sample.xml
@@ -1,4 +1,4 @@
-<xml>
+<hdf5_layout>
   <global name="detector_data_destination" ndattribute="Images"></global>
   <group name="exchange">
     <dataset name="data" source="detector">
@@ -38,6 +38,6 @@
       </group><!-- /detector -->
     </group><!-- /instrument -->
   </group><!-- /measurement -->
-</xml>
+</hdf5_layout>
 
 

--- a/iocs/simDetectorIOC/iocBoot/iocSimDetector/hdf5_layout_demo.xml
+++ b/iocs/simDetectorIOC/iocBoot/iocSimDetector/hdf5_layout_demo.xml
@@ -1,4 +1,4 @@
-<xml>
+<hdf5_layout>
   <global name="detector_data_destination" ndattribute="DataDestination"></global>
   <group name="entry">
     <attribute name="test_float_array" source="constant" value="1.3,2.9,3.4,4.8,5.234" type="float"></attribute>
@@ -28,5 +28,5 @@
     <group name="instruments" ndattr_default="true">
     </group>
   </group>
-</xml>
+</hdf5_layout>
 

--- a/iocs/simDetectorIOC/iocBoot/iocSimDetector/hdf5_layout_nexus.xml
+++ b/iocs/simDetectorIOC/iocBoot/iocSimDetector/hdf5_layout_nexus.xml
@@ -1,4 +1,4 @@
-<xml>
+<hdf5_layout>
   <group name="entry"> 
     <attribute name="NX_class" source="constant" value="NXentry" type="string"></attribute> 
     <group name="instrument"> 
@@ -30,4 +30,4 @@
            tell Nexus utilities that this is a hardlink -->
     </group>              <!-- end group data --> 
   </group>                <!-- end group entry -->
-</xml>
+</hdf5_layout>


### PR DESCRIPTION
This pull request is to resolve reported issue #58 by renaming the root tags as hdf5_layout instead of xml.  The schema has been updated, but there were no required code changes as the root tag is not used by name within the plugin.