### PR TITLE
Cleaning conditional directives that break statements.

### DIFF
--- a/ADApp/netCDFSrc/libsrc/ffio.c
+++ b/ADApp/netCDFSrc/libsrc/ffio.c
@@ -392,12 +392,14 @@ ncio_ffio_global_test(const char *ControlString)
 static int
 ncio_ffio_sync(ncio *const nciop)
 {
+	int test;
 #ifdef __crayx1
 	struct ffsw stat;
-	if(ffflush(nciop->fd,&stat) < 0)
+	test = ffflush(nciop->fd,&stat) < 0;
 #else
-	if(ffflush(nciop->fd) < 0)
+	test = ffflush(nciop->fd) < 0;
 #endif
+	if (test)
 		return errno;
 	return ENOERR;
 }


### PR DESCRIPTION
  A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.

    https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892
    https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/

It might improve code understanding, maintainability and error-proneness.