### PR TITLE
Fix memory leak in NDArrayPool when changing queue szie

### DIFF
--- a/ADApp/pluginSrc/NDPluginDriver.cpp
+++ b/ADApp/pluginSrc/NDPluginDriver.cpp
@@ -166,6 +166,21 @@ void NDPluginDriver::processTask(void)
     this->lock();
     this->pThreadStartedEvent->signal();
     while (1) {
+        /* If the queue size has been changed in the writeInt32 method then create a new one */
+        if (newQueueSize_ > 0) {
+            /* Need to empty the queue and decrease reference count on arrays that were in the queue */
+            while (epicsMessageQueueTryReceive(this->msgQId, &pArray, sizeof(&pArray)) != -1) {
+                pArray->release();
+            }
+            epicsMessageQueueDestroy(this->msgQId);
+            this->msgQId = epicsMessageQueueCreate(newQueueSize_, sizeof(NDArray*));
+            if (!this->msgQId) {
+                asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, 
+                          "%s::%s epicsMessageQueueCreate failure\n", driverName, functionName);
+            }
+            newQueueSize_ = 0;
+        }
+
         /* Wait for an array to arrive from the queue. Release the lock while  waiting. */    
         this->unlock();
         epicsMessageQueueReceive(this->msgQId, &pArray, sizeof(&pArray));
@@ -176,16 +191,6 @@ void NDPluginDriver::processTask(void)
         /* Take the lock.  The function we are calling must release the lock
          * during time-consuming operations when it does not need it. */
         this->lock();
-        /* If the queue size has been changed in the writeInt32 method then create a new one */
-        if (newQueueSize_ > 0) {
-            if (this->msgQId) epicsMessageQueueDestroy(this->msgQId);
-            this->msgQId = epicsMessageQueueCreate(newQueueSize_, sizeof(NDArray*));
-            if (!this->msgQId) {
-                asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, 
-                          "%s::%s epicsMessageQueueCreate failure\n", driverName, functionName);
-            }
-            newQueueSize_ = 0;
-        }
         getIntegerParam(NDPluginDriverQueueSize, &queueSize);
         queueFree = queueSize - epicsMessageQueuePending(this->msgQId);
         setIntegerParam(NDPluginDriverQueueFree, queueFree);


### PR DESCRIPTION
When changing queue size empty old queue first and release each NDArray in the queue; fixes memory leak.

This is a test done under the following conditions:

- simDetector with 1024x1024 Float64 arrays, .001 second AcquireTime=0.001. AcquirePeriod=0.01 (100 frames/s).
- Only NDPluginProcess running.  Doing RecursiveAverage, cannot keep up at 100 frames/s.

This was after acquiring some images and then setting Acquire=0 to stop acquisition.

    epics> asynReport 10 SIM1
    ...
    NDArrayPool:  
    numBuffers=13, maxBuffers=0  
    memorySize=109051904, maxMemory=0  
    numFree=11  

There are 2 allocated NDArrays because the driver and plugin always keep the last one allocated.  This is normal.

This was after starting acquisition and changing NDPluginProcess queue size between 10 and 100 several times, and then stopping acquisition again.

    epics> asynReport 10 SIM1
    ...
    NDArrayPool:
    numBuffers=165, maxBuffers=0
    memorySize=1384120320, maxMemory=0
    numFree=11

numBuffers is now 165, but numFree is only 11.  152 frames have been allocated but not freed.  This is a problem, it is a memory leak because there were NDArrays in the queue when it was deleted, and NDArray->release() was not called for these arrays.

This is the result of doing the same test on the queue_size_fix branch:

    epics> asynReport 10 SIM1
    ...
    NDArrayPool:
    numBuffers=103, maxBuffers=0
    memorySize=864026624, maxMemory=0
    numFree=101

Now numFree is always numBuffers-2, which is correct.  The memory leak in the NDArrayPool is fixed.
