### PR TITLE
Changed sseq_settings.req to sseqRecord_settings.req

### DIFF
--- a/ADApp/Db/NDStats_settings.req
+++ b/ADApp/Db/NDStats_settings.req
@@ -12,5 +12,5 @@ $(P)$(R)HistMax
 $(P)$(R)TSNumPoints
 $(P)$(R)TSRead.SCAN
 file "NDPluginBase_settings.req", P=$(P), R=$(R)
-file "sseq_settings.req", P=$(P), S=$(R)Reset
-file "sseq_settings.req", P=$(P), S=$(R)Reset1
+file "sseqRecord_settings.req", P=$(P), S=$(R)Reset
+file "sseqRecord_settings.req", P=$(P), S=$(R)Reset1

--- a/ADApp/Db/commonPlugin_settings.req
+++ b/ADApp/Db/commonPlugin_settings.req
@@ -49,4 +49,4 @@ file "scan_settings.req",           P=$(P),  S=scan1
 file "scan_settings.req",           P=$(P),  S=scan2
 file "scan_settings.req",           P=$(P),  S=scan3
 file "scan_settings.req",           P=$(P),  S=scan4
-file "sseq_settings.req",           P=$(P),  S=AcquireSequence
+file "sseqRecord_settings.req",     P=$(P),  S=AcquireSequence


### PR DESCRIPTION
Changed sseq_settings.req to sseqRecord_settings.req, which is the preferred filename in new versions of the calc module. This is also required for autosaveBuild calls to succeed.