### PR TITLE
Change queue size

### DIFF
--- a/ADApp/Db/NDPluginBase.template
+++ b/ADApp/Db/NDPluginBase.template
@@ -140,12 +140,19 @@ record(longin, "$(P)$(R)DroppedArrays_RBV")
     field(SCAN, "I/O Intr")
 }
 
-record(longin, "$(P)$(R)QueueSize")
+record(longout, "$(P)$(R)QueueSize")
+{
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))QUEUE_SIZE")
+    field(PINI, "YES")
+}
+
+record(longin, "$(P)$(R)QueueSize_RBV")
 {
     field(DTYP, "asynInt32")
     field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))QUEUE_SIZE")
-    field(PINI, "YES")
     field(FLNK, "$(P)$(R)QueueFreeLow")
+    field(SCAN, "I/O Intr")
 }
 
 record(calcout, "$(P)$(R)QueueFreeLow") {

--- a/ADApp/Db/NDPluginBase_settings.req
+++ b/ADApp/Db/NDPluginBase_settings.req
@@ -3,4 +3,5 @@ $(P)$(R)NDArrayAddress
 $(P)$(R)EnableCallbacks
 $(P)$(R)MinCallbackTime
 $(P)$(R)BlockingCallbacks
+$(P)$(R)QueueSize
 file "NDArrayBase_settings.req", P=$(P), R=$(R)

--- a/ADApp/op/adl/NDPluginBase.adl
+++ b/ADApp/op/adl/NDPluginBase.adl
@@ -1,6 +1,6 @@
 
 file {
-	name="/home/epics/devel/areaDetector-2-4/ADCore/ADApp/op/adl/NDPluginBase.adl"
+	name="/home/epics/devel/areaDetector-2-5/ADCore/ADApp/op/adl/NDPluginBase.adl"
 	version=030107
 }
 display {
@@ -344,21 +344,6 @@ text {
 	}
 	textix="Queue size/free"
 	align="horiz. right"
-}
-"text update" {
-	object {
-		x=167
-		y=180
-		width=100
-		height=18
-	}
-	monitor {
-		chan="$(P)$(R)QueueSize"
-		clr=54
-		bclr=4
-	}
-	limits {
-	}
 }
 "text entry" {
 	object {
@@ -873,6 +858,21 @@ menu {
 	}
 	clrmod="alarm"
 	format="string"
+	limits {
+	}
+}
+"text entry" {
+	object {
+		x=167
+		y=179
+		width=100
+		height=20
+	}
+	control {
+		chan="$(P)$(R)QueueSize"
+		clr=14
+		bclr=51
+	}
 	limits {
 	}
 }

--- a/ADApp/pluginSrc/NDPluginDriver.cpp
+++ b/ADApp/pluginSrc/NDPluginDriver.cpp
@@ -318,6 +318,13 @@ asynStatus NDPluginDriver::writeInt32(asynUser *pasynUser, epicsInt32 value)
         this->unlock();
         status = connectToArrayPort();
         this->lock();
+    } else if (function == NDPluginDriverQueueSize) {
+        if (this->msgQId) epicsMessageQueueDestroy(this->msgQId);
+        this->msgQId = epicsMessageQueueCreate(value, sizeof(NDArray*));
+        if (!this->msgQId) {
+            asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, "%s::%s epicsMessageQueueCreate failure\n", driverName, functionName);
+            status = asynError;
+        }
     } else {
         /* If this parameter belongs to a base class call its method */
         if (function < FIRST_NDPLUGIN_PARAM) 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -25,6 +25,18 @@ Release Notes
 
 R2-5 (March XXX, 2016)
 ========================
+### NDPluginBase
+* Added the ability to change the QueueSize of a plugin at run-time. This can be very useful,
+  particularly for file plugins where an acquisition of N frames is overflowing the queue,
+  but increasing the queue can fix the problem. This will be even more useful in ADCore R3-0
+  where we plan to eliminate Capture mode in NDPluginFile. Being able to increase the queue does
+  everything that Capture mode did, but has the additional advantage that in Capture mode the
+  NDArray memory is not allocated from the NDArrayPool, so there is no check on allocating too
+  many arrays or too much memory. Using the queue means that arrays are allocated from the pool,
+  so the limits on total number of arrays and total memory defined in the constructor will be obeyed.
+  This is very important in preventing system freezes if the user accidentally tries allocate all the
+  system memory, which can effectively crash the computer.
+
 ### NDPluginTimeSeries
 * New plugin to for time-series data.  The plugin accepts input arrays of dimensions
   [NumSignals] or [NumSignals, NewTimePoints].  The plugin creates NumSignals 1-D
@@ -79,6 +91,8 @@ R2-5 (March XXX, 2016)
 * Set ArrayCallbacks.VAL to 1 so array callbacks are enabled by default.
 
 ### NDPluginBase.template
+* Changed QueueSize from longin to longout, because the plugin queue size can now be changed at runtime.
+  Added longin QueueSize_RBV.
 * Changed EnableCallbacks.VAL to $(ENABLED=0), allowing enabling callbacks when loading database,
   but default remains Disable.
 * Set the default value of the MDARRAY_ADDR macro to 0 so it does not need to be defined in most cases.


### PR DESCRIPTION
Added the ability to change the QueueSize of a plugin at run-time.  This can be very useful, particularly for file plugins where an acquisition of N frames is overflowing the queue, but increasing the queue can fix the problem.  This will be even more useful in ADCore R3-0 where we plan to eliminate Capture mode in NDPluginFile.  Being able to increase the queue does everything that Capture mode did, but has the additional advantage that in Capture mode the NDArray memory is not allocated from the NDArrayPool, so there is no check on allocating too many arrays or too much memory.  Using the queue means that arrays are allocated from the pool, so the limits on total number of arrays and total memory defined in the constructor will be obeyed.  This can be really important in preventing system freezes if the user tries to allocate all the system memory.