### PR TITLE
Allow 1-D images, i.e. if ny=0 set ny=1

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -95,6 +95,10 @@ R2-5 (March XXX, 2016)
 * Deleted commonPlugins.cmd and commonPlugin_settings.req.  These were accidentally restored before the R2-4
   release after renaming them to EXAMPLE_commonPlugins.cmd and EXAMPLE_commonPlugin_settings.req.
 
+### ImageJ EPICS_ADViewer
+* Changed to work with 1-D arrays, i.e. nx>0, ny=0, nz=0.  Previously it did not work if ny=0.  This
+  is a useful enhancement because the ImageJ Dynamic Profiler can then be used to plot the 1-D array.
+
 
 R2-4 (September 21, 2015)
 ========================

--- a/Viewers/ImageJ/EPICS_areaDetector/EPICS_AD_Viewer.java
+++ b/Viewers/ImageJ/EPICS_areaDetector/EPICS_AD_Viewer.java
@@ -347,7 +347,8 @@ public class EPICS_AD_Viewer implements PlugIn
             int cm = epicsGetInt(ch_colorMode);
             DBRType dt = ch_image.getFieldType();
 
-            if (nz == 0) nz = 1;
+            if (nz == 0) nz = 1;  // 2-D images without color
+            if (ny == 0) ny = 1;  // 1-D images which are OK, useful with dynamic profiler
             int getsize = nx * ny * nz;
             if (getsize == 0) return;  // Not valid dimensions
 


### PR DESCRIPTION
This is a minor fix that allows the ImageJ plugin to work with 1-D arrays (ny=0).  This is useful because the ImageJ Dynamic Profiler can then be used to plot the 1-D array.