### PR TITLE
Plugin fix clean

### DIFF
--- a/ADApp/pluginSrc/NDFileHDF5.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5.cpp
@@ -2738,9 +2738,9 @@ extern "C" int NDFileHDF5Configure(const char *portName, int queueSize, int bloc
 {
   // Stack Size must be a minimum of 2MB
   if (stackSize < 2097152) stackSize = 2097152;
-  new NDFileHDF5(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
-                 priority, stackSize);
-  return(asynSuccess);
+  NDFileHDF5 *pPlugin = new NDFileHDF5(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
+                                       priority, stackSize);
+  return pPlugin->run();
 }
 
 void NDFileHDF5::checkForOpenFile()

--- a/ADApp/pluginSrc/NDFileJPEG.cpp
+++ b/ADApp/pluginSrc/NDFileJPEG.cpp
@@ -337,9 +337,9 @@ extern "C" int NDFileJPEGConfigure(const char *portName, int queueSize, int bloc
                                    const char *NDArrayPort, int NDArrayAddr,
                                    int priority, int stackSize)
 {
-    new NDFileJPEG(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
-                   priority, stackSize);
-    return(asynSuccess);
+    NDFileJPEG *pPlugin = new NDFileJPEG(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
+                                         priority, stackSize);
+    return pPlugin->run();
 }
 
 

--- a/ADApp/pluginSrc/NDFileMagick.cpp
+++ b/ADApp/pluginSrc/NDFileMagick.cpp
@@ -220,9 +220,9 @@ extern "C" int NDFileMagickConfigure(const char *portName, int queueSize, int bl
                                    const char *NDArrayPort, int NDArrayAddr,
                                    int priority, int stackSize)
 {
-    new NDFileMagick(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
-                     priority, stackSize);
-    return(asynSuccess);
+    NDFileMagick *pPlugin = new NDFileMagick(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
+                                             priority, stackSize);
+    return pPlugin->run();
 }
 
 

--- a/ADApp/pluginSrc/NDFileMagickStub.cpp
+++ b/ADApp/pluginSrc/NDFileMagickStub.cpp
@@ -113,9 +113,9 @@ extern "C" int NDFileMagickConfigure(const char *portName, int queueSize, int bl
                                    const char *NDArrayPort, int NDArrayAddr,
                                    int priority, int stackSize)
 {
-    new NDFileMagick(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
-                     priority, stackSize);
-    return(asynSuccess);
+    NDFileMagick *pPlugin = new NDFileMagick(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
+                                             priority, stackSize);
+    return pPlugin->run();
 }
 
 

--- a/ADApp/pluginSrc/NDFileNetCDF.cpp
+++ b/ADApp/pluginSrc/NDFileNetCDF.cpp
@@ -520,9 +520,9 @@ extern "C" int NDFileNetCDFConfigure(const char *portName, int queueSize, int bl
                                      const char *NDArrayPort, int NDArrayAddr,
                                      int priority, int stackSize)
 {
-    new NDFileNetCDF(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
-                     priority, stackSize);
-    return(asynSuccess);
+    NDFileNetCDF *pPlugin = new NDFileNetCDF(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
+                                             priority, stackSize);
+    return pPlugin->run();
 }
 
 

--- a/ADApp/pluginSrc/NDFileNexus.cpp
+++ b/ADApp/pluginSrc/NDFileNexus.cpp
@@ -864,9 +864,9 @@ extern "C" int NDFileNexusConfigure(const char *portName, int queueSize, int blo
                                     const char *NDArrayPort, int NDArrayAddr,
                                     int priority, int stackSize)
 {
-  new NDFileNexus(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
-                  priority, stackSize);
-  return(asynSuccess);
+  NDFileNexus *pPlugin = new NDFileNexus(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
+                                         priority, stackSize);
+  return pPlugin->run();
 }
 
 

--- a/ADApp/pluginSrc/NDFileNull.cpp
+++ b/ADApp/pluginSrc/NDFileNull.cpp
@@ -93,9 +93,9 @@ extern "C" int NDFileNullConfigure(const char *portName, int queueSize, int bloc
                                    const char *NDArrayPort, int NDArrayAddr,
                                    int priority, int stackSize)
 {
-    new NDFileNull(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
-                   priority, stackSize);
-    return(asynSuccess);
+    NDFileNull *pPlugin = new NDFileNull(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
+                                         priority, stackSize);
+    return pPlugin->run();
 }
 
 

--- a/ADApp/pluginSrc/NDFileTIFF.cpp
+++ b/ADApp/pluginSrc/NDFileTIFF.cpp
@@ -477,9 +477,9 @@ extern "C" int NDFileTIFFConfigure(const char *portName, int queueSize, int bloc
                                    const char *NDArrayPort, int NDArrayAddr,
                                    int priority, int stackSize)
 {
-    new NDFileTIFF(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
-                   priority, stackSize);
-    return(asynSuccess);
+    NDFileTIFF *pPlugin = new NDFileTIFF(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
+                                         priority, stackSize);
+    return pPlugin->run();
 }
 
 

--- a/ADApp/pluginSrc/NDPluginAttribute.cpp
+++ b/ADApp/pluginSrc/NDPluginAttribute.cpp
@@ -287,9 +287,9 @@ extern "C" int NDAttrConfigure(const char *portName, int queueSize, int blocking
                                int maxAttributes, int maxBuffers, size_t maxMemory,
                                int priority, int stackSize)
 {
-    new NDPluginAttribute(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
-                          maxAttributes, maxBuffers, maxMemory, priority, stackSize);
-    return(asynSuccess);
+    NDPluginAttribute *pPlugin = new NDPluginAttribute(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
+                                                       maxAttributes, maxBuffers, maxMemory, priority, stackSize);
+    return pPlugin->run();
 }
 
 /* EPICS iocsh shell commands */

--- a/ADApp/pluginSrc/NDPluginCircularBuff.cpp
+++ b/ADApp/pluginSrc/NDPluginCircularBuff.cpp
@@ -449,9 +449,9 @@ extern "C" int NDCircularBuffConfigure(const char *portName, int queueSize, int 
                                 const char *NDArrayPort, int NDArrayAddr,
                                 int maxBuffers, size_t maxMemory)
 {
-    new NDPluginCircularBuff(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
-                      maxBuffers, maxMemory, 0, 2000000);
-    return(asynSuccess);
+    NDPluginCircularBuff *pPlugin = new NDPluginCircularBuff(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
+                                                             maxBuffers, maxMemory, 0, 2000000);
+    return pPlugin->run();
 }
 
 /* EPICS iocsh shell commands */

--- a/ADApp/pluginSrc/NDPluginColorConvert.cpp
+++ b/ADApp/pluginSrc/NDPluginColorConvert.cpp
@@ -631,9 +631,9 @@ extern "C" int NDColorConvertConfigure(const char *portName, int queueSize, int 
                                           int maxBuffers, size_t maxMemory,
                                           int priority, int stackSize)
 {
-    new NDPluginColorConvert(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr, 
-                             maxBuffers, maxMemory, priority, stackSize);
-    return(asynSuccess);
+    NDPluginColorConvert *pPlugin = new NDPluginColorConvert(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr, 
+                                                             maxBuffers, maxMemory, priority, stackSize);
+    return pPlugin->run();
 }
 
 /** EPICS iocsh shell commands */

--- a/ADApp/pluginSrc/NDPluginDriver.cpp
+++ b/ADApp/pluginSrc/NDPluginDriver.cpp
@@ -167,11 +167,23 @@ void NDPluginDriver::processTask(void)
 {
     /* This thread processes a new array when it arrives */
     int queueSize, queueFree;
+    static const char *functionName = "processTask";
 
     /* Loop forever */
     NDArray *pArray;
+    int nwait=0;
 
     this->lock();
+    
+    while(this->msgQId == 0) {
+        epicsThreadSleep(0.01);
+        nwait++;
+    }
+    if (nwait > 0) {
+        asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
+            "%s::%s, wait %d times for msgQId to be non-zero\n",
+            driverName, functionName, nwait);
+    }
     
     while (1) {
         /* Wait for an array to arrive from the queue. Release the lock while  waiting. */    

--- a/ADApp/pluginSrc/NDPluginDriver.cpp
+++ b/ADApp/pluginSrc/NDPluginDriver.cpp
@@ -155,8 +155,7 @@ void processTask(void *drvPvt)
 {
     NDPluginDriver *pPvt = (NDPluginDriver *)drvPvt;
     
-printf("processTask: entry pPvt=%p, pPvt->processTask=%p, pPvt->msgQId=%d\n", 
-pPvt, pPvt->processTask, pPvt->msgQId);
+printf("processTask: entry pPvt=%p\n", pPvt);
     pPvt->processTask();
 }
 
@@ -175,7 +174,7 @@ void NDPluginDriver::processTask(void)
     NDArray *pArray;
     int nwait=0;
 
-printf("NDPluginDriver::processTask: entry taking lock\n");
+printf("NDPluginDriver::processTask: entry, msgQId=%p taking lock\n", this->msgQId);
     this->lock();
     
     while(this->msgQId == 0) {

--- a/ADApp/pluginSrc/NDPluginDriver.cpp
+++ b/ADApp/pluginSrc/NDPluginDriver.cpp
@@ -156,6 +156,7 @@ void processTask(void *drvPvt)
     NDPluginDriver *pPvt = (NDPluginDriver *)drvPvt;
     int ntries=0;
 
+rintf("processTask, entry\n");
     while(pPvt->msgQId == 0) {
         epicsThreadSleep(0.01);
         ntries++;

--- a/ADApp/pluginSrc/NDPluginDriver.cpp
+++ b/ADApp/pluginSrc/NDPluginDriver.cpp
@@ -155,6 +155,8 @@ void processTask(void *drvPvt)
 {
     NDPluginDriver *pPvt = (NDPluginDriver *)drvPvt;
     
+printf("processTask: entry pPvt=%p, pPvt->processTask=%p, pPvt->msgQId=%d\n", 
+pPvt, pPvt->processTask, pPvt->msgQId);
     pPvt->processTask();
 }
 
@@ -173,6 +175,7 @@ void NDPluginDriver::processTask(void)
     NDArray *pArray;
     int nwait=0;
 
+printf("NDPluginDriver::processTask: entry taking lock\n");
     this->lock();
     
     while(this->msgQId == 0) {

--- a/ADApp/pluginSrc/NDPluginDriver.cpp
+++ b/ADApp/pluginSrc/NDPluginDriver.cpp
@@ -155,7 +155,8 @@ void processTask(void *drvPvt)
 {
     NDPluginDriver *pPvt = (NDPluginDriver *)drvPvt;
     
-printf("processTask: entry pPvt=%p\n", pPvt);
+    epicsThreadSleep(0.1);
+printf("processTask: entry pPvt=%p, slept for 0.1 seconds, calling NDPluginDriver::processTask\n", pPvt);
     pPvt->processTask();
 }
 
@@ -168,25 +169,13 @@ void NDPluginDriver::processTask(void)
 {
     /* This thread processes a new array when it arrives */
     int queueSize, queueFree;
-    static const char *functionName = "processTask";
 
     /* Loop forever */
     NDArray *pArray;
-    int nwait=0;
-
+ 
 printf("NDPluginDriver::processTask: entry, msgQId=%p taking lock\n", this->msgQId);
     this->lock();
-    
-    while(this->msgQId == 0) {
-        epicsThreadSleep(0.01);
-        nwait++;
-    }
-    if (nwait > 0) {
-        asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
-            "%s::%s, wait %d times for msgQId to be non-zero\n",
-            driverName, functionName, nwait);
-    }
-    
+        
     while (1) {
         /* Wait for an array to arrive from the queue. Release the lock while  waiting. */    
         this->unlock();

--- a/ADApp/pluginSrc/NDPluginDriver.cpp
+++ b/ADApp/pluginSrc/NDPluginDriver.cpp
@@ -154,9 +154,13 @@ void NDPluginDriver::driverCallback(asynUser *pasynUser, void *genericPointer)
 void processTask(void *drvPvt)
 {
     NDPluginDriver *pPvt = (NDPluginDriver *)drvPvt;
-    
-    epicsThreadSleep(0.1);
-printf("processTask: entry pPvt=%p, slept for 0.1 seconds, calling NDPluginDriver::processTask\n", pPvt);
+    int ntries=0;
+
+    while(pPvt->msgQId == 0) {
+        epicsThreadSleep(0.01);
+        ntries++;
+    }
+printf("processTask, ntries=%d\n", ntries);
     pPvt->processTask();
 }
 

--- a/ADApp/pluginSrc/NDPluginDriver.cpp
+++ b/ADApp/pluginSrc/NDPluginDriver.cpp
@@ -156,7 +156,7 @@ void processTask(void *drvPvt)
     NDPluginDriver *pPvt = (NDPluginDriver *)drvPvt;
     int ntries=0;
 
-rintf("processTask, entry\n");
+printf("processTask, entry\n");
     while(pPvt->msgQId == 0) {
         epicsThreadSleep(0.01);
         ntries++;

--- a/ADApp/pluginSrc/NDPluginDriver.h
+++ b/ADApp/pluginSrc/NDPluginDriver.h
@@ -36,11 +36,11 @@ public:
     /* These are the methods that are new to this class */
     virtual void driverCallback(asynUser *pasynUser, void *genericPointer);
     virtual void processTask(void);
-    epicsMessageQueueId msgQId;
+    virtual asynStatus run(void);
 
 protected:
     virtual void processCallbacks(NDArray *pArray);
-    virtual asynStatus connectToArrayPort(void);    
+    virtual asynStatus connectToArrayPort(void);
 
 protected:
     int NDPluginDriverArrayPort;
@@ -66,6 +66,7 @@ private:
     void *asynGenericPointerPvt;                /**< Handle for connecting to NDArray driver */
     asynGenericPointer *pasynGenericPointer;    /**< asyn interface for connecting to NDArray driver */
     bool connectedToArrayPort;
+    epicsMessageQueueId msgQId;
     epicsTimeStamp lastProcessTime;
     int dimsPrev[ND_ARRAY_MAX_DIMS];
 };

--- a/ADApp/pluginSrc/NDPluginDriver.h
+++ b/ADApp/pluginSrc/NDPluginDriver.h
@@ -36,6 +36,7 @@ public:
     /* These are the methods that are new to this class */
     virtual void driverCallback(asynUser *pasynUser, void *genericPointer);
     virtual void processTask(void);
+    epicsMessageQueueId msgQId;
 
 protected:
     virtual void processCallbacks(NDArray *pArray);
@@ -65,7 +66,6 @@ private:
     void *asynGenericPointerPvt;                /**< Handle for connecting to NDArray driver */
     asynGenericPointer *pasynGenericPointer;    /**< asyn interface for connecting to NDArray driver */
     bool connectedToArrayPort;
-    epicsMessageQueueId msgQId;
     epicsTimeStamp lastProcessTime;
     int dimsPrev[ND_ARRAY_MAX_DIMS];
 };

--- a/ADApp/pluginSrc/NDPluginDriver.h
+++ b/ADApp/pluginSrc/NDPluginDriver.h
@@ -3,6 +3,8 @@
 
 #include <epicsTypes.h>
 #include <epicsMessageQueue.h>
+#include <epicsThread.h>
+#include <epicsEvent.h>
 #include <epicsTime.h>
 
 #include "asynNDArrayDriver.h"
@@ -25,6 +27,7 @@ public:
                    const char *NDArrayPort, int NDArrayAddr, int maxAddr, int numParams,
                    int maxBuffers, size_t maxMemory, int interfaceMask, int interruptMask,
                    int asynFlags, int autoConnect, int priority, int stackSize);
+    ~NDPluginDriver();
                  
     /* These are the methods that we override from asynNDArrayDriver */
     virtual asynStatus writeInt32(asynUser *pasynUser, epicsInt32 value);
@@ -67,6 +70,8 @@ private:
     asynGenericPointer *pasynGenericPointer;    /**< asyn interface for connecting to NDArray driver */
     bool connectedToArrayPort;
     epicsMessageQueueId msgQId;
+    epicsThreadId threadId;
+    epicsEvent *pThreadStartedEvent;
     epicsTimeStamp lastProcessTime;
     int dimsPrev[ND_ARRAY_MAX_DIMS];
 };

--- a/ADApp/pluginSrc/NDPluginFFT.cpp
+++ b/ADApp/pluginSrc/NDPluginFFT.cpp
@@ -344,9 +344,9 @@ extern "C" int NDFFTConfigure(const char *portName, int queueSize, int blockingC
                                      int maxBuffers, size_t maxMemory,
                                      int priority, int stackSize)
 {
-    new NDPluginFFT(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr, 
-                    maxBuffers, maxMemory, priority, stackSize);
-    return(asynSuccess);
+    NDPluginFFT *pPlugin = new NDPluginFFT(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr, 
+                                           maxBuffers, maxMemory, priority, stackSize);
+    return pPlugin->run();
 }
 
 /* EPICS iocsh shell commands */

--- a/ADApp/pluginSrc/NDPluginOverlay.cpp
+++ b/ADApp/pluginSrc/NDPluginOverlay.cpp
@@ -399,9 +399,9 @@ extern "C" int NDOverlayConfigure(const char *portName, int queueSize, int block
                                  int maxBuffers, size_t maxMemory,
                                  int priority, int stackSize)
 {
-    new NDPluginOverlay(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr, maxOverlays,
-                        maxBuffers, maxMemory, priority, stackSize);
-    return(asynSuccess);
+    NDPluginOverlay *pPlugin = new NDPluginOverlay(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr, maxOverlays,
+                                                   maxBuffers, maxMemory, priority, stackSize);
+    return pPlugin->run();
 }
 
 /* EPICS iocsh shell commands */

--- a/ADApp/pluginSrc/NDPluginProcess.cpp
+++ b/ADApp/pluginSrc/NDPluginProcess.cpp
@@ -446,9 +446,9 @@ extern "C" int NDProcessConfigure(const char *portName, int queueSize, int block
                                  int maxBuffers, size_t maxMemory,
                                  int priority, int stackSize)
 {
-    new NDPluginProcess(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
-                        maxBuffers, maxMemory, priority, stackSize);
-    return(asynSuccess);
+    NDPluginProcess *pPlugin = new NDPluginProcess(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
+                                                   maxBuffers, maxMemory, priority, stackSize);
+    return pPlugin->run();
 }
 
 /* EPICS iocsh shell commands */

--- a/ADApp/pluginSrc/NDPluginROI.cpp
+++ b/ADApp/pluginSrc/NDPluginROI.cpp
@@ -359,9 +359,9 @@ extern "C" int NDROIConfigure(const char *portName, int queueSize, int blockingC
                                  int maxBuffers, size_t maxMemory,
                                  int priority, int stackSize)
 {
-    new NDPluginROI(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
-                    maxBuffers, maxMemory, priority, stackSize);
-    return(asynSuccess);
+    NDPluginROI *pPlugin = new NDPluginROI(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
+                                           maxBuffers, maxMemory, priority, stackSize);
+    return pPlugin->run();
 }
 
 /* EPICS iocsh shell commands */

--- a/ADApp/pluginSrc/NDPluginROIStat.cpp
+++ b/ADApp/pluginSrc/NDPluginROIStat.cpp
@@ -581,14 +581,9 @@ extern "C" int NDROIStatConfigure(const char *portName, int queueSize, int block
                                  int maxBuffers, size_t maxMemory,
                                  int priority, int stackSize)
 {
-    NDPluginROIStat *pPlugin =
-        new NDPluginROIStat(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr, maxROIs,
-                        maxBuffers, maxMemory, priority, stackSize);
-    //To take care of compiler warnings
-    if (pPlugin) {
-      pPlugin = NULL;  
-    }
-    return(asynSuccess);
+    NDPluginROIStat *pPlugin = new NDPluginROIStat(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr, maxROIs,
+                                                   maxBuffers, maxMemory, priority, stackSize);
+    return pPlugin->run();
 }
 
 /* EPICS iocsh shell commands */

--- a/ADApp/pluginSrc/NDPluginStats.cpp
+++ b/ADApp/pluginSrc/NDPluginStats.cpp
@@ -841,9 +841,9 @@ extern "C" int NDStatsConfigure(const char *portName, int queueSize, int blockin
                                  int maxBuffers, size_t maxMemory,
                                  int priority, int stackSize)
 {
-    new NDPluginStats(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
-                      maxBuffers, maxMemory, priority, stackSize);
-    return(asynSuccess);
+    NDPluginStats *pPlugin = new NDPluginStats(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
+                                              maxBuffers, maxMemory, priority, stackSize);
+    return pPlugin->run();
 }
 
 /* EPICS iocsh shell commands */

--- a/ADApp/pluginSrc/NDPluginStdArrays.cpp
+++ b/ADApp/pluginSrc/NDPluginStdArrays.cpp
@@ -300,9 +300,9 @@ extern "C" int NDStdArraysConfigure(const char *portName, int queueSize, int blo
                                     const char *NDArrayPort, int NDArrayAddr, size_t maxMemory,
                                     int priority, int stackSize)
 {
-    new NDPluginStdArrays(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr, maxMemory,
-                          priority, stackSize);
-    return(asynSuccess);
+    NDPluginStdArrays *pPlugin = new NDPluginStdArrays(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr, maxMemory,
+                                                       priority, stackSize);
+    return pPlugin->run();
 }
 
 

--- a/ADApp/pluginSrc/NDPluginTimeSeries.cpp
+++ b/ADApp/pluginSrc/NDPluginTimeSeries.cpp
@@ -534,9 +534,9 @@ extern "C" int NDTimeSeriesConfigure(const char *portName, int queueSize, int bl
                                      int maxBuffers, size_t maxMemory,
                                      int priority, int stackSize)
 {
-    new NDPluginTimeSeries(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr, 
-                           maxSignals, maxBuffers, maxMemory, priority, stackSize);
-    return(asynSuccess);
+    NDPluginTimeSeries *pPlugin = new NDPluginTimeSeries(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr, 
+                                                         maxSignals, maxBuffers, maxMemory, priority, stackSize);
+    return pPlugin->run();
 }
 
 /* EPICS iocsh shell commands */

--- a/ADApp/pluginSrc/NDPluginTransform.cpp
+++ b/ADApp/pluginSrc/NDPluginTransform.cpp
@@ -624,9 +624,9 @@ extern "C" int NDTransformConfigure(const char *portName, int queueSize, int blo
                                     int maxBuffers, size_t maxMemory,
                                     int priority, int stackSize)
 {
-  new NDPluginTransform(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
-              maxBuffers, maxMemory, priority, stackSize);
-  return(asynSuccess);
+  NDPluginTransform *pPlugin = new NDPluginTransform(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
+                                                      maxBuffers, maxMemory, priority, stackSize);
+  return pPlugin->run();
 }
 
 /* EPICS iocsh shell commands */

--- a/ADApp/pluginTests/test_NDFileHDF5.cpp
+++ b/ADApp/pluginTests/test_NDFileHDF5.cpp
@@ -54,6 +54,7 @@ struct NDFileHDF5TestFixture
 
 
     // Enable the plugin
+    hdf5->run(); // start the plugin thread although not required for this unittesting
     hdf5->write(NDPluginDriverEnableCallbacksString, 1);
     hdf5->write(NDPluginDriverBlockingCallbacksString, 1);
 

--- a/ADApp/pluginTests/test_NDPluginCircularBuff.cpp
+++ b/ADApp/pluginTests/test_NDPluginCircularBuff.cpp
@@ -53,6 +53,7 @@ struct PluginFixture
 
         // This is the plugin under test
         cb = new NDPluginCircularBuff(testport.c_str(), 50, 0, dummy_port.c_str(), 0, 1000, -1, 0, 2000000);
+        cb->run(); // start the plugin thread although not required for this unittesting
 
         // This is the mock downstream plugin
         ds = new TestingPlugin(testport.c_str(), 0);

--- a/ADApp/pluginTests/test_NDPluginTimeSeries.cpp
+++ b/ADApp/pluginTests/test_NDPluginTimeSeries.cpp
@@ -87,6 +87,7 @@ struct TimeSeriesPluginTestFixture
     downstream_plugin = new TestingPlugin(testport.c_str(), 0);
 
     // Enable the plugin
+    ts->run(); // start the plugin thread although not required for this unittesting
     ts->write(NDPluginDriverEnableCallbacksString, 1);
     ts->write(NDPluginDriverBlockingCallbacksString, 1);
 


### PR DESCRIPTION
This seems like the correct solution.  Even if we don't fully understand why it is crashing on some systems and not on others, the fact is that the processTask thread should not be accessing the plugin object until we can be sure that all constructors have finished.  One easy way to do that is to create the thread after the final derived class is instantiated.  Changes still need to be make to ADPluginEdge (a plugin not in ADCore) and simDetectorNoIOC which instantiates objects outside the context of an IOC.