### PR TITLE
[ENH] Added timeStamp to ROIStats timeseries data

### DIFF
--- a/ADApp/Db/NDROIStatN.template
+++ b/ADApp/Db/NDROIStatN.template
@@ -257,3 +257,11 @@ record(waveform, "$(P)$(R)TSNet")
    field(SCAN, "I/O Intr")
 }
 
+record(waveform, "$(P)$(R)TSTimestamp")
+{
+   field(DTYP, "asynFloat64ArrayIn")
+   field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ROISTAT_TS_TIMESTAMP")
+   field(NELM, "$(NCHANS)")
+   field(FTVL, "DOUBLE")
+   field(SCAN, "I/O Intr")
+}

--- a/ADApp/pluginSrc/NDPluginROIStat.cpp
+++ b/ADApp/pluginSrc/NDPluginROIStat.cpp
@@ -282,6 +282,7 @@ void NDPluginROIStat::processCallbacks(NDArray *pArray)
       pData[TSMeanValue*numTSPoints_ + currentTSPoint_] = pROI->mean;
       pData[TSTotal*numTSPoints_ + currentTSPoint_]     = pROI->total;
       pData[TSNet*numTSPoints_ + currentTSPoint_]       = pROI->net;
+      pData[TSTimestamp*numTSPoints_ + currentTSPoint_] = pArray->timeStamp;
     }
 
     /* We must enter the loop and exit with the mutex locked */
@@ -446,6 +447,7 @@ void NDPluginROIStat::doTimeSeriesCallbacks()
     doCallbacksFloat64Array(pData + TSMeanValue*numTSPoints_,  currentTSPoint_, NDPluginROIStatTSMeanValue, roi);
     doCallbacksFloat64Array(pData + TSTotal*numTSPoints_,      currentTSPoint_, NDPluginROIStatTSTotal, roi);
     doCallbacksFloat64Array(pData + TSNet*numTSPoints_,        currentTSPoint_, NDPluginROIStatTSNet, roi);
+    doCallbacksFloat64Array(pData + TSTimestamp*numTSPoints_,  currentTSPoint_, NDPluginROIStatTSTimestamp, roi);
   }
 }
 
@@ -527,6 +529,7 @@ NDPluginROIStat::NDPluginROIStat(const char *portName, int queueSize, int blocki
   createParam(NDPluginROIStatTSMeanValueString,  asynParamFloat64Array, &NDPluginROIStatTSMeanValue);
   createParam(NDPluginROIStatTSTotalString,      asynParamFloat64Array, &NDPluginROIStatTSTotal);
   createParam(NDPluginROIStatTSNetString,        asynParamFloat64Array, &NDPluginROIStatTSNet);
+  createParam(NDPluginROIStatTSTimestampString,  asynParamFloat64Array, &NDPluginROIStatTSTimestamp);
 
   createParam(NDPluginROIStatLastString,              asynParamInt32, &NDPluginROIStatLast);
   

--- a/ADApp/pluginSrc/NDPluginROIStat.h
+++ b/ADApp/pluginSrc/NDPluginROIStat.h
@@ -46,6 +46,7 @@
 #define NDPluginROIStatTSMeanValueString        "ROISTAT_TS_MEAN_VALUE"     /* (asynFloat64Array, r/o) Series of mean counts */
 #define NDPluginROIStatTSTotalString            "ROISTAT_TS_TOTAL"          /* (asynFloat64Array, r/o) Series of total */
 #define NDPluginROIStatTSNetString              "ROISTAT_TS_NET"            /* (asynFloat64Array, r/o) Series of net */
+#define NDPluginROIStatTSTimestampString        "ROISTAT_TS_TIMESTAMP"      /* (asynFloat64Array, r/o) Series of timestamps */
 
 typedef enum {
     TSMinValue,
@@ -53,6 +54,7 @@ typedef enum {
     TSMeanValue,
     TSTotal,
     TSNet,
+    TSTimestamp,
     MAX_TIME_SERIES_TYPES
 } NDPluginROIStatTSType;
 
@@ -128,6 +130,7 @@ protected:
     int NDPluginROIStatTSMeanValue;
     int NDPluginROIStatTSTotal;
     int NDPluginROIStatTSNet;
+    int NDPluginROIStatTSTimestamp;
     
     int NDPluginROIStatLast;
     #define LAST_NDPLUGIN_ROISTAT_PARAM NDPluginROIStatLast


### PR DESCRIPTION
This pull request follows #140 and adds the time series of timestamps to the roistats plugin like the stats plugin. 