### PR TITLE
Only loop over 3 user chunking array elements to fix issue #86.

### DIFF
--- a/ADApp/pluginSrc/NDFileHDF5.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5.cpp
@@ -2479,7 +2479,8 @@ asynStatus NDFileHDF5::configureDims(NDArray *pArray)
   getIntegerParam(NDFileHDF5_nColChunks,    &user_chunking[0]);
   int max_items = 0;
   int hdfdim = 0;
-  for (i = 0; i<ndims; i++)
+  // Loop over the number of user_chunking array elements (3 elements here)
+  for (i = 0; i<3; i++)
   {
       hdfdim = ndims - i - 1;
       max_items = (int)this->maxdims[hdfdim];


### PR DESCRIPTION
Within the configureDims method a loop is performed to calculate chunking
parameters.  There are three user chunking parameters declared but the
loop is looping over the number of dims, this has been changed with a
comment to explain what the loop is doing.

This fixes issue #86 