### PR TITLE
NDAttribute::sourceType was never being set

### DIFF
--- a/ADApp/ADSrc/NDAttribute.cpp
+++ b/ADApp/ADSrc/NDAttribute.cpp
@@ -45,6 +45,7 @@ const char *NDAttribute::attrSourceString(NDAttrSource_t type)
 
   this->pName = pName? epicsStrDup(pName): epicsStrDup("");
   this->pDescription = pDescription? epicsStrDup(pDescription): epicsStrDup("");
+  this->sourceType = sourceType;
   switch (sourceType) {
     case NDAttrSourceDriver:
       this->pSourceTypeString = epicsStrDup("NDAttrSourceDriver");
@@ -59,6 +60,7 @@ const char *NDAttribute::attrSourceString(NDAttrSource_t type)
       this->pSourceTypeString = epicsStrDup("NDAttrSourceFunct");
       break;
     default:
+      this->sourceType = NDAttrSourceUndefined;
       this->pSourceTypeString = epicsStrDup("Undefined");
   }
   this->pSource = pSource? epicsStrDup(pSource): epicsStrDup("");
@@ -385,7 +387,8 @@ int NDAttribute::report(FILE *fp, int details)
   fprintf(fp, "NDAttribute, address=%p:\n", this);
   fprintf(fp, "  name=%s\n", this->pName);
   fprintf(fp, "  description=%s\n", this->pDescription);
-  fprintf(fp, "  source type=%s\n", this->pSourceTypeString);
+  fprintf(fp, "  source type=%d\n", this->sourceType);
+  fprintf(fp, "  source type string=%s\n", this->pSourceTypeString);
   fprintf(fp, "  source=%s\n", this->pSource);
   switch (this->dataType) {
     case NDAttrInt8:

--- a/ADApp/ADSrc/NDAttribute.h
+++ b/ADApp/ADSrc/NDAttribute.h
@@ -57,7 +57,8 @@ typedef enum
     NDAttrSourceDriver,    /**< Attribute is obtained directly from driver */
     NDAttrSourceParam,     /**< Attribute is obtained from parameter library */
     NDAttrSourceEPICSPV,   /**< Attribute is obtained from an EPICS PV */
-    NDAttrSourceFunct      /**< Attribute is obtained from a user-specified function */
+    NDAttrSourceFunct,     /**< Attribute is obtained from a user-specified function */
+    NDAttrSourceUndefined  /**< Attribute source is undefined */
 } NDAttrSource_t;
 
 /** Union defining the values in an NDAttribute object */


### PR DESCRIPTION
NDAttribute::sourceType was never being set. Set it in constructor.  Add new NDAttrSourceUndefined enum; print NDAttribute::sourceType in NDAttribute::report().