### PR TITLE
Fixes to Attributes handling

### DIFF
--- a/ADApp/ADSrc/NDAttribute.cpp
+++ b/ADApp/ADSrc/NDAttribute.cpp
@@ -45,6 +45,7 @@ const char *NDAttribute::attrSourceString(NDAttrSource_t type)
 
   this->pName = pName? epicsStrDup(pName): epicsStrDup("");
   this->pDescription = pDescription? epicsStrDup(pDescription): epicsStrDup("");
+  this->sourceType = sourceType;
   switch (sourceType) {
     case NDAttrSourceDriver:
       this->pSourceTypeString = epicsStrDup("NDAttrSourceDriver");
@@ -59,6 +60,7 @@ const char *NDAttribute::attrSourceString(NDAttrSource_t type)
       this->pSourceTypeString = epicsStrDup("NDAttrSourceFunct");
       break;
     default:
+      this->sourceType = NDAttrSourceUndefined;
       this->pSourceTypeString = epicsStrDup("Undefined");
   }
   this->pSource = pSource? epicsStrDup(pSource): epicsStrDup("");
@@ -385,7 +387,8 @@ int NDAttribute::report(FILE *fp, int details)
   fprintf(fp, "NDAttribute, address=%p:\n", this);
   fprintf(fp, "  name=%s\n", this->pName);
   fprintf(fp, "  description=%s\n", this->pDescription);
-  fprintf(fp, "  source type=%s\n", this->pSourceTypeString);
+  fprintf(fp, "  source type=%d\n", this->sourceType);
+  fprintf(fp, "  source type string=%s\n", this->pSourceTypeString);
   fprintf(fp, "  source=%s\n", this->pSource);
   switch (this->dataType) {
     case NDAttrInt8:

--- a/ADApp/ADSrc/NDAttribute.h
+++ b/ADApp/ADSrc/NDAttribute.h
@@ -57,7 +57,8 @@ typedef enum
     NDAttrSourceDriver,    /**< Attribute is obtained directly from driver */
     NDAttrSourceParam,     /**< Attribute is obtained from parameter library */
     NDAttrSourceEPICSPV,   /**< Attribute is obtained from an EPICS PV */
-    NDAttrSourceFunct      /**< Attribute is obtained from a user-specified function */
+    NDAttrSourceFunct,     /**< Attribute is obtained from a user-specified function */
+    NDAttrSourceUndefined  /**< Attribute source is undefined */
 } NDAttrSource_t;
 
 /** Union defining the values in an NDAttribute object */

--- a/ADApp/ntndArrayConverterSrc/ntndArrayConverter.cpp
+++ b/ADApp/ntndArrayConverterSrc/ntndArrayConverter.cpp
@@ -486,18 +486,17 @@ void NTNDArrayConverter::createAttributes (NDArray *src)
         switch(attr->getDataType())
         {
 
-        case NDAttrInt8:    value->set(PVDC->createPVScalar<PVByte>());   break;
-        case NDAttrUInt8:   value->set(PVDC->createPVScalar<PVUByte>());  break;
-        case NDAttrInt16:   value->set(PVDC->createPVScalar<PVShort>());  break;
-        case NDAttrUInt16:  value->set(PVDC->createPVScalar<PVUShort>()); break;
-        case NDAttrInt32:   value->set(PVDC->createPVScalar<PVInt>());    break;
-        case NDAttrUInt32:  value->set(PVDC->createPVScalar<PVUInt>());   break;
-        case NDAttrFloat32: value->set(PVDC->createPVScalar<PVFloat>());  break;
-        case NDAttrFloat64: value->set(PVDC->createPVScalar<PVDouble>()); break;
-        case NDAttrString:  value->set(PVDC->createPVScalar<PVString>()); break;
-        case NDAttrUndefined:
-        default:
-            throw std::runtime_error("invalid attribute data type");
+        case NDAttrInt8:      value->set(PVDC->createPVScalar<PVByte>());   break;
+        case NDAttrUInt8:     value->set(PVDC->createPVScalar<PVUByte>());  break;
+        case NDAttrInt16:     value->set(PVDC->createPVScalar<PVShort>());  break;
+        case NDAttrUInt16:    value->set(PVDC->createPVScalar<PVUShort>()); break;
+        case NDAttrInt32:     value->set(PVDC->createPVScalar<PVInt>());    break;
+        case NDAttrUInt32:    value->set(PVDC->createPVScalar<PVUInt>());   break;
+        case NDAttrFloat32:   value->set(PVDC->createPVScalar<PVFloat>());  break;
+        case NDAttrFloat64:   value->set(PVDC->createPVScalar<PVDouble>()); break;
+        case NDAttrString:    value->set(PVDC->createPVScalar<PVString>()); break;
+        case NDAttrUndefined: value->get().reset(); break;
+        default:              throw std::runtime_error("invalid attribute data type");
         }
 
         destVec.push_back(pvAttr);
@@ -524,18 +523,17 @@ void NTNDArrayConverter::fromAttributes (NDArray *src)
         PVStructurePtr pvAttr(*it);
         switch(attr->getDataType())
         {
-        case NDAttrInt8:    fromAttribute <PVByte,   int8_t>  (pvAttr, attr); break;
-        case NDAttrUInt8:   fromAttribute <PVUByte,  uint8_t> (pvAttr, attr); break;
-        case NDAttrInt16:   fromAttribute <PVShort,  int16_t> (pvAttr, attr); break;
-        case NDAttrUInt16:  fromAttribute <PVUShort, uint16_t>(pvAttr, attr); break;
-        case NDAttrInt32:   fromAttribute <PVInt,    int32_t> (pvAttr, attr); break;
-        case NDAttrUInt32:  fromAttribute <PVUInt,   uint32_t>(pvAttr, attr); break;
-        case NDAttrFloat32: fromAttribute <PVFloat,  float>   (pvAttr, attr); break;
-        case NDAttrFloat64: fromAttribute <PVDouble, double>  (pvAttr, attr); break;
-        case NDAttrString:  fromStringAttribute(pvAttr, attr); break;
-        case NDAttrUndefined:
-        default:
-            throw std::runtime_error("invalid attribute data type");
+        case NDAttrInt8:      fromAttribute <PVByte,   int8_t>  (pvAttr, attr); break;
+        case NDAttrUInt8:     fromAttribute <PVUByte,  uint8_t> (pvAttr, attr); break;
+        case NDAttrInt16:     fromAttribute <PVShort,  int16_t> (pvAttr, attr); break;
+        case NDAttrUInt16:    fromAttribute <PVUShort, uint16_t>(pvAttr, attr); break;
+        case NDAttrInt32:     fromAttribute <PVInt,    int32_t> (pvAttr, attr); break;
+        case NDAttrUInt32:    fromAttribute <PVUInt,   uint32_t>(pvAttr, attr); break;
+        case NDAttrFloat32:   fromAttribute <PVFloat,  float>   (pvAttr, attr); break;
+        case NDAttrFloat64:   fromAttribute <PVDouble, double>  (pvAttr, attr); break;
+        case NDAttrString:    fromStringAttribute(pvAttr, attr); break;
+        case NDAttrUndefined: break;
+        default:              throw std::runtime_error("invalid attribute data type");
         }
         attr = srcList->next(attr);
     }

--- a/ADApp/ntndArrayConverterSrc/ntndArrayConverter.cpp
+++ b/ADApp/ntndArrayConverterSrc/ntndArrayConverter.cpp
@@ -295,41 +295,41 @@ void NTNDArrayConverter::toDataTimeStamp (NDArray *dest)
     dest->timeStamp = ts.toSeconds();
 }
 
-
 template <typename pvAttrType, typename valueType>
 void NTNDArrayConverter::toAttribute (NDArray *dest, PVStructurePtr src)
 {
-    NDAttributeList *destList = dest->pAttributeList;
-    NDAttrDataType_t destType = scalarToNDAttrDataType[pvAttrType::typeCode];
-    PVUnionPtr valueUnion(src->getSubField<PVUnion>("value"));
-    valueType value = valueUnion->get<pvAttrType>()->get();
-    const char *name = src->getSubField<PVString>("name")->get().c_str();
-    const char *desc = src->getSubField<PVString>("descriptor")->get().c_str();
-    // sourceType and source are lost
+    const char *name          = src->getSubField<PVString>("name")->get().c_str();
+    const char *desc          = src->getSubField<PVString>("descriptor")->get().c_str();
+    NDAttrSource_t sourceType = (NDAttrSource_t)src->getSubField<PVInt>("sourceType")->get();
+    const char *source        = src->getSubField<PVString>("source")->get().c_str();
+    NDAttrDataType_t dataType = scalarToNDAttrDataType[pvAttrType::typeCode];
+    valueType value           = src->getSubField<PVUnion>("value")->get<pvAttrType>()->get();
 
-    destList->add(name, desc, destType, (void*)&value);
+    NDAttribute *attr = new NDAttribute(name, desc, sourceType, source, dataType, (void*)&value);
+    dest->pAttributeList->add(attr);
 }
 
 void NTNDArrayConverter::toStringAttribute (NDArray *dest, PVStructurePtr src)
 {
-    NDAttributeList *destList = dest->pAttributeList;
-    PVUnionPtr valueUnion(src->getSubField<PVUnion>("value"));
-    string value(valueUnion->get<PVString>()->get());
-    const char *name = src->getSubField<PVString>("name")->get().c_str();
-    const char *desc = src->getSubField<PVString>("descriptor")->get().c_str();
-    // sourceType and source are lost
+    const char *name          = src->getSubField<PVString>("name")->get().c_str();
+    const char *desc          = src->getSubField<PVString>("descriptor")->get().c_str();
+    NDAttrSource_t sourceType = (NDAttrSource_t)src->getSubField<PVInt>("sourceType")->get();
+    const char *source        = src->getSubField<PVString>("source")->get().c_str();
+    const char *value         = src->getSubField<PVUnion>("value")->get<PVString>()->get().c_str();
 
-    destList->add(name, desc, NDAttrString, (void*)value.c_str());
+    NDAttribute *attr = new NDAttribute(name, desc, sourceType, source, NDAttrString, (void*)value);
+    dest->pAttributeList->add(attr);
 }
 
 void NTNDArrayConverter::toUndefinedAttribute (NDArray *dest, PVStructurePtr src)
 {
-    NDAttributeList *destList = dest->pAttributeList;
-    const char *name = src->getSubField<PVString>("name")->get().c_str();
-    const char *desc = src->getSubField<PVString>("descriptor")->get().c_str();
-    // sourceType and source are lost
+    const char *name          = src->getSubField<PVString>("name")->get().c_str();
+    const char *desc          = src->getSubField<PVString>("descriptor")->get().c_str();
+    NDAttrSource_t sourceType = (NDAttrSource_t)src->getSubField<PVInt>("sourceType")->get();
+    const char *source        = src->getSubField<PVString>("source")->get().c_str();
 
-    destList->add(name, desc, NDAttrUndefined, NULL);
+    NDAttribute *attr = new NDAttribute(name, desc, sourceType, source, NDAttrUndefined, NULL);
+    dest->pAttributeList->add(attr);
 }
 
 void NTNDArrayConverter::toAttributes (NDArray *dest)

--- a/ADApp/ntndArrayConverterSrc/ntndArrayConverter.cpp
+++ b/ADApp/ntndArrayConverterSrc/ntndArrayConverter.cpp
@@ -481,7 +481,7 @@ void NTNDArrayConverter::createAttributes (NDArray *src)
     NDAttributeList *srcList = src->pAttributeList;
     NDAttribute *attr = srcList->next(NULL);
     PVStructureArrayPtr dest(m_array->getAttribute());
-    PVStructureArray::svector destVec(dest->reuse());
+    PVStructureArray::svector destVec(0);
     StructureConstPtr structure(dest->getStructureArray()->getStructure());
 
     while(attr)

--- a/ADApp/ntndArrayConverterSrc/ntndArrayConverter.h
+++ b/ADApp/ntndArrayConverterSrc/ntndArrayConverter.h
@@ -57,7 +57,7 @@ private:
     template <typename pvAttrType, typename valueType>
     void fromAttribute (epics::pvData::PVStructurePtr dest, NDAttribute *src);
     void fromStringAttribute (epics::pvData::PVStructurePtr dest, NDAttribute *src);
-    void createAttributes (NDArray *src);
+    void fromUndefinedAttribute (epics::pvData::PVStructurePtr dest);
     void fromAttributes (NDArray *src);
 };
 

--- a/ADApp/ntndArrayConverterSrc/ntndArrayConverter.h
+++ b/ADApp/ntndArrayConverterSrc/ntndArrayConverter.h
@@ -43,6 +43,7 @@ private:
     template <typename pvAttrType, typename valueType>
     void toAttribute (NDArray *dest, epics::pvData::PVStructurePtr src);
     void toStringAttribute (NDArray *dest, epics::pvData::PVStructurePtr src);
+    void toUndefinedAttribute (NDArray *dest, epics::pvData::PVStructurePtr src);
     void toAttributes (NDArray *dest);
 
     template <typename arrayType, typename srcDataType>


### PR DESCRIPTION
A couple of issues on the conversion code between NDArrays and NTNDArrays regarding Attributes handling were fixed. Namely:

* Undefined attributes from NDArray to NTNDArray are now parsed correctly instead of throwing an exception.
* Source and source type of Attributes are now correctly parsed from NTNDArray to NDArray instead of being ignored.