### PR TITLE
3rd party software reference in documentation

### DIFF
--- a/documentation/areaDetector.html
+++ b/documentation/areaDetector.html
@@ -129,6 +129,12 @@
     Some areaDetector support have been developed by others. These are not distributed
     with the areaDetector releases (source or binary) and are not directly
     supported by the areaDetector working group, but may be useful for users:</p>
+  <p>From <a href="http://www.imxpad.com">imXPAD</a></p>
+  <ul>
+    <li>The XPAD detector.</li>
+    <li>areaDetector driver source on <a href="https://github.com/oirled/ADXpad">github</a></li>
+  </ul>
+      
   <h2>
     Where to find it</h2>
   <p>

--- a/documentation/areaDetector.html
+++ b/documentation/areaDetector.html
@@ -124,6 +124,12 @@
     Please email any comments and bug reports to <a href="mailto:rivers@cars.uchicago.edu">
       Mark Rivers</a> who is responsible for coordinating development and releases.</p>
   <h2>
+    areaDetector camera drivers supplied by 3rd parties</h2>
+  <p>
+    Some areaDetector support have been developed by others. These are not distributed
+    with the areaDetector releases (source or binary) and are not directly
+    supported by the areaDetector working group, but may be useful for users:</p>
+  <h2>
     Where to find it</h2>
   <p>
     Beginning with release R2-0 (March 2014) the areaDetector module is in the <a href="https://github.com/areaDetector">


### PR DESCRIPTION
This change adds a section to the areaDetector HTML front-page where we can list and reference 3rd party supplied areaDetector drivers. I think it is useful for users to get a view of what cameras they can control with areaDetector - even the ones that we do not develop/support/distribute as part of the work in the areaDetector working group.

This was triggered by a request to include the ImXPAD detector driver by @oirled. This PR also include a reference to the XPAD detector.
