### PR TITLE
Unittest made work on Darwin

### DIFF
--- a/ADApp/pluginTests/AsynPortClientContainer.cpp
+++ b/ADApp/pluginTests/AsynPortClientContainer.cpp
@@ -17,7 +17,7 @@ void AsynPortClientContainer::write(const std::string& paramName, int value)
 	// Check for the client
 	if (int32Clients.count(paramName) == 0){
 		// We need to create the client as it isn't stored
-		int32Clients[paramName] = std::tr1::shared_ptr<asynInt32Client>(new asynInt32Client(portName.c_str(), 0, paramName.c_str()));
+		int32Clients[paramName] = boost::shared_ptr<asynInt32Client>(new asynInt32Client(portName.c_str(), 0, paramName.c_str()));
 	}
 	if (int32Clients[paramName]->write(value) != asynSuccess){
 	  throw AsynException();
@@ -29,7 +29,7 @@ void AsynPortClientContainer::write(const std::string& paramName, double value)
 	// Check for the client
 	if (float64Clients.count(paramName) == 0){
 		// We need to create the client as it isn't stored
-		float64Clients[paramName] = std::tr1::shared_ptr<asynFloat64Client>(new asynFloat64Client(portName.c_str(), 0, paramName.c_str()));
+		float64Clients[paramName] = boost::shared_ptr<asynFloat64Client>(new asynFloat64Client(portName.c_str(), 0, paramName.c_str()));
 	}
 	if (float64Clients[paramName]->write(value) != asynSuccess){
 	  throw AsynException();
@@ -43,7 +43,7 @@ unsigned long int AsynPortClientContainer::write(const std::string& paramName, c
 	// Check for the client
 	if (octetClients.count(paramName) == 0){
 		// We need to create the client as it isn't stored
-		octetClients[paramName] = std::tr1::shared_ptr<asynOctetClient>(new asynOctetClient(portName.c_str(), 0, paramName.c_str()));
+		octetClients[paramName] = boost::shared_ptr<asynOctetClient>(new asynOctetClient(portName.c_str(), 0, paramName.c_str()));
 	}
 	length = value.size();
 	if (octetClients[paramName]->write(value.c_str(), length, &numWritten) != asynSuccess){
@@ -58,7 +58,7 @@ int AsynPortClientContainer::readInt(const std::string& paramName)
   // Check for the client
   if (int32Clients.count(paramName) == 0){
     // We need to create the client as it isn't stored
-    int32Clients[paramName] = std::tr1::shared_ptr<asynInt32Client>(new asynInt32Client(portName.c_str(), 0, paramName.c_str()));
+    int32Clients[paramName] = boost::shared_ptr<asynInt32Client>(new asynInt32Client(portName.c_str(), 0, paramName.c_str()));
   }
   if (int32Clients[paramName]->read(&value) != asynSuccess){
     throw AsynException();
@@ -72,7 +72,7 @@ double AsynPortClientContainer::readDouble(const std::string& paramName)
   // Check for the client
   if (float64Clients.count(paramName) == 0){
     // We need to create the client as it isn't stored
-    float64Clients[paramName] = std::tr1::shared_ptr<asynFloat64Client>(new asynFloat64Client(portName.c_str(), 0, paramName.c_str()));
+    float64Clients[paramName] = boost::shared_ptr<asynFloat64Client>(new asynFloat64Client(portName.c_str(), 0, paramName.c_str()));
   }
   if (float64Clients[paramName]->read(&value) != asynSuccess){
     throw AsynException();
@@ -89,7 +89,7 @@ std::string AsynPortClientContainer::readString(const std::string& paramName)
   // Check for the client
   if (octetClients.count(paramName) == 0){
     // We need to create the client as it isn't stored
-    octetClients[paramName] = std::tr1::shared_ptr<asynOctetClient>(new asynOctetClient(portName.c_str(), 0, paramName.c_str()));
+    octetClients[paramName] = boost::shared_ptr<asynOctetClient>(new asynOctetClient(portName.c_str(), 0, paramName.c_str()));
   }
   if (octetClients[paramName]->read(value, maxlen, &nRead, &reason) != asynSuccess){
     throw AsynException();

--- a/ADApp/pluginTests/AsynPortClientContainer.h
+++ b/ADApp/pluginTests/AsynPortClientContainer.h
@@ -8,7 +8,7 @@
 #ifndef IOCS_SIMDETECTORNOIOC_SIMDETECTORNOIOCAPP_SRC_AsynPortClientContainer_H_
 #define IOCS_SIMDETECTORNOIOC_SIMDETECTORNOIOCAPP_SRC_AsynPortClientContainer_H_
 
-#include <tr1/memory>
+#include <boost/shared_ptr.hpp>
 #include <map>
 
 #include <epicsThread.h>
@@ -34,9 +34,9 @@ protected:
 	std::string portName;
 
 private:
-	std::map<std::string, std::tr1::shared_ptr<asynInt32Client> > int32Clients;
-	std::map<std::string, std::tr1::shared_ptr<asynFloat64Client> > float64Clients;
-	std::map<std::string, std::tr1::shared_ptr<asynOctetClient> > octetClients;
+	std::map<std::string, boost::shared_ptr<asynInt32Client> > int32Clients;
+	std::map<std::string, boost::shared_ptr<asynFloat64Client> > float64Clients;
+	std::map<std::string, boost::shared_ptr<asynOctetClient> > octetClients;
 };
 
 #endif /* IOCS_SIMDETECTORNOIOC_SIMDETECTORNOIOCAPP_SRC_AsynPortClientContainer_H_ */

--- a/ADApp/pluginTests/HDF5FileReader.cpp
+++ b/ADApp/pluginTests/HDF5FileReader.cpp
@@ -26,7 +26,7 @@ HDF5FileReader::HDF5FileReader(const std::string& filename)
 
 void HDF5FileReader::report()
 {
-  std::map<std::string, std::tr1::shared_ptr<HDF5Object> >::iterator iter;
+  std::map<std::string, boost::shared_ptr<HDF5Object> >::iterator iter;
   for (iter = objects.begin(); iter != objects.end(); iter++){
     printf("[%s] %s\n", iter->second->getTypeString().c_str(), iter->first.c_str());
   }
@@ -37,7 +37,7 @@ void HDF5FileReader::processGroup(hid_t loc_id, const char *name, H5O_type_t typ
   std::string sname(name);
   std::string oldname = cname;
   cname = cname + "/" + sname;
-  objects[cname] = std::tr1::shared_ptr<HDF5Object>(new HDF5Object(name, type));
+  objects[cname] = boost::shared_ptr<HDF5Object>(new HDF5Object(name, type));
   if (type == H5O_TYPE_GROUP){
     hsize_t idx = 0;
     H5Literate_by_name(loc_id, name, H5_INDEX_NAME, H5_ITER_NATIVE, &idx, file_info, this, H5P_DEFAULT);

--- a/ADApp/pluginTests/HDF5FileReader.h
+++ b/ADApp/pluginTests/HDF5FileReader.h
@@ -9,7 +9,7 @@
 #define PLUGINTESTS_HDF5FileReader_H_
 
 #include <string>
-#include <tr1/memory>
+#include <boost/shared_ptr.hpp>
 #include <map>
 #include <vector>
 #include <hdf5.h>
@@ -78,7 +78,7 @@ private:
   };
 
   std::string cname;
-  std::map<std::string, std::tr1::shared_ptr<HDF5Object> > objects;
+  std::map<std::string, boost::shared_ptr<HDF5Object> > objects;
 
 };
 

--- a/ADApp/pluginTests/Makefile
+++ b/ADApp/pluginTests/Makefile
@@ -14,6 +14,7 @@ ifdef BOOST
   # data, asyn port names, record output NDArrays etc etc.
   # This utility library can be used by external modules that provides unittests.
   LIBRARY_IOC_Linux += ADTestUtility
+  LIBRARY_IOC_Darwin += ADTestUtility
   ADTestUtility_SRCS += testingutilities.cpp
   ADTestUtility_SRCS += AsynPortClientContainer.cpp
   ADTestUtility_SRCS += AsynException.cpp
@@ -22,6 +23,7 @@ ifdef BOOST
   ADTestUtility_SRCS += TimeSeriesPluginWrapper.cpp
 
   PROD_IOC_Linux += plugin-test
+  PROD_IOC_Darwin += plugin-test
   plugin-test_SRCS += plugin-test.cpp
   plugin-test_SRCS += test_NDPluginCircularBuff.cpp
   plugin-test_SRCS += test_NDFileHDF5.cpp

--- a/ADApp/pluginTests/test_NDFileHDF5.cpp
+++ b/ADApp/pluginTests/test_NDFileHDF5.cpp
@@ -13,7 +13,7 @@
 #include <stdint.h>
 
 #include <deque>
-#include <tr1/memory>
+#include <boost/shared_ptr.hpp>
 using namespace std;
 
 #include "testingutilities.h"
@@ -24,7 +24,7 @@ struct NDFileHDF5TestFixture
 {
   NDArrayPool *arrayPool;
   asynPortDriver* dummy_driver;
-  std::tr1::shared_ptr<HDF5PluginWrapper> hdf5;
+  boost::shared_ptr<HDF5PluginWrapper> hdf5;
 
   static int testCase;
 
@@ -44,7 +44,7 @@ struct NDFileHDF5TestFixture
     dummy_driver = new asynPortDriver(dummy_port.c_str(), 0, 1, asynGenericPointerMask, asynGenericPointerMask, 0, 0, 0, 2000000);
 
     // This is the plugin under test
-    hdf5 = std::tr1::shared_ptr<HDF5PluginWrapper>(new HDF5PluginWrapper(testport.c_str(),
+    hdf5 = boost::shared_ptr<HDF5PluginWrapper>(new HDF5PluginWrapper(testport.c_str(),
                                                                          50,
                                                                          1,
                                                                          dummy_port.c_str(),

--- a/ADApp/pluginTests/test_NDPluginTimeSeries.cpp
+++ b/ADApp/pluginTests/test_NDPluginTimeSeries.cpp
@@ -20,7 +20,7 @@
 #include <stdint.h>
 
 #include <deque>
-#include <tr1/memory>
+#include <boost/shared_ptr.hpp>
 #include <iostream>
 #include <fstream>
 using namespace std;
@@ -42,9 +42,9 @@ void TS_callback(void *userPvt, asynUser *pasynUser, void *pointer)
 struct TimeSeriesPluginTestFixture
 {
   NDArrayPool *arrayPool;
-  std::tr1::shared_ptr<asynPortDriver> driver;
-  std::tr1::shared_ptr<TimeSeriesPluginWrapper> ts;
-  std::tr1::shared_ptr<asynGenericPointerClient> client;
+  boost::shared_ptr<asynPortDriver> driver;
+  boost::shared_ptr<TimeSeriesPluginWrapper> ts;
+  boost::shared_ptr<asynGenericPointerClient> client;
   TestingPlugin* downstream_plugin; // TODO: we don't put this in a shared_ptr and purposefully leak memory because asyn ports cannot be deleted
   std::vector<NDArray*>arrays_1d;
   std::vector<size_t>dims_1d;
@@ -67,14 +67,14 @@ struct TimeSeriesPluginTestFixture
 
     // We need some upstream driver for our test plugin so that calls to connectArrayPort
     // don't fail, but we can then ignore it and send arrays by calling processCallbacks directly.
-    driver = std::tr1::shared_ptr<asynPortDriver>(new asynPortDriver(simport.c_str(),
+    driver = boost::shared_ptr<asynPortDriver>(new asynPortDriver(simport.c_str(),
                                                                      1, 1,
                                                                      asynGenericPointerMask,
                                                                      asynGenericPointerMask,
                                                                      0, 0, 0, 2000000));
 
     // This is the plugin under test
-    ts = std::tr1::shared_ptr<TimeSeriesPluginWrapper>(new TimeSeriesPluginWrapper(testport.c_str(),
+    ts = boost::shared_ptr<TimeSeriesPluginWrapper>(new TimeSeriesPluginWrapper(testport.c_str(),
                                                                       50,
                                                                       1,
                                                                       simport.c_str(),
@@ -90,7 +90,7 @@ struct TimeSeriesPluginTestFixture
     ts->write(NDPluginDriverEnableCallbacksString, 1);
     ts->write(NDPluginDriverBlockingCallbacksString, 1);
 
-    client = std::tr1::shared_ptr<asynGenericPointerClient>(new asynGenericPointerClient(testport.c_str(), 0, NDArrayDataString));
+    client = boost::shared_ptr<asynGenericPointerClient>(new asynGenericPointerClient(testport.c_str(), 0, NDArrayDataString));
     client->registerInterruptUser(&TS_callback);
 
     // 1D: 8 channels with a single scalar sample element in each one


### PR DESCRIPTION
Replaced use of tr1::shared_ptr with boost::shared_ptr within the unittest framework which is based on boost. The boost::shared_ptr should be a 1:1 replacement for the tr1::shared_ptr and does not require OS dependent ifdefs to work...