### PR TITLE
Further fix to the calculation of chunking dimensions #86.

### DIFF
--- a/ADApp/pluginSrc/NDFileHDF5.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5.cpp
@@ -2479,8 +2479,17 @@ asynStatus NDFileHDF5::configureDims(NDArray *pArray)
   getIntegerParam(NDFileHDF5_nColChunks,    &user_chunking[0]);
   int max_items = 0;
   int hdfdim = 0;
-  // Loop over the number of user_chunking array elements (3 elements here)
-  for (i = 0; i<3; i++)
+  int fileWriteMode = 0;
+  // Work out the number of chunking dims we are going to work with (number of array dims)
+  int numDimsForChunking = pArray->ndims;
+  getIntegerParam(NDFileWriteMode, &fileWriteMode);    
+  // Check that we are not in single mode
+  if (fileWriteMode != NDFileModeSingle){
+    // There is another dimension (frame number)
+    numDimsForChunking++;
+  }
+  // Loop over the number of user_chunking array elements
+  for (i = 0; i<numDimsForChunking; i++)
   {
       hdfdim = ndims - i - 1;
       max_items = (int)this->maxdims[hdfdim];

--- a/iocs/simDetectorIOC/iocBoot/iocHDF5Test/test6.sh
+++ b/iocs/simDetectorIOC/iocBoot/iocHDF5Test/test6.sh
@@ -1,0 +1,20 @@
+caput 13SIM1:cam1:SizeX 10
+caput 13SIM1:cam1:SizeY 10
+caput 13SIM1:cam1:AcquireTime .001
+caput 13SIM1:cam1:AcquirePeriod 0.1
+caput 13SIM1:cam1:ImageMode "Continuous"
+caput 13SIM1:cam1:ArrayCallbacks "Enable"
+caput 13SIM1:cam1:Acquire 1
+caput 13SIM1:HDF1:EnableCallbacks Enable
+caput -S 13SIM1:HDF1:FilePath "./"
+caput -S 13SIM1:HDF1:FileName "test6"
+caput -S 13SIM1:HDF1:FileTemplate "%s%s_%3.3d.h5"
+caput 13SIM1:HDF1:FileNumber 1
+caput 13SIM1:HDF1:FileWriteMode "Single"
+caput 13SIM1:HDF1:NumCapture "1"
+caput 13SIM1:HDF1:AutoSave 1
+sleep 1
+caput 13SIM1:HDF1:AutoSave 0
+sleep 5
+h5dump test6_001.h5 > test6_001.txt
+


### PR DESCRIPTION
The chunking dimensions calculation was not satisfactory in its previous
form.  Using the total number of dimensions didn't work when using extra
virtual dimensions, and my previous fix of hardcoding to 3 dims didn't
work when the writer was used in single mode (with only 2 dimensions of
array data).  The value used is now calculated using a combination of the
incoming array dimensions plus the mode of the writer.

The addition of iocHDF5Test/test6.sh reproduce the problem (and verify the fix - works for myself and @ajgdls).

This fixes #86 
