### PR TITLE
Allow boost, hdf5, and sz to be SYS_LIBS 

### DIFF
--- a/ADApp/pluginTests/Makefile
+++ b/ADApp/pluginTests/Makefile
@@ -28,8 +28,12 @@ ifdef BOOST
   #plugin-test_SRCS += test_<plugin name>.cpp
   
   plugin-test_LIBS += ADTestUtility
-  plugin-test_SYS_LIBS += boost_unit_test_framework
-  boost_unit_test_framework_DIR=$(BOOST_LIB)
+  ifdef BOOST_LIB
+    boost_unit_test_framework_DIR=$(BOOST_LIB)
+    plugin-test_LIBS += boost_unit_test_framework
+  else
+    plugin-test_SYS_LIBS += boost_unit_test_framework
+  endif
 endif
 
 USR_INCLUDES += $(HDF5_INCLUDE)
@@ -37,13 +41,26 @@ USR_INCLUDES += $(SZ_INCLUDE)
 USR_INCLUDES += $(XML2_INCLUDE)
 USR_INCLUDES += $(BOOST_INCLUDE)
 
-PROD_LIBS += NDPlugin ADBase asyn hdf5
-ifdef SZIP
-  sz_DIR = $(SZIP_LIB)
-  PROD_LIBS += sz
+PROD_LIBS += NDPlugin ADBase asyn
+
+ifdef HDF5_LIB
+  hdf5_DIR = $(HDF5_LIB)
+  PROD_LIBS += hdf5
+else
+  PROD_SYS_LIBS += hdf5
 endif
+
+ifdef SZIP
+  ifdef SZIP_LIB
+    sz_DIR = $(SZIP_LIB)
+    PROD_LIBS += sz
+  else
+    PROD_SYS_LIBS += sz
+  endif
+endif
+
 PROD_LIBS += $(EPICS_BASE_IOC_LIBS)
+
 PROD_SYS_LIBS += xml2
-hdf5_DIR = $(HDF5_LIB)
 
 include $(TOP)/configure/RULES


### PR DESCRIPTION
The main problem we discussed earlier is when library A should use a system library in the normal default location, but library B exists in the system location but that version system should not be used for library B.  The problem is that if A_DIR is specified then the default system location can be searched first, and it will find the wrong version of library B.  This version of the Makefile allows defining BOOST but not BOOST_LIB, not defining HDF5_LIB, and defining SZIP but not SZIP_LIB.  If the _LIB definition is present it defines the _DIR and adds the library to PROD_LIBS.  If the _LIB definition is not present then it does not define the _DIR and adds the library to PROD_SYS_LIBS.  This prevents the system libraries from being added early in the library search path, and should fix the most common issues.