### PR TITLE
Time series fix

### DIFF
--- a/ADApp/pluginSrc/NDPluginTimeSeries.h
+++ b/ADApp/pluginSrc/NDPluginTimeSeries.h
@@ -79,6 +79,7 @@ private:
 
   int maxSignals_;
   int numSignals_;
+  int numSignalsIn_;
   NDDataType_t dataType_;
   int dataSize_;
   int numTimePoints_;


### PR DESCRIPTION
I was unable to reproduce a crash by changing the number of point in the time series plugin reported in #165.  However, I was able to crash it if the number of signals (first array dimension) in the driver callback was different from MaxSignals used in the array constructor.  This pull request fixes this problem.  I tested by changing the ADCSimDetector st.cmd to have MaxSignals be 1, 4, 8, 9.   The previous value was 8, which matches the size of the array from ADCSimDetector.  It now passes the tests, while previously it crashed.