### PR TITLE
Destructor race condition issue

### DIFF
--- a/ADApp/pluginSrc/NDFileHDF5.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5.cpp
@@ -2738,9 +2738,9 @@ extern "C" int NDFileHDF5Configure(const char *portName, int queueSize, int bloc
 {
   // Stack Size must be a minimum of 2MB
   if (stackSize < 2097152) stackSize = 2097152;
-  new NDFileHDF5(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
-                 priority, stackSize);
-  return(asynSuccess);
+  NDFileHDF5 *pPlugin = new NDFileHDF5(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
+                                       priority, stackSize);
+  return pPlugin->start();
 }
 
 void NDFileHDF5::checkForOpenFile()

--- a/ADApp/pluginSrc/NDFileJPEG.cpp
+++ b/ADApp/pluginSrc/NDFileJPEG.cpp
@@ -337,9 +337,9 @@ extern "C" int NDFileJPEGConfigure(const char *portName, int queueSize, int bloc
                                    const char *NDArrayPort, int NDArrayAddr,
                                    int priority, int stackSize)
 {
-    new NDFileJPEG(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
-                   priority, stackSize);
-    return(asynSuccess);
+    NDFileJPEG *pPlugin = new NDFileJPEG(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
+                                         priority, stackSize);
+    return pPlugin->start();
 }
 
 

--- a/ADApp/pluginSrc/NDFileMagick.cpp
+++ b/ADApp/pluginSrc/NDFileMagick.cpp
@@ -220,9 +220,9 @@ extern "C" int NDFileMagickConfigure(const char *portName, int queueSize, int bl
                                    const char *NDArrayPort, int NDArrayAddr,
                                    int priority, int stackSize)
 {
-    new NDFileMagick(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
-                     priority, stackSize);
-    return(asynSuccess);
+    NDFileMagick *pPlugin = new NDFileMagick(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
+                                             priority, stackSize);
+    return pPlugin->start();
 }
 
 

--- a/ADApp/pluginSrc/NDFileMagickStub.cpp
+++ b/ADApp/pluginSrc/NDFileMagickStub.cpp
@@ -113,9 +113,9 @@ extern "C" int NDFileMagickConfigure(const char *portName, int queueSize, int bl
                                    const char *NDArrayPort, int NDArrayAddr,
                                    int priority, int stackSize)
 {
-    new NDFileMagick(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
-                     priority, stackSize);
-    return(asynSuccess);
+    NDFileMagick *pPlugin = new NDFileMagick(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
+                                             priority, stackSize);
+    return pPlugin->start();
 }
 
 

--- a/ADApp/pluginSrc/NDFileNetCDF.cpp
+++ b/ADApp/pluginSrc/NDFileNetCDF.cpp
@@ -520,9 +520,9 @@ extern "C" int NDFileNetCDFConfigure(const char *portName, int queueSize, int bl
                                      const char *NDArrayPort, int NDArrayAddr,
                                      int priority, int stackSize)
 {
-    new NDFileNetCDF(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
-                     priority, stackSize);
-    return(asynSuccess);
+    NDFileNetCDF *pPlugin = new NDFileNetCDF(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
+                                             priority, stackSize);
+    return pPlugin->start();
 }
 
 

--- a/ADApp/pluginSrc/NDFileNexus.cpp
+++ b/ADApp/pluginSrc/NDFileNexus.cpp
@@ -864,9 +864,9 @@ extern "C" int NDFileNexusConfigure(const char *portName, int queueSize, int blo
                                     const char *NDArrayPort, int NDArrayAddr,
                                     int priority, int stackSize)
 {
-  new NDFileNexus(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
-                  priority, stackSize);
-  return(asynSuccess);
+  NDFileNexus *pPlugin = new NDFileNexus(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
+                                         priority, stackSize);
+  return pPlugin->start();
 }
 
 

--- a/ADApp/pluginSrc/NDFileNull.cpp
+++ b/ADApp/pluginSrc/NDFileNull.cpp
@@ -93,9 +93,9 @@ extern "C" int NDFileNullConfigure(const char *portName, int queueSize, int bloc
                                    const char *NDArrayPort, int NDArrayAddr,
                                    int priority, int stackSize)
 {
-    new NDFileNull(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
-                   priority, stackSize);
-    return(asynSuccess);
+    NDFileNull *pPlugin = new NDFileNull(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
+                                         priority, stackSize);
+    return pPlugin->start();
 }
 
 

--- a/ADApp/pluginSrc/NDFileTIFF.cpp
+++ b/ADApp/pluginSrc/NDFileTIFF.cpp
@@ -477,9 +477,9 @@ extern "C" int NDFileTIFFConfigure(const char *portName, int queueSize, int bloc
                                    const char *NDArrayPort, int NDArrayAddr,
                                    int priority, int stackSize)
 {
-    new NDFileTIFF(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
-                   priority, stackSize);
-    return(asynSuccess);
+    NDFileTIFF *pPlugin = new NDFileTIFF(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
+                                         priority, stackSize);
+    return pPlugin->start();
 }
 
 

--- a/ADApp/pluginSrc/NDPluginAttribute.cpp
+++ b/ADApp/pluginSrc/NDPluginAttribute.cpp
@@ -287,9 +287,9 @@ extern "C" int NDAttrConfigure(const char *portName, int queueSize, int blocking
                                int maxAttributes, int maxBuffers, size_t maxMemory,
                                int priority, int stackSize)
 {
-    new NDPluginAttribute(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
-                          maxAttributes, maxBuffers, maxMemory, priority, stackSize);
-    return(asynSuccess);
+    NDPluginAttribute *pPlugin = new NDPluginAttribute(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
+                                                       maxAttributes, maxBuffers, maxMemory, priority, stackSize);
+    return pPlugin->start();
 }
 
 /* EPICS iocsh shell commands */

--- a/ADApp/pluginSrc/NDPluginCircularBuff.cpp
+++ b/ADApp/pluginSrc/NDPluginCircularBuff.cpp
@@ -449,9 +449,9 @@ extern "C" int NDCircularBuffConfigure(const char *portName, int queueSize, int 
                                 const char *NDArrayPort, int NDArrayAddr,
                                 int maxBuffers, size_t maxMemory)
 {
-    new NDPluginCircularBuff(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
-                      maxBuffers, maxMemory, 0, 2000000);
-    return(asynSuccess);
+    NDPluginCircularBuff *pPlugin = new NDPluginCircularBuff(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
+                                                             maxBuffers, maxMemory, 0, 2000000);
+    return pPlugin->start();
 }
 
 /* EPICS iocsh shell commands */

--- a/ADApp/pluginSrc/NDPluginColorConvert.cpp
+++ b/ADApp/pluginSrc/NDPluginColorConvert.cpp
@@ -631,9 +631,9 @@ extern "C" int NDColorConvertConfigure(const char *portName, int queueSize, int 
                                           int maxBuffers, size_t maxMemory,
                                           int priority, int stackSize)
 {
-    new NDPluginColorConvert(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr, 
-                             maxBuffers, maxMemory, priority, stackSize);
-    return(asynSuccess);
+    NDPluginColorConvert *pPlugin = new NDPluginColorConvert(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr, 
+                                                             maxBuffers, maxMemory, priority, stackSize);
+    return pPlugin->start();
 }
 
 /** EPICS iocsh shell commands */

--- a/ADApp/pluginSrc/NDPluginDriver.cpp
+++ b/ADApp/pluginSrc/NDPluginDriver.cpp
@@ -542,7 +542,7 @@ NDPluginDriver::~NDPluginDriver()
     NDArray *parr = new NDArray();
     parr->pData = NULL;
     epicsMessageQueueSendWithTimeout(this->msgQId, parr, sizeof(parr), 2.0);
-    delete this->pThread;
+    delete this->pThread; // The epicsThread destructor waits for the thread to return
     delete this->pThreadStartedEvent;
     delete parr;
   }

--- a/ADApp/pluginSrc/NDPluginDriver.h
+++ b/ADApp/pluginSrc/NDPluginDriver.h
@@ -3,6 +3,8 @@
 
 #include <epicsTypes.h>
 #include <epicsMessageQueue.h>
+#include <epicsThread.h>
+#include <epicsEvent.h>
 #include <epicsTime.h>
 
 #include "asynNDArrayDriver.h"
@@ -25,6 +27,7 @@ public:
                    const char *NDArrayPort, int NDArrayAddr, int maxAddr, int numParams,
                    int maxBuffers, size_t maxMemory, int interfaceMask, int interruptMask,
                    int asynFlags, int autoConnect, int priority, int stackSize);
+    ~NDPluginDriver();
                  
     /* These are the methods that we override from asynNDArrayDriver */
     virtual asynStatus writeInt32(asynUser *pasynUser, epicsInt32 value);
@@ -66,6 +69,8 @@ private:
     asynGenericPointer *pasynGenericPointer;    /**< asyn interface for connecting to NDArray driver */
     bool connectedToArrayPort;
     epicsMessageQueueId msgQId;
+    epicsThreadId threadId;
+    epicsEvent *pThreadStartedEvent;
     epicsTimeStamp lastProcessTime;
     int dimsPrev[ND_ARRAY_MAX_DIMS];
 };

--- a/ADApp/pluginSrc/NDPluginDriver.h
+++ b/ADApp/pluginSrc/NDPluginDriver.h
@@ -21,7 +21,7 @@
                                                                          *  to execute plugin code */
 
 /** Class from which actual plugin drivers are derived; derived from asynNDArrayDriver */
-class epicsShareClass NDPluginDriver : public asynNDArrayDriver {
+class epicsShareClass NDPluginDriver : public asynNDArrayDriver, public epicsThreadRunable {
 public:
     NDPluginDriver(const char *portName, int queueSize, int blockingCallbacks, 
                    const char *NDArrayPort, int NDArrayAddr, int maxAddr, int numParams,
@@ -39,6 +39,8 @@ public:
     /* These are the methods that are new to this class */
     virtual void driverCallback(asynUser *pasynUser, void *genericPointer);
     virtual void processTask(void);
+    virtual void run(void);
+    virtual asynStatus start(void);
 
 protected:
     virtual void processCallbacks(NDArray *pArray);
@@ -69,7 +71,7 @@ private:
     asynGenericPointer *pasynGenericPointer;    /**< asyn interface for connecting to NDArray driver */
     bool connectedToArrayPort;
     epicsMessageQueueId msgQId;
-    epicsThreadId threadId;
+    epicsThread * pThread;
     epicsEvent *pThreadStartedEvent;
     epicsTimeStamp lastProcessTime;
     int dimsPrev[ND_ARRAY_MAX_DIMS];

--- a/ADApp/pluginSrc/NDPluginFFT.cpp
+++ b/ADApp/pluginSrc/NDPluginFFT.cpp
@@ -344,9 +344,9 @@ extern "C" int NDFFTConfigure(const char *portName, int queueSize, int blockingC
                                      int maxBuffers, size_t maxMemory,
                                      int priority, int stackSize)
 {
-    new NDPluginFFT(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr, 
-                    maxBuffers, maxMemory, priority, stackSize);
-    return(asynSuccess);
+    NDPluginFFT *pPlugin = new NDPluginFFT(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr, 
+                                           maxBuffers, maxMemory, priority, stackSize);
+    return pPlugin->start();
 }
 
 /* EPICS iocsh shell commands */

--- a/ADApp/pluginSrc/NDPluginOverlay.cpp
+++ b/ADApp/pluginSrc/NDPluginOverlay.cpp
@@ -399,9 +399,9 @@ extern "C" int NDOverlayConfigure(const char *portName, int queueSize, int block
                                  int maxBuffers, size_t maxMemory,
                                  int priority, int stackSize)
 {
-    new NDPluginOverlay(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr, maxOverlays,
-                        maxBuffers, maxMemory, priority, stackSize);
-    return(asynSuccess);
+    NDPluginOverlay *pPlugin = new NDPluginOverlay(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr, maxOverlays,
+                                                   maxBuffers, maxMemory, priority, stackSize);
+    return pPlugin->start();
 }
 
 /* EPICS iocsh shell commands */

--- a/ADApp/pluginSrc/NDPluginProcess.cpp
+++ b/ADApp/pluginSrc/NDPluginProcess.cpp
@@ -446,9 +446,9 @@ extern "C" int NDProcessConfigure(const char *portName, int queueSize, int block
                                  int maxBuffers, size_t maxMemory,
                                  int priority, int stackSize)
 {
-    new NDPluginProcess(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
-                        maxBuffers, maxMemory, priority, stackSize);
-    return(asynSuccess);
+    NDPluginProcess *pPlugin = new NDPluginProcess(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
+                                                   maxBuffers, maxMemory, priority, stackSize);
+    return pPlugin->start();
 }
 
 /* EPICS iocsh shell commands */

--- a/ADApp/pluginSrc/NDPluginROI.cpp
+++ b/ADApp/pluginSrc/NDPluginROI.cpp
@@ -359,9 +359,9 @@ extern "C" int NDROIConfigure(const char *portName, int queueSize, int blockingC
                                  int maxBuffers, size_t maxMemory,
                                  int priority, int stackSize)
 {
-    new NDPluginROI(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
-                    maxBuffers, maxMemory, priority, stackSize);
-    return(asynSuccess);
+    NDPluginROI *pPlugin = new NDPluginROI(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
+                                           maxBuffers, maxMemory, priority, stackSize);
+    return pPlugin->start();
 }
 
 /* EPICS iocsh shell commands */

--- a/ADApp/pluginSrc/NDPluginROIStat.cpp
+++ b/ADApp/pluginSrc/NDPluginROIStat.cpp
@@ -581,14 +581,9 @@ extern "C" int NDROIStatConfigure(const char *portName, int queueSize, int block
                                  int maxBuffers, size_t maxMemory,
                                  int priority, int stackSize)
 {
-    NDPluginROIStat *pPlugin =
-        new NDPluginROIStat(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr, maxROIs,
-                        maxBuffers, maxMemory, priority, stackSize);
-    //To take care of compiler warnings
-    if (pPlugin) {
-      pPlugin = NULL;  
-    }
-    return(asynSuccess);
+    NDPluginROIStat *pPlugin = new NDPluginROIStat(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr, maxROIs,
+                                                   maxBuffers, maxMemory, priority, stackSize);
+    return pPlugin->start();
 }
 
 /* EPICS iocsh shell commands */

--- a/ADApp/pluginSrc/NDPluginStats.cpp
+++ b/ADApp/pluginSrc/NDPluginStats.cpp
@@ -841,9 +841,9 @@ extern "C" int NDStatsConfigure(const char *portName, int queueSize, int blockin
                                  int maxBuffers, size_t maxMemory,
                                  int priority, int stackSize)
 {
-    new NDPluginStats(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
-                      maxBuffers, maxMemory, priority, stackSize);
-    return(asynSuccess);
+    NDPluginStats *pPlugin = new NDPluginStats(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
+                                              maxBuffers, maxMemory, priority, stackSize);
+    return pPlugin->start();
 }
 
 /* EPICS iocsh shell commands */

--- a/ADApp/pluginSrc/NDPluginStdArrays.cpp
+++ b/ADApp/pluginSrc/NDPluginStdArrays.cpp
@@ -300,9 +300,9 @@ extern "C" int NDStdArraysConfigure(const char *portName, int queueSize, int blo
                                     const char *NDArrayPort, int NDArrayAddr, size_t maxMemory,
                                     int priority, int stackSize)
 {
-    new NDPluginStdArrays(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr, maxMemory,
-                          priority, stackSize);
-    return(asynSuccess);
+    NDPluginStdArrays *pPlugin = new NDPluginStdArrays(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr, maxMemory,
+                                                       priority, stackSize);
+    return pPlugin->start();
 }
 
 

--- a/ADApp/pluginSrc/NDPluginTimeSeries.cpp
+++ b/ADApp/pluginSrc/NDPluginTimeSeries.cpp
@@ -534,9 +534,9 @@ extern "C" int NDTimeSeriesConfigure(const char *portName, int queueSize, int bl
                                      int maxBuffers, size_t maxMemory,
                                      int priority, int stackSize)
 {
-    new NDPluginTimeSeries(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr, 
-                           maxSignals, maxBuffers, maxMemory, priority, stackSize);
-    return(asynSuccess);
+    NDPluginTimeSeries *pPlugin = new NDPluginTimeSeries(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr, 
+                                                         maxSignals, maxBuffers, maxMemory, priority, stackSize);
+    return pPlugin->start();
 }
 
 /* EPICS iocsh shell commands */

--- a/ADApp/pluginSrc/NDPluginTransform.cpp
+++ b/ADApp/pluginSrc/NDPluginTransform.cpp
@@ -624,9 +624,9 @@ extern "C" int NDTransformConfigure(const char *portName, int queueSize, int blo
                                     int maxBuffers, size_t maxMemory,
                                     int priority, int stackSize)
 {
-  new NDPluginTransform(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
-              maxBuffers, maxMemory, priority, stackSize);
-  return(asynSuccess);
+  NDPluginTransform *pPlugin = new NDPluginTransform(portName, queueSize, blockingCallbacks, NDArrayPort, NDArrayAddr,
+                                                      maxBuffers, maxMemory, priority, stackSize);
+  return pPlugin->start();
 }
 
 /* EPICS iocsh shell commands */

--- a/ADApp/pluginTests/test_NDFileHDF5.cpp
+++ b/ADApp/pluginTests/test_NDFileHDF5.cpp
@@ -54,6 +54,7 @@ struct NDFileHDF5TestFixture
 
 
     // Enable the plugin
+    hdf5->start(); // start the plugin thread although not required for this unittesting
     hdf5->write(NDPluginDriverEnableCallbacksString, 1);
     hdf5->write(NDPluginDriverBlockingCallbacksString, 1);
 

--- a/ADApp/pluginTests/test_NDPluginCircularBuff.cpp
+++ b/ADApp/pluginTests/test_NDPluginCircularBuff.cpp
@@ -53,6 +53,7 @@ struct PluginFixture
 
         // This is the plugin under test
         cb = new NDPluginCircularBuff(testport.c_str(), 50, 0, dummy_port.c_str(), 0, 1000, -1, 0, 2000000);
+        cb->start(); // start the plugin thread although not required for this unittesting
 
         // This is the mock downstream plugin
         ds = new TestingPlugin(testport.c_str(), 0);

--- a/ADApp/pluginTests/test_NDPluginTimeSeries.cpp
+++ b/ADApp/pluginTests/test_NDPluginTimeSeries.cpp
@@ -87,6 +87,7 @@ struct TimeSeriesPluginTestFixture
     downstream_plugin = new TestingPlugin(testport.c_str(), 0);
 
     // Enable the plugin
+    ts->start(); // start the plugin thread although not required for this unittesting
     ts->write(NDPluginDriverEnableCallbacksString, 1);
     ts->write(NDPluginDriverBlockingCallbacksString, 1);
 


### PR DESCRIPTION
This fixes #157 which was originally an issue with a race condition between the NDPluginDriver constructor and a thread being started in the constructor. Eventually we also found that there was a similar issue with the destructor. The two are somewhat related and this PR include fixes for both.

- Adding a locking mechanism to the NDPluginDriver constructor and thread so that a thread does not start running until the object is fully initialized.
- Switching NDPluginDriver from using the epics thread C interface to the epicsThreadRunable C++ class. This class has a feature to wait for a thread to exit which is required in the object destructor.
- Added NDPluginDriver::start() method which starts up the thread - and wait for it to signal that it is running. This method must be called outside of the NDPluginDriver constructor.


Part of the code in this PR was developed on branch "plugin_fix_clean" and PR #161 which I will now close as deprecated.