### PR TITLE
Set EnableCallbacks from db, and set ArrayCallbacks to 1 by default

### DIFF
--- a/ADApp/Db/NDArrayBase.template
+++ b/ADApp/Db/NDArrayBase.template
@@ -319,6 +319,7 @@ record(bo, "$(P)$(R)ArrayCallbacks")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ARRAY_CALLBACKS")
     field(ZNAM, "Disable")
     field(ONAM, "Enable")
+    field(VAL, "1")
     info(autosaveFields, "VAL")
 }
 

--- a/ADApp/Db/NDPluginBase.template
+++ b/ADApp/Db/NDPluginBase.template
@@ -66,7 +66,7 @@ record(bo, "$(P)$(R)EnableCallbacks")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ENABLE_CALLBACKS")
     field(ZNAM, "Disable")
     field(ONAM, "Enable")
-    field(VAL,  "0")
+    field(VAL,  "$(Enabled=0)")
     info(autosaveFields, "VAL")
 }
 

--- a/ADApp/pluginSrc/NDPluginDriver.cpp
+++ b/ADApp/pluginSrc/NDPluginDriver.cpp
@@ -516,7 +516,6 @@ NDPluginDriver::NDPluginDriver(const char *portName, int queueSize, int blocking
      * Values set here will be overridden by values from save/restore if they exist. */
     setStringParam (NDPluginDriverArrayPort, NDArrayPort);
     setIntegerParam(NDPluginDriverArrayAddr, NDArrayAddr);
-    setIntegerParam(NDPluginDriverEnableCallbacks, 0);
     setIntegerParam(NDPluginDriverDroppedArrays, 0);
     setIntegerParam(NDPluginDriverQueueSize, queueSize);
     setIntegerParam(NDPluginDriverQueueFree, queueSize);


### PR DESCRIPTION
We've had this local patch at DLS for a while, it means that:
* all areaDetector drivers produce ArrayCallbacks by default. This is a change from the current behaviour, but we've never had a reason to turn ArrayCallbacks off apart from debugging.
* all areaDetector plugins can optionally be turned on by setting Enabled=1 in the substitution file. If this is not specified, the behaviour is the same as it is currently.

We've found this very useful, as we can deploy an IOC without having to go and enable manually every plugin and driver we need, and then rely on autosave to keep those changes for us.

Would this be acceptable?