### PR TITLE
Update NDAttribute datasets to increase in dimension as required Fix #74

### DIFF
--- a/ADApp/Db/NDFileHDF5.template
+++ b/ADApp/Db/NDFileHDF5.template
@@ -82,6 +82,22 @@ record(longin, "$(P)$(R)NumFramesChunks_RBV")
     field(SCAN, "I/O Intr")
 }
 
+record(longout, "$(P)$(R)NDAttributeChunk")
+{
+    field(DTYP, "asynInt32")
+    field(OUT, "@asyn($(PORT),0)HDF5_NDAttributeChunk")
+    field(PINI, "YES")
+    info(autosaveFields, "VAL")
+}
+
+record(longin, "$(P)$(R)NDAttributeChunk_RBV")
+{
+    field(DTYP, "asynInt32")
+    field(INP, "@asyn($(PORT),0)HDF5_NDAttributeChunk")
+    field(PINI, "NO")
+    field(SCAN, "I/O Intr")
+}
+
 record(longout, "$(P)$(R)BoundaryAlign")
 {
     field(DTYP, "asynInt32")

--- a/ADApp/pluginSrc/NDFileHDF5.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5.cpp
@@ -1749,6 +1749,7 @@ NDFileHDF5::NDFileHDF5(const char *portName, int queueSize, int blockingCallback
   this->createParam(str_NDFileHDF5_nFramesChunks,   asynParamInt32,   &NDFileHDF5_nFramesChunks);
   this->createParam(str_NDFileHDF5_chunkBoundaryAlign, asynParamInt32,&NDFileHDF5_chunkBoundaryAlign);
   this->createParam(str_NDFileHDF5_chunkBoundaryThreshold, asynParamInt32,&NDFileHDF5_chunkBoundaryThreshold);
+  this->createParam(str_NDFileHDF5_NDAttributeChunk,asynParamInt32,   &NDFileHDF5_NDAttributeChunk);
   this->createParam(str_NDFileHDF5_extraDimNameN,   asynParamOctet,   &NDFileHDF5_extraDimNameN);
   this->createParam(str_NDFileHDF5_nExtraDims,      asynParamInt32,   &NDFileHDF5_nExtraDims);
   this->createParam(str_NDFileHDF5_extraDimSizeX,   asynParamInt32,   &NDFileHDF5_extraDimSizeX);
@@ -1774,6 +1775,7 @@ NDFileHDF5::NDFileHDF5(const char *portName, int queueSize, int blockingCallback
   setIntegerParam(NDFileHDF5_nRowChunks,      0);
   setIntegerParam(NDFileHDF5_nColChunks,      0);
   setIntegerParam(NDFileHDF5_nFramesChunks,   0);
+  setIntegerParam(NDFileHDF5_NDAttributeChunk,0);
   setIntegerParam(NDFileHDF5_extraDimSizeN,   1);
   setIntegerParam(NDFileHDF5_chunkBoundaryAlign, 0);
   setIntegerParam(NDFileHDF5_chunkBoundaryThreshold, 65536);
@@ -2043,7 +2045,9 @@ asynStatus NDFileHDF5::createAttributeDataset()
   NDAttribute *ndAttr = NULL;
   NDAttrSource_t ndAttrSourceType;
   int extraDims;
+  int chunking = 0;
   hsize_t hdfdims=1;
+  hsize_t maxdims[2] = {H5S_UNLIMITED, H5S_UNLIMITED};
   int numCaptures = 1;
   hid_t groupDefault = -1;
   const char *attrNames[5] = {"NDAttrName", "NDAttrDescription", "NDAttrSourceType", "NDAttrSource", NULL};
@@ -2073,6 +2077,14 @@ asynStatus NDFileHDF5::createAttributeDataset()
               driverName, functionName);
   }
 
+  // Check the chunking value
+  getIntegerParam(NDFileHDF5_NDAttributeChunk, &chunking);
+  // If the chunking is zero then use the number of frames
+  if (chunking == 0){
+    // In this case we want to read back the number of frames and use this for chunking
+    getIntegerParam(NDFileNumCapture, &chunking);
+  }
+
   ndAttr = this->pFileAttributes->next(ndAttr); // get the first NDAttribute
   while(ndAttr != NULL)
   {
@@ -2091,19 +2103,23 @@ asynStatus NDFileHDF5::createAttributeDataset()
     //set the default save frequence to be every frame
     hdfAttrNode->whenToSave = hdf5::OnFrame;
 
-
+    // Creating extendible data sets
+    hdfAttrNode->hdfdims[0] = 1;
     if (ndAttr->getDataType() < NDAttrString){
       hdfAttrNode->hdfdatatype  = this->typeNd2Hdf((NDDataType_t)ndAttr->getDataType());
-      hdfAttrNode->hdfdims[0] = hdfdims;
+      hdfAttrNode->chunk[0]   = chunking;
       hdfAttrNode->hdfrank    = 1;
     } else {
       // String dataset required, use type N5T_NATIVE_CHAR
       hdfAttrNode->hdfdatatype = H5T_NATIVE_CHAR;
       hdfAttrNode->hdfdims[1] = MAX_ATTRIBUTE_STRING_SIZE;
-      hdfAttrNode->hdfdims[0] = hdfdims;
+      hdfAttrNode->chunk[0]   = chunking;
+      hdfAttrNode->chunk[1]   = MAX_ATTRIBUTE_STRING_SIZE;
       hdfAttrNode->hdfrank    = 2;
     }
     H5Pset_fill_value (hdfAttrNode->hdfcparm, hdfAttrNode->hdfdatatype, this->ptrFillValue );
+
+    H5Pset_chunk(hdfAttrNode->hdfcparm, hdfAttrNode->hdfrank, hdfAttrNode->chunk);
 
     hdf5::Dataset *dset = NULL;
     // Search for the dataset of the NDAttribute.  If it exists then we use it
@@ -2117,7 +2133,7 @@ asynStatus NDFileHDF5::createAttributeDataset()
           hdfAttrNode->hdfdims[0] = 1;
       }
 
-      hdfAttrNode->hdfdataspace = H5Screate_simple(hdfAttrNode->hdfrank, hdfAttrNode->hdfdims, NULL);
+      hdfAttrNode->hdfdataspace = H5Screate_simple(hdfAttrNode->hdfrank, hdfAttrNode->hdfdims, maxdims);
       // Get the group from the dataset
       hid_t dsetgroup = H5Gopen(this->file, dset->get_parent()->get_full_name().c_str(), H5P_DEFAULT);
 
@@ -2154,7 +2170,7 @@ asynStatus NDFileHDF5::createAttributeDataset()
 
     } else {
       if(groupDefault > -1) {
-        hdfAttrNode->hdfdataspace = H5Screate_simple(hdfAttrNode->hdfrank, hdfAttrNode->hdfdims, NULL);
+        hdfAttrNode->hdfdataspace = H5Screate_simple(hdfAttrNode->hdfrank, hdfAttrNode->hdfdims, maxdims);
         // In here we need to create the dataset
         hdfAttrNode->hdfdataset   = H5Dcreate2(groupDefault, hdfAttrNode->attrName,
                                                hdfAttrNode->hdfdatatype, hdfAttrNode->hdfdataspace,
@@ -2231,6 +2247,7 @@ asynStatus NDFileHDF5::writeAttributeDataset(hdf5::When_t whenToSave)
       memset(datavalue, 0, 8);
     }
     // Work with HDF5 library to select a suitable hyperslab (one element) and write the new data to it
+    H5Dset_extent(hdfAttrNode->hdfdataset, hdfAttrNode->hdfdims);
     hdfAttrNode->hdffilespace = H5Dget_space(hdfAttrNode->hdfdataset);
     H5Sselect_hyperslab(hdfAttrNode->hdffilespace, H5S_SELECT_SET,
                                     hdfAttrNode->offset, NULL,
@@ -2242,6 +2259,7 @@ asynStatus NDFileHDF5::writeAttributeDataset(hdf5::When_t whenToSave)
                          H5P_DEFAULT, datavalue);
 
     H5Sclose(hdfAttrNode->hdffilespace);
+    hdfAttrNode->hdfdims[0]++;
     hdfAttrNode->offset[0]++;
   }
   return status;

--- a/ADApp/pluginSrc/NDFileHDF5.h
+++ b/ADApp/pluginSrc/NDFileHDF5.h
@@ -20,6 +20,7 @@
 #define str_NDFileHDF5_nFramesChunks     "HDF5_nFramesChunks"
 #define str_NDFileHDF5_chunkBoundaryAlign "HDF5_chunkBoundaryAlign"
 #define str_NDFileHDF5_chunkBoundaryThreshold "HDF5_chunkBoundaryThreshold"
+#define str_NDFileHDF5_NDAttributeChunk  "HDF5_NDAttributeChunk"
 #define str_NDFileHDF5_extraDimNameN     "HDF5_extraDimNameN"
 #define str_NDFileHDF5_nExtraDims        "HDF5_nExtraDims"
 #define str_NDFileHDF5_extraDimSizeX     "HDF5_extraDimSizeX"
@@ -54,6 +55,7 @@ typedef struct HDFAttributeNode {
   hid_t hdffilespace;
   hsize_t hdfdims[2];
   hsize_t offset[2];
+  hsize_t chunk[2];
   hsize_t elementSize[2];
   int hdfrank;
   hdf5::When_t whenToSave;
@@ -119,6 +121,7 @@ class epicsShareClass NDFileHDF5 : public NDPluginFile
     int NDFileHDF5_nFramesChunks;
     int NDFileHDF5_chunkBoundaryAlign;
     int NDFileHDF5_chunkBoundaryThreshold;
+    int NDFileHDF5_NDAttributeChunk;
     int NDFileHDF5_nExtraDims;
     int NDFileHDF5_extraDimNameN;
     int NDFileHDF5_extraDimSizeX;


### PR DESCRIPTION
Introduced a new parameter NDAttributeChunk for setting chunking.  Updated
NDAttribute datasets to use unlimited maximum length and then increase the
size as required.  If the user stops the collection early then only
collected data is stored to the datasets.
This resolves issue #74.