### PR TITLE
Added dataset support for String type NDAttributes (fixes ticket #64).

### DIFF
--- a/ADApp/pluginSrc/NDFileHDF5.h
+++ b/ADApp/pluginSrc/NDFileHDF5.h
@@ -52,9 +52,9 @@ typedef struct HDFAttributeNode {
   hid_t hdfdatatype;
   hid_t hdfcparm;
   hid_t hdffilespace;
-  hsize_t hdfdims;
-  hsize_t offset;
-  hsize_t elementSize;
+  hsize_t hdfdims[2];
+  hsize_t offset[2];
+  hsize_t elementSize[2];
   int hdfrank;
   hdf5::When_t whenToSave;
 } HDFAttributeNode;


### PR DESCRIPTION
Added support by creating datasets of chars with a dimension of size MAX_ATTRIBUTE_STRING_SIZE.  Added support for attribute datasets with rank of 2 if they are string type (2D datasets instead of usual 1D).
Fixes ticket #64 