### PR TITLE
Add timestamps waveform to timeseries

### DIFF
--- a/ADApp/Db/NDStats.template
+++ b/ADApp/Db/NDStats.template
@@ -481,6 +481,14 @@ record(waveform, "$(P)$(R)TSSigmaXY")
    field(SCAN, "I/O Intr")
 }
 
+record(waveform, "$(P)$(R)TSTimestamp")
+{
+   field(DTYP, "asynFloat64ArrayIn")
+   field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))TS_TIMESTAMP_VALUE")
+   field(NELM, "$(NCHANS)")
+   field(FTVL, "DOUBLE")
+   field(SCAN, "I/O Intr")
+}
 
 ###################################################################
 #  These records control profiles                                 #

--- a/ADApp/pluginSrc/NDPluginStats.cpp
+++ b/ADApp/pluginSrc/NDPluginStats.cpp
@@ -395,6 +395,7 @@ void NDPluginStats::doTimeSeriesCallbacks()
     doCallbacksFloat64Array(this->timeSeries[TSSigmaX],     currentPoint, NDPluginStatsTSSigmaX, 0);
     doCallbacksFloat64Array(this->timeSeries[TSSigmaY],     currentPoint, NDPluginStatsTSSigmaY, 0);
     doCallbacksFloat64Array(this->timeSeries[TSSigmaXY],    currentPoint, NDPluginStatsTSSigmaXY, 0);
+    doCallbacksFloat64Array(this->timeSeries[TSTimestamp],  currentPoint, NDPluginStatsTSTimestamp, 0);
 }
 
 
@@ -556,11 +557,12 @@ void NDPluginStats::processCallbacks(NDArray *pArray)
         timeSeries[TSSigmaValue][currentTSPoint]  = pStats->sigma;
         timeSeries[TSTotal][currentTSPoint]       = pStats->total;
         timeSeries[TSNet][currentTSPoint]         = pStats->net;
-        timeSeries[TSCentroidX][currentTSPoint] = this->centroidX;
-        timeSeries[TSCentroidY][currentTSPoint] = this->centroidY;
-        timeSeries[TSSigmaX][currentTSPoint]    = this->sigmaX;
-        timeSeries[TSSigmaY][currentTSPoint]    = this->sigmaY;
-        timeSeries[TSSigmaXY][currentTSPoint]   = this->sigmaXY;
+        timeSeries[TSCentroidX][currentTSPoint]   = this->centroidX;
+        timeSeries[TSCentroidY][currentTSPoint]   = this->centroidY;
+        timeSeries[TSSigmaX][currentTSPoint]      = this->sigmaX;
+        timeSeries[TSSigmaY][currentTSPoint]      = this->sigmaY;
+        timeSeries[TSSigmaXY][currentTSPoint]     = this->sigmaXY;
+        timeSeries[TSTimestamp][currentTSPoint]   = pArray->timeStamp;
         currentTSPoint++;
         setIntegerParam(NDPluginStatsTSCurrentPoint, currentTSPoint);
         if (currentTSPoint >= numTSPoints) {
@@ -790,6 +792,7 @@ NDPluginStats::NDPluginStats(const char *portName, int queueSize, int blockingCa
     createParam(NDPluginStatsTSSigmaXString,          asynParamFloat64Array, &NDPluginStatsTSSigmaX);
     createParam(NDPluginStatsTSSigmaYString,          asynParamFloat64Array, &NDPluginStatsTSSigmaY);
     createParam(NDPluginStatsTSSigmaXYString,         asynParamFloat64Array, &NDPluginStatsTSSigmaXY);
+    createParam(NDPluginStatsTSTimestampString,       asynParamFloat64Array, &NDPluginStatsTSTimestamp);
 
     /* Profiles */
     createParam(NDPluginStatsComputeProfilesString,   asynParamInt32,         &NDPluginStatsComputeProfiles);

--- a/ADApp/pluginSrc/NDPluginStats.h
+++ b/ADApp/pluginSrc/NDPluginStats.h
@@ -42,9 +42,10 @@ typedef enum {
     TSCentroidY,
     TSSigmaX,
     TSSigmaY,
-    TSSigmaXY
+    TSSigmaXY,
+    TSTimestamp
 } NDStatTSType;
-#define MAX_TIME_SERIES_TYPES TSSigmaXY+1
+#define MAX_TIME_SERIES_TYPES TSTimestamp+1
 
 typedef enum {
     TSEraseStart,
@@ -97,6 +98,7 @@ typedef enum {
 #define NDPluginStatsTSSigmaXString           "TS_SIGMAX_VALUE"     /* (asynFloat64Array, r/o) Series of sigma X */
 #define NDPluginStatsTSSigmaYString           "TS_SIGMAY_VALUE"     /* (asynFloat64Array, r/o) Series of sigma Y */
 #define NDPluginStatsTSSigmaXYString          "TS_SIGMAXY_VALUE"    /* (asynFloat64Array, r/o) Series of sigma XY */
+#define NDPluginStatsTSTimestampString        "TS_TIMESTAMP_VALUE"  /* (asynFloat64Array, r/o) Series of timestamps */
 
 /* Profiles*/   
 #define NDPluginStatsComputeProfilesString    "COMPUTE_PROFILES"    /* (asynInt32,        r/w) Compute profiles? */
@@ -195,6 +197,7 @@ protected:
     int NDPluginStatsTSSigmaX;
     int NDPluginStatsTSSigmaY;
     int NDPluginStatsTSSigmaXY;
+    int NDPluginStatsTSTimestamp;
     
     /* Profiles */
     int NDPluginStatsComputeProfiles;


### PR DESCRIPTION
Hi,

I am submitting this as a suggestion to add a new waveform to the stats plugin to record the timestamp of each image in the timeseries buffer along with the actual values. This means that the data can be used later to match up with other values. This of course means the pImage->timeStamp value needs to be correct and hopefully set by hardware.

Any comments? Is there a better way to do this? 

S