### PR TITLE
Default attributes from NDArrays stored in HDF5 files

### DIFF
--- a/ADApp/pluginSrc/NDFileHDF5.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5.cpp
@@ -2807,18 +2807,18 @@ asynStatus NDFileHDF5::createFileLayout(NDArray *pArray)
         return asynError;
       }
     } else {
-      // The file does not exist, raise a warning and use the default
+      // The file does not exist, raise an error
+      // Note that we should never get here as the file is verified prior to this
       asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
-                "%s%s Warning: specified XML file does not exist, using default\n",
+                "%s%s Warning: specified XML file does not exist\n",
                 driverName, functionName);
-      this->layout.load_xml();
-      this->createXMLFileLayout();
       delete[] layoutFile;
       return asynError;
     }
   }
   delete [] layoutFile;
-  return this->createXMLFileLayout();
+  asynStatus ret = this->createXMLFileLayout();
+  return ret;
 }
 
 

--- a/ADApp/pluginSrc/NDFileHDF5.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5.cpp
@@ -1137,16 +1137,10 @@ asynStatus NDFileHDF5::writeFile(NDArray *pArray)
                 driverName, functionName);
       return asynError;
     }
-    // Update the values for some NDArray properties.
-    NDAttribute *pAttribute;
-    pAttribute = this->pFileAttributes->find("NDArrayUniqueId");
-    pAttribute->setValue(&pArray->uniqueId);
-    pAttribute = this->pFileAttributes->find("NDArrayTimeStamp");
-    pAttribute->setValue(&pArray->timeStamp);
-    pAttribute = this->pFileAttributes->find("NDArrayEpicsTSSec");
-    pAttribute->setValue(&pArray->epicsTS.secPastEpoch);
-    pAttribute = this->pFileAttributes->find("NDArrayEpicsTSnSec");
-    pAttribute->setValue(&pArray->epicsTS.nsec);
+
+    // Insert default NDAttribute from the NDArray object (timestamps etc)
+    this->addDefaultAttributes(pArray);
+
     // Now append the attributes from the array which are already up to date from
     // the driver and prior plugins
     asynPrint(this->pasynUserSelf, ASYN_TRACE_FLOW, 
@@ -2669,6 +2663,28 @@ void NDFileHDF5::checkForOpenFile()
     this->closeFile();
   }
 }
+
+/** Add the default attributes from NDArrays into the local NDAttribute list.
+ *
+ * The relevant attributes are: uniqueId, timeStamp, epicsTS.secPastEpoch and
+ * epicsTS.nsec.
+ */
+void NDFileHDF5::addDefaultAttributes(NDArray *pArray)
+{
+  this->pFileAttributes->add("NDArrayUniqueId",
+                             "The unique ID of the NDArray",
+                             NDAttrInt32, (void*)&(pArray->uniqueId));
+  this->pFileAttributes->add("NDArrayTimeStamp",
+                             "The timestamp of the NDArray",
+                             NDAttrFloat64, (void*)&(pArray->timeStamp));
+  this->pFileAttributes->add("NDArrayEpicsTSSec",
+                             "The NDArray EPICS timestamp in seconds past epoch",
+                             NDAttrUInt32, (void*)&(pArray->epicsTS.secPastEpoch));
+  this->pFileAttributes->add("NDArrayEpicsTSNSec",
+                             "The NDArray EPICS timestamp in nanoseconds",
+                             NDAttrUInt32, (void*)&(pArray->epicsTS.nsec));
+}
+
 
 asynStatus NDFileHDF5::createNewFile(const char *fileName)
 {

--- a/ADApp/pluginSrc/NDFileHDF5.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5.cpp
@@ -106,12 +106,6 @@ asynStatus NDFileHDF5::openFile(const char *fileName, NDFileOpenMode_t openMode,
   // First clear the list
   this->pFileAttributes->clear();
 
-  // Add attributes for some NDArray properties.  This makes it easy to save them in the file.
-  this->pFileAttributes->add("NDArrayUniqueId",    "Unique ID",            NDAttrInt32,   &pArray->uniqueId);
-  this->pFileAttributes->add("NDArrayTimeStamp",   "Timestamp",            NDAttrFloat64, &pArray->timeStamp);
-  this->pFileAttributes->add("NDArrayEpicsTSSec",  "EPICS timestamp sec",  NDAttrInt32,   &pArray->epicsTS.secPastEpoch);
-  this->pFileAttributes->add("NDArrayEpicsTSnSec", "EPICS timestamp nsec", NDAttrInt32,   &pArray->epicsTS.nsec);
-
   // Now get the current values of the attributes for this plugin
   this->getAttributes(this->pFileAttributes);
 
@@ -2680,7 +2674,7 @@ void NDFileHDF5::addDefaultAttributes(NDArray *pArray)
   this->pFileAttributes->add("NDArrayEpicsTSSec",
                              "The NDArray EPICS timestamp in seconds past epoch",
                              NDAttrUInt32, (void*)&(pArray->epicsTS.secPastEpoch));
-  this->pFileAttributes->add("NDArrayEpicsTSNSec",
+  this->pFileAttributes->add("NDArrayEpicsTSnSec",
                              "The NDArray EPICS timestamp in nanoseconds",
                              NDAttrUInt32, (void*)&(pArray->epicsTS.nsec));
 }

--- a/ADApp/pluginSrc/NDFileHDF5.h
+++ b/ADApp/pluginSrc/NDFileHDF5.h
@@ -160,9 +160,11 @@ class epicsShareClass NDFileHDF5 : public NDPluginFile
     hsize_t calcChunkCacheSlots();
 
     void checkForOpenFile();
+    void addDefaultAttributes(NDArray *pArray);
     asynStatus createNewFile(const char *fileName);
     asynStatus createFileLayout(NDArray *pArray);
     asynStatus createAttributeDataset();
+
 
     hdf5::LayoutXML layout;
 

--- a/ADApp/pluginSrc/NDFileHDF5.h
+++ b/ADApp/pluginSrc/NDFileHDF5.h
@@ -161,6 +161,7 @@ class epicsShareClass NDFileHDF5 : public NDPluginFile
 
     void checkForOpenFile();
     void addDefaultAttributes(NDArray *pArray);
+    asynStatus writeDefaultDatasetAttributes(NDArray *pArray);
     asynStatus createNewFile(const char *fileName);
     asynStatus createFileLayout(NDArray *pArray);
     asynStatus createAttributeDataset();

--- a/ADApp/pluginSrc/NDFileHDF5Layout.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5Layout.cpp
@@ -30,6 +30,11 @@ namespace hdf5
   {
   }
 
+  Attribute::Attribute(const char* name, DataSource& src) : source(src), name(name), onFileOpen(true)
+  {
+  }
+
+
   Attribute& Attribute::operator=(const Attribute& src)
   {
     this->_copy(src);

--- a/ADApp/pluginSrc/NDFileHDF5Layout.h
+++ b/ADApp/pluginSrc/NDFileHDF5Layout.h
@@ -89,6 +89,7 @@ namespace hdf5
       Attribute(const Attribute& src); // Copy constructor
       Attribute(std::string& name);
       Attribute(const char* name);
+      Attribute(const char* name, DataSource& src);
       ~Attribute(){};
       Attribute& operator=(const Attribute& src);
       std::string get_name();


### PR DESCRIPTION
This resolves issue #68 

The following are added as NDAttributes (and stored using the usual rules and logic):

* NDArray.uniqueId as "NDArrayUniqueId"
* NDArray.timeStamp as "NDArrayTimeStamp"
* NDArray.epicsTS.secPastEpoch as "NDArrayEpicsTSSec"
* NDArray.epicsTS.nsec as "NDArrayEpicsTSnSec"

The following data is added as 1D attributes to all detector datasets with one element per image dimension:

* NDArray.ndims as "NDArrayNumDims" (special case: scaler integer, rather than 1D array)
* NDArray.dims[].offset as "NDArrayDimOffset"
* NDArray.dims[].binning as "NDArrayDimBinning"
* NDArray.dims[].reverse as "NDArrayDimReverse"

