### PR TITLE
Allow writing NDAttributes of type NDAttrString as strings rather than char arrays

### DIFF
--- a/ADApp/Db/NDFileHDF5.template
+++ b/ADApp/Db/NDFileHDF5.template
@@ -257,6 +257,26 @@ record(bi, "$(P)$(R)StoreAttr_RBV")
     field(ONAM, "Yes")
 }
 
+record(bo, "$(P)$(R)StrAttrDataType")
+{
+    field(DTYP, "asynInt32")
+    field(OUT, "@asyn($(PORT),0)HDF5_stringAttributeDataType")
+    field(PINI, "YES")
+    field(ZNAM, "Char")
+    field(ONAM, "String")
+    info(autosaveFields, "VAL")
+}
+
+record(bi, "$(P)$(R)StrAttrDataType_RBV")
+{
+    field(DTYP, "asynInt32")
+    field(INP, "@asyn($(PORT),0)HDF5_stringAttributeDataType")
+    field(PINI, "NO")
+    field(SCAN, "I/O Intr")
+    field(ZNAM, "Char")
+    field(ONAM, "String")
+}
+
 record(bo, "$(P)$(R)StorePerform")
 {
     field(DTYP, "asynInt32")

--- a/ADApp/Db/NDFileHDF5_settings.req
+++ b/ADApp/Db/NDFileHDF5_settings.req
@@ -11,6 +11,7 @@ $(P)$(R)SZipNumPixels
 $(P)$(R)ZLevel
 $(P)$(R)StorePerform
 $(P)$(R)StoreAttr
+$(P)$(R)StrAttrDataType
 $(P)$(R)NumExtraDims
 $(P)$(R)ExtraDimSizeN
 $(P)$(R)ExtraDimSizeX

--- a/ADApp/op/adl/NDFileHDF5.adl
+++ b/ADApp/op/adl/NDFileHDF5.adl
@@ -1,6 +1,6 @@
 
 file {
-	name="/home/epics/devel/areaDetector/ADCore/ADApp/op/adl/NDFileHDF5.adl"
+	name="/home/epics/devel/areaDetector-2-5/ADCore/ADApp/op/adl/NDFileHDF5.adl"
 	version=030107
 }
 display {
@@ -132,37 +132,887 @@ composite {
 	"composite name"=""
 	"composite file"="NDPluginBase.adl"
 }
-composite {
+text {
+	object {
+		x=852
+		y=455
+		width=160
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Extra dimensions"
+	align="horiz. right"
+}
+"text update" {
+	object {
+		x=400
+		y=695
+		width=500
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)XMLErrorMsg_RBV"
+		clr=54
+		bclr=4
+	}
+	format="string"
+	limits {
+	}
+}
+rectangle {
 	object {
 		x=390
 		y=450
 		width=675
 		height=320
 	}
+	"basic attribute" {
+		clr=14
+		fill="outline"
+	}
+}
+composite {
+	object {
+		x=470
+		y=505
+		width=310
+		height=20
+	}
 	"composite name"=""
 	children {
 		text {
 			object {
-				x=852
-				y=455
+				x=470
+				y=505
 				width=160
 				height=20
 			}
 			"basic attribute" {
 				clr=14
 			}
-			textix="Extra dimensions"
+			textix="Data bits offset"
+			align="horiz. right"
+		}
+		"text entry" {
+			object {
+				x=635
+				y=505
+				width=60
+				height=20
+			}
+			control {
+				chan="$(P)$(R)DataBitsOffset"
+				clr=14
+				bclr=51
+			}
+			limits {
+			}
+		}
+		"text update" {
+			object {
+				x=700
+				y=506
+				width=80
+				height=18
+			}
+			monitor {
+				chan="$(P)$(R)DataBitsOffset_RBV"
+				clr=54
+				bclr=4
+			}
+			limits {
+			}
+		}
+	}
+}
+composite {
+	object {
+		x=500
+		y=530
+		width=280
+		height=20
+	}
+	"composite name"=""
+	children {
+		text {
+			object {
+				x=500
+				y=530
+				width=130
+				height=20
+			}
+			"basic attribute" {
+				clr=14
+			}
+			textix="SZip # pixels"
+			align="horiz. right"
+		}
+		"text entry" {
+			object {
+				x=635
+				y=530
+				width=60
+				height=20
+			}
+			control {
+				chan="$(P)$(R)SZipNumPixels"
+				clr=14
+				bclr=51
+			}
+			limits {
+			}
+		}
+		"text update" {
+			object {
+				x=700
+				y=531
+				width=80
+				height=18
+			}
+			monitor {
+				chan="$(P)$(R)SZipNumPixels_RBV"
+				clr=54
+				bclr=4
+			}
+			limits {
+			}
+		}
+	}
+}
+composite {
+	object {
+		x=530
+		y=555
+		width=250
+		height=20
+	}
+	"composite name"=""
+	children {
+		text {
+			object {
+				x=530
+				y=555
+				width=100
+				height=20
+			}
+			"basic attribute" {
+				clr=14
+			}
+			textix="Zlib level"
+			align="horiz. right"
+		}
+		"text entry" {
+			object {
+				x=635
+				y=555
+				width=60
+				height=20
+			}
+			control {
+				chan="$(P)$(R)ZLevel"
+				clr=14
+				bclr=51
+			}
+			limits {
+			}
+		}
+		"text update" {
+			object {
+				x=700
+				y=556
+				width=80
+				height=18
+			}
+			monitor {
+				chan="$(P)$(R)ZLevel_RBV"
+				clr=54
+				bclr=4
+			}
+			limits {
+			}
+		}
+	}
+}
+composite {
+	object {
+		x=460
+		y=580
+		width=320
+		height=20
+	}
+	"composite name"=""
+	children {
+		text {
+			object {
+				x=460
+				y=580
+				width=170
+				height=20
+			}
+			"basic attribute" {
+				clr=14
+			}
+			textix="Store performance"
+			align="horiz. right"
+		}
+		menu {
+			object {
+				x=635
+				y=580
+				width=60
+				height=20
+			}
+			control {
+				chan="$(P)$(R)StorePerform"
+				clr=14
+				bclr=51
+			}
+		}
+		"text update" {
+			object {
+				x=700
+				y=581
+				width=80
+				height=18
+			}
+			monitor {
+				chan="$(P)$(R)StorePerform_RBV"
+				clr=54
+				bclr=4
+			}
+			limits {
+			}
+		}
+	}
+}
+composite {
+	object {
+		x=470
+		y=605
+		width=310
+		height=20
+	}
+	"composite name"=""
+	children {
+		text {
+			object {
+				x=470
+				y=605
+				width=160
+				height=20
+			}
+			"basic attribute" {
+				clr=14
+			}
+			textix="Store attributes"
+			align="horiz. right"
+		}
+		menu {
+			object {
+				x=635
+				y=605
+				width=60
+				height=20
+			}
+			control {
+				chan="$(P)$(R)StoreAttr"
+				clr=14
+				bclr=51
+			}
+		}
+		"text update" {
+			object {
+				x=700
+				y=606
+				width=80
+				height=18
+			}
+			monitor {
+				chan="$(P)$(R)StoreAttr_RBV"
+				clr=54
+				bclr=4
+			}
+			limits {
+			}
+		}
+	}
+}
+composite {
+	object {
+		x=830
+		y=480
+		width=220
+		height=20
+	}
+	"composite name"=""
+	children {
+		"text entry" {
+			object {
+				x=905
+				y=480
+				width=60
+				height=20
+			}
+			control {
+				chan="$(P)$(R)NumExtraDims"
+				clr=14
+				bclr=51
+			}
+			limits {
+			}
+		}
+		text {
+			object {
+				x=830
+				y=480
+				width=70
+				height=20
+			}
+			"basic attribute" {
+				clr=14
+			}
+			textix="# (0-2)"
 			align="horiz. right"
 		}
 		"text update" {
 			object {
-				x=400
+				x=970
+				y=481
+				width=80
+				height=18
+			}
+			monitor {
+				chan="$(P)$(R)NumExtraDims_RBV"
+				clr=54
+				bclr=4
+			}
+			limits {
+			}
+		}
+	}
+}
+composite {
+	object {
+		x=520
+		y=455
+		width=260
+		height=20
+	}
+	"composite name"=""
+	children {
+		"text update" {
+			object {
+				x=700
+				y=456
+				width=80
+				height=18
+			}
+			monitor {
+				chan="$(P)$(R)Compression_RBV"
+				clr=54
+				bclr=4
+			}
+			limits {
+			}
+		}
+		text {
+			object {
+				x=520
+				y=455
+				width=110
+				height=20
+			}
+			"basic attribute" {
+				clr=14
+			}
+			textix="Compression"
+			align="horiz. right"
+		}
+		menu {
+			object {
+				x=635
+				y=455
+				width=60
+				height=20
+			}
+			control {
+				chan="$(P)$(R)Compression"
+				clr=14
+				bclr=51
+			}
+		}
+	}
+}
+composite {
+	object {
+		x=550
+		y=630
+		width=165
+		height=20
+	}
+	"composite name"=""
+	children {
+		"text update" {
+			object {
+				x=635
+				y=631
+				width=80
+				height=18
+			}
+			monitor {
+				chan="$(P)$(R)RunTime"
+				clr=54
+				bclr=4
+			}
+			limits {
+			}
+		}
+		text {
+			object {
+				x=550
+				y=630
+				width=80
+				height=20
+			}
+			"basic attribute" {
+				clr=14
+			}
+			textix="Run time"
+			align="horiz. right"
+		}
+	}
+}
+composite {
+	object {
+		x=540
+		y=655
+		width=175
+		height=20
+	}
+	"composite name"=""
+	children {
+		text {
+			object {
+				x=540
+				y=655
+				width=90
+				height=20
+			}
+			"basic attribute" {
+				clr=14
+			}
+			textix="I/O speed"
+			align="horiz. right"
+		}
+		"text update" {
+			object {
+				x=635
+				y=656
+				width=80
+				height=18
+			}
+			monitor {
+				chan="$(P)$(R)IOSpeed"
+				clr=54
+				bclr=4
+			}
+			limits {
+			}
+		}
+	}
+}
+composite {
+	object {
+		x=520
+		y=480
+		width=260
+		height=20
+	}
+	"composite name"=""
+	children {
+		text {
+			object {
+				x=520
+				y=480
+				width=110
+				height=20
+			}
+			"basic attribute" {
+				clr=14
+			}
+			textix="# data bits"
+			align="horiz. right"
+		}
+		"text entry" {
+			object {
+				x=635
+				y=480
+				width=60
+				height=20
+			}
+			control {
+				chan="$(P)$(R)NumDataBits"
+				clr=14
+				bclr=51
+			}
+			limits {
+			}
+		}
+		"text update" {
+			object {
+				x=700
+				y=481
+				width=80
+				height=18
+			}
+			monitor {
+				chan="$(P)$(R)NumDataBits_RBV"
+				clr=54
+				bclr=4
+			}
+			limits {
+			}
+		}
+	}
+}
+composite {
+	object {
+		x=840
+		y=505
+		width=210
+		height=20
+	}
+	"composite name"=""
+	children {
+		text {
+			object {
+				x=840
+				y=505
+				width=60
+				height=20
+			}
+			"basic attribute" {
+				clr=14
+			}
+			textix="Size N"
+			align="horiz. right"
+		}
+		"text entry" {
+			object {
+				x=905
+				y=505
+				width=60
+				height=20
+			}
+			control {
+				chan="$(P)$(R)ExtraDimSizeN"
+				clr=14
+				bclr=51
+			}
+			limits {
+			}
+		}
+		"text update" {
+			object {
+				x=970
+				y=506
+				width=80
+				height=18
+			}
+			monitor {
+				chan="$(P)$(R)ExtraDimSizeN_RBV"
+				clr=54
+				bclr=4
+			}
+			limits {
+			}
+		}
+	}
+}
+composite {
+	object {
+		x=840
+		y=530
+		width=215
+		height=20
+	}
+	"composite name"=""
+	children {
+		text {
+			object {
+				x=840
+				y=530
+				width=60
+				height=20
+			}
+			"basic attribute" {
+				clr=14
+			}
+			textix="Name N"
+			align="horiz. right"
+		}
+		"text update" {
+			object {
+				x=905
+				y=531
+				width=150
+				height=18
+			}
+			monitor {
+				chan="$(P)$(R)ExtraDimNameN_RBV"
+				clr=54
+				bclr=4
+			}
+			limits {
+			}
+		}
+	}
+}
+composite {
+	object {
+		x=840
+		y=555
+		width=210
+		height=20
+	}
+	"composite name"=""
+	children {
+		text {
+			object {
+				x=840
+				y=555
+				width=60
+				height=20
+			}
+			"basic attribute" {
+				clr=14
+			}
+			textix="Size X"
+			align="horiz. right"
+		}
+		"text entry" {
+			object {
+				x=905
+				y=555
+				width=60
+				height=20
+			}
+			control {
+				chan="$(P)$(R)ExtraDimSizeX"
+				clr=14
+				bclr=51
+			}
+			limits {
+			}
+		}
+		"text update" {
+			object {
+				x=970
+				y=556
+				width=80
+				height=18
+			}
+			monitor {
+				chan="$(P)$(R)ExtraDimSizeX_RBV"
+				clr=54
+				bclr=4
+			}
+			limits {
+			}
+		}
+	}
+}
+composite {
+	object {
+		x=840
+		y=580
+		width=215
+		height=20
+	}
+	"composite name"=""
+	children {
+		text {
+			object {
+				x=840
+				y=580
+				width=60
+				height=20
+			}
+			"basic attribute" {
+				clr=14
+			}
+			textix="Name X"
+			align="horiz. right"
+		}
+		"text update" {
+			object {
+				x=905
+				y=581
+				width=150
+				height=18
+			}
+			monitor {
+				chan="$(P)$(R)ExtraDimNameX_RBV"
+				clr=54
+				bclr=4
+			}
+			limits {
+			}
+		}
+	}
+}
+composite {
+	object {
+		x=840
+		y=605
+		width=210
+		height=20
+	}
+	"composite name"=""
+	children {
+		text {
+			object {
+				x=840
+				y=605
+				width=60
+				height=20
+			}
+			"basic attribute" {
+				clr=14
+			}
+			textix="Size Y"
+			align="horiz. right"
+		}
+		"text entry" {
+			object {
+				x=905
+				y=605
+				width=60
+				height=20
+			}
+			control {
+				chan="$(P)$(R)ExtraDimSizeY"
+				clr=14
+				bclr=51
+			}
+			limits {
+			}
+		}
+		"text update" {
+			object {
+				x=970
+				y=606
+				width=80
+				height=18
+			}
+			monitor {
+				chan="$(P)$(R)ExtraDimSizeY_RBV"
+				clr=54
+				bclr=4
+			}
+			limits {
+			}
+		}
+	}
+}
+composite {
+	object {
+		x=840
+		y=630
+		width=215
+		height=20
+	}
+	"composite name"=""
+	children {
+		text {
+			object {
+				x=840
+				y=630
+				width=60
+				height=20
+			}
+			"basic attribute" {
+				clr=14
+			}
+			textix="Name Y"
+			align="horiz. right"
+		}
+		"text update" {
+			object {
+				x=905
+				y=631
+				width=150
+				height=18
+			}
+			monitor {
+				chan="$(P)$(R)ExtraDimNameY_RBV"
+				clr=54
+				bclr=4
+			}
+			limits {
+			}
+		}
+	}
+}
+composite {
+	object {
+		x=926
+		y=695
+		width=115
+		height=20
+	}
+	"composite name"=""
+	children {
+		"text update" {
+			object {
+				x=1001
 				y=695
+				width=40
+				height=20
+			}
+			monitor {
+				chan="$(P)$(R)XMLValid_RBV"
+				clr=14
+				bclr=2
+			}
+			clrmod="alarm"
+			limits {
+			}
+		}
+		text {
+			object {
+				x=926
+				y=695
+				width=70
+				height=20
+			}
+			"basic attribute" {
+				clr=14
+			}
+			textix="Exists:"
+		}
+	}
+}
+composite {
+	object {
+		x=400
+		y=720
+		width=635
+		height=43
+	}
+	"composite name"=""
+	children {
+		"text update" {
+			object {
+				x=535
+				y=720
 				width=500
 				height=18
 			}
 			monitor {
-				chan="$(P)$(R)XMLErrorMsg_RBV"
+				chan="$(P)$(R)XMLFileName_RBV"
 				clr=54
 				bclr=4
 			}
@@ -170,903 +1020,42 @@ composite {
 			limits {
 			}
 		}
-		rectangle {
-			object {
-				x=390
-				y=450
-				width=675
-				height=320
-			}
-			"basic attribute" {
-				clr=14
-				fill="outline"
-			}
-		}
 		composite {
 			object {
-				x=470
-				y=505
-				width=310
+				x=400
+				y=743
+				width=635
 				height=20
 			}
 			"composite name"=""
 			children {
 				text {
 					object {
-						x=470
-						y=505
-						width=160
-						height=20
-					}
-					"basic attribute" {
-						clr=14
-					}
-					textix="Data bits offset"
-					align="horiz. right"
-				}
-				"text entry" {
-					object {
-						x=635
-						y=505
-						width=60
-						height=20
-					}
-					control {
-						chan="$(P)$(R)DataBitsOffset"
-						clr=14
-						bclr=51
-					}
-					limits {
-					}
-				}
-				"text update" {
-					object {
-						x=700
-						y=506
-						width=80
-						height=18
-					}
-					monitor {
-						chan="$(P)$(R)DataBitsOffset_RBV"
-						clr=54
-						bclr=4
-					}
-					limits {
-					}
-				}
-			}
-		}
-		composite {
-			object {
-				x=500
-				y=530
-				width=280
-				height=20
-			}
-			"composite name"=""
-			children {
-				text {
-					object {
-						x=500
-						y=530
+						x=400
+						y=743
 						width=130
 						height=20
 					}
 					"basic attribute" {
 						clr=14
 					}
-					textix="SZip # pixels"
+					textix="XML File name"
 					align="horiz. right"
 				}
 				"text entry" {
-					object {
-						x=635
-						y=530
-						width=60
-						height=20
-					}
-					control {
-						chan="$(P)$(R)SZipNumPixels"
-						clr=14
-						bclr=51
-					}
-					limits {
-					}
-				}
-				"text update" {
-					object {
-						x=700
-						y=531
-						width=80
-						height=18
-					}
-					monitor {
-						chan="$(P)$(R)SZipNumPixels_RBV"
-						clr=54
-						bclr=4
-					}
-					limits {
-					}
-				}
-			}
-		}
-		composite {
-			object {
-				x=530
-				y=555
-				width=250
-				height=20
-			}
-			"composite name"=""
-			children {
-				text {
-					object {
-						x=530
-						y=555
-						width=100
-						height=20
-					}
-					"basic attribute" {
-						clr=14
-					}
-					textix="Zlib level"
-					align="horiz. right"
-				}
-				"text entry" {
-					object {
-						x=635
-						y=555
-						width=60
-						height=20
-					}
-					control {
-						chan="$(P)$(R)ZLevel"
-						clr=14
-						bclr=51
-					}
-					limits {
-					}
-				}
-				"text update" {
-					object {
-						x=700
-						y=556
-						width=80
-						height=18
-					}
-					monitor {
-						chan="$(P)$(R)ZLevel_RBV"
-						clr=54
-						bclr=4
-					}
-					limits {
-					}
-				}
-			}
-		}
-		composite {
-			object {
-				x=460
-				y=580
-				width=320
-				height=20
-			}
-			"composite name"=""
-			children {
-				text {
-					object {
-						x=460
-						y=580
-						width=170
-						height=20
-					}
-					"basic attribute" {
-						clr=14
-					}
-					textix="Store performance"
-					align="horiz. right"
-				}
-				menu {
-					object {
-						x=635
-						y=580
-						width=60
-						height=20
-					}
-					control {
-						chan="$(P)$(R)StorePerform"
-						clr=14
-						bclr=51
-					}
-				}
-				"text update" {
-					object {
-						x=700
-						y=581
-						width=80
-						height=18
-					}
-					monitor {
-						chan="$(P)$(R)StorePerform_RBV"
-						clr=54
-						bclr=4
-					}
-					limits {
-					}
-				}
-			}
-		}
-		composite {
-			object {
-				x=470
-				y=605
-				width=310
-				height=20
-			}
-			"composite name"=""
-			children {
-				text {
-					object {
-						x=470
-						y=605
-						width=160
-						height=20
-					}
-					"basic attribute" {
-						clr=14
-					}
-					textix="Store attributes"
-					align="horiz. right"
-				}
-				menu {
-					object {
-						x=635
-						y=605
-						width=60
-						height=20
-					}
-					control {
-						chan="$(P)$(R)StoreAttr"
-						clr=14
-						bclr=51
-					}
-				}
-				"text update" {
-					object {
-						x=700
-						y=606
-						width=80
-						height=18
-					}
-					monitor {
-						chan="$(P)$(R)StoreAttr_RBV"
-						clr=54
-						bclr=4
-					}
-					limits {
-					}
-				}
-			}
-		}
-		composite {
-			object {
-				x=830
-				y=480
-				width=220
-				height=20
-			}
-			"composite name"=""
-			children {
-				"text entry" {
-					object {
-						x=905
-						y=480
-						width=60
-						height=20
-					}
-					control {
-						chan="$(P)$(R)NumExtraDims"
-						clr=14
-						bclr=51
-					}
-					limits {
-					}
-				}
-				text {
-					object {
-						x=830
-						y=480
-						width=70
-						height=20
-					}
-					"basic attribute" {
-						clr=14
-					}
-					textix="# (0-2)"
-					align="horiz. right"
-				}
-				"text update" {
-					object {
-						x=970
-						y=481
-						width=80
-						height=18
-					}
-					monitor {
-						chan="$(P)$(R)NumExtraDims_RBV"
-						clr=54
-						bclr=4
-					}
-					limits {
-					}
-				}
-			}
-		}
-		composite {
-			object {
-				x=520
-				y=455
-				width=260
-				height=20
-			}
-			"composite name"=""
-			children {
-				"text update" {
-					object {
-						x=700
-						y=456
-						width=80
-						height=18
-					}
-					monitor {
-						chan="$(P)$(R)Compression_RBV"
-						clr=54
-						bclr=4
-					}
-					limits {
-					}
-				}
-				text {
-					object {
-						x=520
-						y=455
-						width=110
-						height=20
-					}
-					"basic attribute" {
-						clr=14
-					}
-					textix="Compression"
-					align="horiz. right"
-				}
-				menu {
-					object {
-						x=635
-						y=455
-						width=60
-						height=20
-					}
-					control {
-						chan="$(P)$(R)Compression"
-						clr=14
-						bclr=51
-					}
-				}
-			}
-		}
-		composite {
-			object {
-				x=550
-				y=630
-				width=165
-				height=20
-			}
-			"composite name"=""
-			children {
-				"text update" {
-					object {
-						x=635
-						y=631
-						width=80
-						height=18
-					}
-					monitor {
-						chan="$(P)$(R)RunTime"
-						clr=54
-						bclr=4
-					}
-					limits {
-					}
-				}
-				text {
-					object {
-						x=550
-						y=630
-						width=80
-						height=20
-					}
-					"basic attribute" {
-						clr=14
-					}
-					textix="Run time"
-					align="horiz. right"
-				}
-			}
-		}
-		composite {
-			object {
-				x=540
-				y=655
-				width=175
-				height=20
-			}
-			"composite name"=""
-			children {
-				text {
-					object {
-						x=540
-						y=655
-						width=90
-						height=20
-					}
-					"basic attribute" {
-						clr=14
-					}
-					textix="I/O speed"
-					align="horiz. right"
-				}
-				"text update" {
-					object {
-						x=635
-						y=656
-						width=80
-						height=18
-					}
-					monitor {
-						chan="$(P)$(R)IOSpeed"
-						clr=54
-						bclr=4
-					}
-					limits {
-					}
-				}
-			}
-		}
-		composite {
-			object {
-				x=520
-				y=480
-				width=260
-				height=20
-			}
-			"composite name"=""
-			children {
-				text {
-					object {
-						x=520
-						y=480
-						width=110
-						height=20
-					}
-					"basic attribute" {
-						clr=14
-					}
-					textix="# data bits"
-					align="horiz. right"
-				}
-				"text entry" {
-					object {
-						x=635
-						y=480
-						width=60
-						height=20
-					}
-					control {
-						chan="$(P)$(R)NumDataBits"
-						clr=14
-						bclr=51
-					}
-					limits {
-					}
-				}
-				"text update" {
-					object {
-						x=700
-						y=481
-						width=80
-						height=18
-					}
-					monitor {
-						chan="$(P)$(R)NumDataBits_RBV"
-						clr=54
-						bclr=4
-					}
-					limits {
-					}
-				}
-			}
-		}
-		composite {
-			object {
-				x=840
-				y=505
-				width=210
-				height=20
-			}
-			"composite name"=""
-			children {
-				text {
-					object {
-						x=840
-						y=505
-						width=60
-						height=20
-					}
-					"basic attribute" {
-						clr=14
-					}
-					textix="Size N"
-					align="horiz. right"
-				}
-				"text entry" {
-					object {
-						x=905
-						y=505
-						width=60
-						height=20
-					}
-					control {
-						chan="$(P)$(R)ExtraDimSizeN"
-						clr=14
-						bclr=51
-					}
-					limits {
-					}
-				}
-				"text update" {
-					object {
-						x=970
-						y=506
-						width=80
-						height=18
-					}
-					monitor {
-						chan="$(P)$(R)ExtraDimSizeN_RBV"
-						clr=54
-						bclr=4
-					}
-					limits {
-					}
-				}
-			}
-		}
-		composite {
-			object {
-				x=840
-				y=530
-				width=215
-				height=20
-			}
-			"composite name"=""
-			children {
-				text {
-					object {
-						x=840
-						y=530
-						width=60
-						height=20
-					}
-					"basic attribute" {
-						clr=14
-					}
-					textix="Name N"
-					align="horiz. right"
-				}
-				"text update" {
-					object {
-						x=905
-						y=531
-						width=150
-						height=18
-					}
-					monitor {
-						chan="$(P)$(R)ExtraDimNameN_RBV"
-						clr=54
-						bclr=4
-					}
-					limits {
-					}
-				}
-			}
-		}
-		composite {
-			object {
-				x=840
-				y=555
-				width=210
-				height=20
-			}
-			"composite name"=""
-			children {
-				text {
-					object {
-						x=840
-						y=555
-						width=60
-						height=20
-					}
-					"basic attribute" {
-						clr=14
-					}
-					textix="Size X"
-					align="horiz. right"
-				}
-				"text entry" {
-					object {
-						x=905
-						y=555
-						width=60
-						height=20
-					}
-					control {
-						chan="$(P)$(R)ExtraDimSizeX"
-						clr=14
-						bclr=51
-					}
-					limits {
-					}
-				}
-				"text update" {
-					object {
-						x=970
-						y=556
-						width=80
-						height=18
-					}
-					monitor {
-						chan="$(P)$(R)ExtraDimSizeX_RBV"
-						clr=54
-						bclr=4
-					}
-					limits {
-					}
-				}
-			}
-		}
-		composite {
-			object {
-				x=840
-				y=580
-				width=215
-				height=20
-			}
-			"composite name"=""
-			children {
-				text {
-					object {
-						x=840
-						y=580
-						width=60
-						height=20
-					}
-					"basic attribute" {
-						clr=14
-					}
-					textix="Name X"
-					align="horiz. right"
-				}
-				"text update" {
-					object {
-						x=905
-						y=581
-						width=150
-						height=18
-					}
-					monitor {
-						chan="$(P)$(R)ExtraDimNameX_RBV"
-						clr=54
-						bclr=4
-					}
-					limits {
-					}
-				}
-			}
-		}
-		composite {
-			object {
-				x=840
-				y=605
-				width=210
-				height=20
-			}
-			"composite name"=""
-			children {
-				text {
-					object {
-						x=840
-						y=605
-						width=60
-						height=20
-					}
-					"basic attribute" {
-						clr=14
-					}
-					textix="Size Y"
-					align="horiz. right"
-				}
-				"text entry" {
-					object {
-						x=905
-						y=605
-						width=60
-						height=20
-					}
-					control {
-						chan="$(P)$(R)ExtraDimSizeY"
-						clr=14
-						bclr=51
-					}
-					limits {
-					}
-				}
-				"text update" {
-					object {
-						x=970
-						y=606
-						width=80
-						height=18
-					}
-					monitor {
-						chan="$(P)$(R)ExtraDimSizeY_RBV"
-						clr=54
-						bclr=4
-					}
-					limits {
-					}
-				}
-			}
-		}
-		composite {
-			object {
-				x=840
-				y=630
-				width=215
-				height=20
-			}
-			"composite name"=""
-			children {
-				text {
-					object {
-						x=840
-						y=630
-						width=60
-						height=20
-					}
-					"basic attribute" {
-						clr=14
-					}
-					textix="Name Y"
-					align="horiz. right"
-				}
-				"text update" {
-					object {
-						x=905
-						y=631
-						width=150
-						height=18
-					}
-					monitor {
-						chan="$(P)$(R)ExtraDimNameY_RBV"
-						clr=54
-						bclr=4
-					}
-					limits {
-					}
-				}
-			}
-		}
-		composite {
-			object {
-				x=926
-				y=695
-				width=115
-				height=20
-			}
-			"composite name"=""
-			children {
-				"text update" {
-					object {
-						x=1001
-						y=695
-						width=40
-						height=20
-					}
-					monitor {
-						chan="$(P)$(R)XMLValid_RBV"
-						clr=14
-						bclr=2
-					}
-					clrmod="alarm"
-					limits {
-					}
-				}
-				text {
-					object {
-						x=926
-						y=695
-						width=70
-						height=20
-					}
-					"basic attribute" {
-						clr=14
-					}
-					textix="Exists:"
-				}
-			}
-		}
-		composite {
-			object {
-				x=400
-				y=720
-				width=635
-				height=43
-			}
-			"composite name"=""
-			children {
-				"text update" {
 					object {
 						x=535
-						y=720
+						y=743
 						width=500
-						height=18
+						height=20
 					}
-					monitor {
-						chan="$(P)$(R)XMLFileName_RBV"
-						clr=54
-						bclr=4
+					control {
+						chan="$(P)$(R)XMLFileName"
+						clr=14
+						bclr=51
 					}
 					format="string"
 					limits {
-					}
-				}
-				composite {
-					object {
-						x=400
-						y=743
-						width=635
-						height=20
-					}
-					"composite name"=""
-					children {
-						text {
-							object {
-								x=400
-								y=743
-								width=130
-								height=20
-							}
-							"basic attribute" {
-								clr=14
-							}
-							textix="XML File name"
-							align="horiz. right"
-						}
-						"text entry" {
-							object {
-								x=535
-								y=743
-								width=500
-								height=20
-							}
-							control {
-								chan="$(P)$(R)XMLFileName"
-								clr=14
-								bclr=51
-							}
-							format="string"
-							limits {
-							}
-						}
 					}
 				}
 			}
@@ -1083,350 +1072,369 @@ composite {
 	"composite name"=""
 	"composite file"="NDFileBase.adl"
 }
-composite {
+rectangle {
 	object {
 		x=5
 		y=575
 		width=380
-		height=160
+		height=185
+	}
+	"basic attribute" {
+		clr=14
+		fill="outline"
+	}
+}
+composite {
+	object {
+		x=105
+		y=580
+		width=270
+		height=20
 	}
 	"composite name"=""
 	children {
-		rectangle {
-			object {
-				x=5
-				y=575
-				width=380
-				height=160
-			}
-			"basic attribute" {
-				clr=14
-				fill="outline"
-			}
-		}
-		composite {
+		text {
 			object {
 				x=105
 				y=580
-				width=270
+				width=140
 				height=20
 			}
-			"composite name"=""
-			children {
-				text {
-					object {
-						x=105
-						y=580
-						width=140
-						height=20
-					}
-					"basic attribute" {
-						clr=14
-					}
-					textix="Rows per chunk"
-					align="horiz. right"
-				}
-				"text entry" {
-					object {
-						x=250
-						y=580
-						width=60
-						height=20
-					}
-					control {
-						chan="$(P)$(R)NumRowChunks"
-						clr=14
-						bclr=51
-					}
-					limits {
-					}
-				}
-				"text update" {
-					object {
-						x=315
-						y=581
-						width=60
-						height=18
-					}
-					monitor {
-						chan="$(P)$(R)NumRowChunks_RBV"
-						clr=54
-						bclr=4
-					}
-					limits {
-					}
-				}
+			"basic attribute" {
+				clr=14
+			}
+			textix="Rows per chunk"
+			align="horiz. right"
+		}
+		"text entry" {
+			object {
+				x=250
+				y=580
+				width=60
+				height=20
+			}
+			control {
+				chan="$(P)$(R)NumRowChunks"
+				clr=14
+				bclr=51
+			}
+			limits {
 			}
 		}
-		composite {
+		"text update" {
+			object {
+				x=315
+				y=581
+				width=60
+				height=18
+			}
+			monitor {
+				chan="$(P)$(R)NumRowChunks_RBV"
+				clr=54
+				bclr=4
+			}
+			limits {
+			}
+		}
+	}
+}
+composite {
+	object {
+		x=75
+		y=605
+		width=300
+		height=20
+	}
+	"composite name"=""
+	children {
+		text {
 			object {
 				x=75
 				y=605
-				width=300
+				width=170
 				height=20
 			}
-			"composite name"=""
-			children {
-				text {
-					object {
-						x=75
-						y=605
-						width=170
-						height=20
-					}
-					"basic attribute" {
-						clr=14
-					}
-					textix="Columns per chunk"
-					align="horiz. right"
-				}
-				"text entry" {
-					object {
-						x=250
-						y=605
-						width=60
-						height=20
-					}
-					control {
-						chan="$(P)$(R)NumColChunks"
-						clr=14
-						bclr=51
-					}
-					limits {
-					}
-				}
-				"text update" {
-					object {
-						x=315
-						y=606
-						width=60
-						height=18
-					}
-					monitor {
-						chan="$(P)$(R)NumColChunks_RBV"
-						clr=54
-						bclr=4
-					}
-					limits {
-					}
-				}
+			"basic attribute" {
+				clr=14
+			}
+			textix="Columns per chunk"
+			align="horiz. right"
+		}
+		"text entry" {
+			object {
+				x=250
+				y=605
+				width=60
+				height=20
+			}
+			control {
+				chan="$(P)$(R)NumColChunks"
+				clr=14
+				bclr=51
+			}
+			limits {
 			}
 		}
-		composite {
+		"text update" {
+			object {
+				x=315
+				y=606
+				width=60
+				height=18
+			}
+			monitor {
+				chan="$(P)$(R)NumColChunks_RBV"
+				clr=54
+				bclr=4
+			}
+			limits {
+			}
+		}
+	}
+}
+composite {
+	object {
+		x=15
+		y=630
+		width=360
+		height=20
+	}
+	"composite name"=""
+	children {
+		text {
 			object {
 				x=15
 				y=630
-				width=360
+				width=230
 				height=20
 			}
-			"composite name"=""
-			children {
-				text {
-					object {
-						x=15
-						y=630
-						width=230
-						height=20
-					}
-					"basic attribute" {
-						clr=14
-					}
-					textix="Frames cached per chunk"
-					align="horiz. right"
-				}
-				"text entry" {
-					object {
-						x=250
-						y=630
-						width=60
-						height=20
-					}
-					control {
-						chan="$(P)$(R)NumFramesChunks"
-						clr=14
-						bclr=51
-					}
-					limits {
-					}
-				}
-				"text update" {
-					object {
-						x=315
-						y=631
-						width=60
-						height=18
-					}
-					monitor {
-						chan="$(P)$(R)NumFramesChunks_RBV"
-						clr=54
-						bclr=4
-					}
-					limits {
-					}
-				}
+			"basic attribute" {
+				clr=14
+			}
+			textix="Frames cached per chunk"
+			align="horiz. right"
+		}
+		"text entry" {
+			object {
+				x=250
+				y=630
+				width=60
+				height=20
+			}
+			control {
+				chan="$(P)$(R)NumFramesChunks"
+				clr=14
+				bclr=51
+			}
+			limits {
 			}
 		}
-		composite {
+		"text update" {
+			object {
+				x=315
+				y=631
+				width=60
+				height=18
+			}
+			monitor {
+				chan="$(P)$(R)NumFramesChunks_RBV"
+				clr=54
+				bclr=4
+			}
+			limits {
+			}
+		}
+	}
+}
+composite {
+	object {
+		x=15
+		y=655
+		width=360
+		height=20
+	}
+	"composite name"=""
+	children {
+		text {
 			object {
 				x=15
 				y=655
-				width=360
+				width=230
 				height=20
 			}
-			"composite name"=""
-			children {
-				text {
-					object {
-						x=15
-						y=655
-						width=230
-						height=20
-					}
-					"basic attribute" {
-						clr=14
-					}
-					textix="Boundary alignment"
-					align="horiz. right"
-				}
-				"text entry" {
-					object {
-						x=250
-						y=655
-						width=60
-						height=20
-					}
-					control {
-						chan="$(P)$(R)BoundaryAlign"
-						clr=14
-						bclr=51
-					}
-					limits {
-					}
-				}
-				"text update" {
-					object {
-						x=315
-						y=656
-						width=60
-						height=18
-					}
-					monitor {
-						chan="$(P)$(R)BoundaryAlign_RBV"
-						clr=54
-						bclr=4
-					}
-					limits {
-					}
-				}
+			"basic attribute" {
+				clr=14
+			}
+			textix="Boundary alignment"
+			align="horiz. right"
+		}
+		"text entry" {
+			object {
+				x=250
+				y=655
+				width=60
+				height=20
+			}
+			control {
+				chan="$(P)$(R)BoundaryAlign"
+				clr=14
+				bclr=51
+			}
+			limits {
 			}
 		}
-		composite {
+		"text update" {
+			object {
+				x=315
+				y=656
+				width=60
+				height=18
+			}
+			monitor {
+				chan="$(P)$(R)BoundaryAlign_RBV"
+				clr=54
+				bclr=4
+			}
+			limits {
+			}
+		}
+	}
+}
+composite {
+	object {
+		x=15
+		y=680
+		width=360
+		height=20
+	}
+	"composite name"=""
+	children {
+		text {
 			object {
 				x=15
 				y=680
-				width=360
+				width=230
 				height=20
 			}
-			"composite name"=""
-			children {
-				text {
-					object {
-						x=15
-						y=680
-						width=230
-						height=20
-					}
-					"basic attribute" {
-						clr=14
-					}
-					textix="Boundary threshold"
-					align="horiz. right"
-				}
-				"text entry" {
-					object {
-						x=250
-						y=680
-						width=60
-						height=20
-					}
-					control {
-						chan="$(P)$(R)BoundaryThreshold"
-						clr=14
-						bclr=51
-					}
-					limits {
-					}
-				}
-				"text update" {
-					object {
-						x=315
-						y=681
-						width=60
-						height=18
-					}
-					monitor {
-						chan="$(P)$(R)BoundaryThreshold_RBV"
-						clr=54
-						bclr=4
-					}
-					limits {
-					}
-				}
+			"basic attribute" {
+				clr=14
 			}
+			textix="Boundary threshold"
+			align="horiz. right"
 		}
-		composite {
+		"text entry" {
 			object {
-				x=55
-				y=705
-				width=320
+				x=250
+				y=680
+				width=60
 				height=20
 			}
-			"composite name"=""
-			children {
-				text {
-					object {
-						x=55
-						y=705
-						width=190
-						height=20
-					}
-					"basic attribute" {
-						clr=14
-					}
-					textix="Flush on N'th frame"
-					align="horiz. right"
-				}
-				"text entry" {
-					object {
-						x=250
-						y=705
-						width=60
-						height=20
-					}
-					control {
-						chan="$(P)$(R)NumFramesFlush"
-						clr=14
-						bclr=51
-					}
-					limits {
-					}
-				}
-				"text update" {
-					object {
-						x=315
-						y=706
-						width=60
-						height=18
-					}
-					monitor {
-						chan="$(P)$(R)NumFramesFlush_RBV"
-						clr=54
-						bclr=4
-					}
-					limits {
-					}
-				}
+			control {
+				chan="$(P)$(R)BoundaryThreshold"
+				clr=14
+				bclr=51
+			}
+			limits {
 			}
 		}
+		"text update" {
+			object {
+				x=315
+				y=681
+				width=60
+				height=18
+			}
+			monitor {
+				chan="$(P)$(R)BoundaryThreshold_RBV"
+				clr=54
+				bclr=4
+			}
+			limits {
+			}
+		}
+	}
+}
+text {
+	object {
+		x=35
+		y=730
+		width=210
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="String attribute type"
+	align="horiz. right"
+}
+menu {
+	object {
+		x=250
+		y=730
+		width=60
+		height=20
+	}
+	control {
+		chan="$(P)$(R)StrAttrDataType"
+		clr=14
+		bclr=51
+	}
+}
+"text update" {
+	object {
+		x=315
+		y=731
+		width=60
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)StrAttrDataType_RBV"
+		clr=54
+		bclr=4
+	}
+	limits {
+	}
+}
+text {
+	object {
+		x=55
+		y=705
+		width=190
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Flush on N'th frame"
+	align="horiz. right"
+}
+"text entry" {
+	object {
+		x=250
+		y=705
+		width=60
+		height=20
+	}
+	control {
+		chan="$(P)$(R)NumFramesFlush"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+"text update" {
+	object {
+		x=315
+		y=706
+		width=60
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)NumFramesFlush_RBV"
+		clr=54
+		bclr=4
+	}
+	limits {
 	}
 }

--- a/ADApp/pluginSrc/NDFileHDF5.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5.cpp
@@ -26,6 +26,9 @@
 #include <epicsTime.h>
 #include <epicsString.h>
 #include <iocsh.h>
+#ifdef epicsAssertAuthor
+  #undef epicsAssertAuthor
+#endif
 #define epicsAssertAuthor "the EPICS areaDetector collaboration (https://github.com/areaDetector/ADCore/issues)"
 #include <epicsAssert.h>
 #include <osiSock.h>
@@ -2168,7 +2171,7 @@ asynStatus NDFileHDF5::createAttributeDataset()
       hdfAttrNode->hdfrank    = 1;
     } else {
       // String dataset required, use type N5T_NATIVE_CHAR
-      hdfAttrNode->hdfdatatype = H5T_NATIVE_CHAR;
+      hdfAttrNode->hdfdatatype = H5T_C_S1;
       hdfAttrNode->hdfdims[1] = MAX_ATTRIBUTE_STRING_SIZE;
       hdfAttrNode->chunk[0]   = chunking;
       hdfAttrNode->chunk[1]   = MAX_ATTRIBUTE_STRING_SIZE;

--- a/ADApp/pluginSrc/NDFileHDF5.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5.cpp
@@ -1769,6 +1769,7 @@ NDFileHDF5::NDFileHDF5(const char *portName, int queueSize, int blockingCallback
   this->createParam(str_NDFileHDF5_extraDimNameY,   asynParamOctet,   &NDFileHDF5_extraDimNameY);
   this->createParam(str_NDFileHDF5_extraDimOffsetY, asynParamInt32,   &NDFileHDF5_extraDimOffsetY);
   this->createParam(str_NDFileHDF5_storeAttributes, asynParamInt32,   &NDFileHDF5_storeAttributes);
+  this->createParam(str_NDFileHDF5_stringAttributeDataType, asynParamInt32, &NDFileHDF5_stringAttributeDataType);
   this->createParam(str_NDFileHDF5_storePerformance,asynParamInt32,   &NDFileHDF5_storePerformance);
   this->createParam(str_NDFileHDF5_totalRuntime,    asynParamFloat64, &NDFileHDF5_totalRuntime);
   this->createParam(str_NDFileHDF5_totalIoSpeed,    asynParamFloat64, &NDFileHDF5_totalIoSpeed);
@@ -1795,6 +1796,7 @@ NDFileHDF5::NDFileHDF5(const char *portName, int queueSize, int blockingCallback
   setIntegerParam(NDFileHDF5_extraDimSizeY,   1);
   setIntegerParam(NDFileHDF5_extraDimOffsetY, 0);
   setIntegerParam(NDFileHDF5_storeAttributes, 1);
+  setIntegerParam(NDFileHDF5_stringAttributeDataType, hdf5::nativeChar);
   setIntegerParam(NDFileHDF5_storePerformance,1);
   setDoubleParam (NDFileHDF5_totalRuntime,    0.0);
   setDoubleParam (NDFileHDF5_totalIoSpeed,    0.0);
@@ -1848,7 +1850,6 @@ NDFileHDF5::NDFileHDF5(const char *portName, int queueSize, int blockingCallback
   this->performanceBuf       = NULL;
   this->performancePtr       = NULL;
   this->numPerformancePoints = 0;
-
   this->hostname = (char*)calloc(MAXHOSTNAMELEN, sizeof(char));
   gethostname(this->hostname, MAXHOSTNAMELEN);
 }
@@ -2089,6 +2090,7 @@ asynStatus NDFileHDF5::createAttributeDataset()
   HDFAttributeNode *hdfAttrNode;
   NDAttribute *ndAttr = NULL;
   NDAttrSource_t ndAttrSourceType;
+  int stringAttributeDataType;
   int extraDims;
   int chunking = 0;
   int fileWriteMode = 0;
@@ -2102,6 +2104,7 @@ asynStatus NDFileHDF5::createAttributeDataset()
 
   this->lock();
   getIntegerParam(NDFileHDF5_nExtraDims, &extraDims);
+  getIntegerParam(NDFileHDF5_stringAttributeDataType, &stringAttributeDataType);
   // Check the chunking value
   getIntegerParam(NDFileHDF5_NDAttributeChunk, &chunking);
   // If the chunking is zero then use the number of frames
@@ -2165,17 +2168,24 @@ asynStatus NDFileHDF5::createAttributeDataset()
 
     // Creating extendible data sets
     hdfAttrNode->hdfdims[0] = 1;
+    hdfAttrNode->chunk[0]   = chunking;
+    hdfAttrNode->hdfrank    = 1;
     if (ndAttr->getDataType() < NDAttrString){
       hdfAttrNode->hdfdatatype  = this->typeNd2Hdf((NDDataType_t)ndAttr->getDataType());
-      hdfAttrNode->chunk[0]   = chunking;
-      hdfAttrNode->hdfrank    = 1;
     } else {
-      // String dataset required, use type N5T_NATIVE_CHAR
-      hdfAttrNode->hdfdatatype = H5T_C_S1;
-      hdfAttrNode->hdfdims[1] = MAX_ATTRIBUTE_STRING_SIZE;
-      hdfAttrNode->chunk[0]   = chunking;
-      hdfAttrNode->chunk[1]   = MAX_ATTRIBUTE_STRING_SIZE;
-      hdfAttrNode->hdfrank    = 2;
+      switch (stringAttributeDataType) {
+        case hdf5::nativeChar:
+          hdfAttrNode->hdfdatatype = H5T_NATIVE_CHAR;
+          hdfAttrNode->hdfdims[1] = MAX_ATTRIBUTE_STRING_SIZE;
+          hdfAttrNode->chunk[1]   = MAX_ATTRIBUTE_STRING_SIZE;
+          hdfAttrNode->hdfrank    = 2;
+          break;
+        
+        case hdf5::CString:
+          hdfAttrNode->hdfdatatype = H5Tcopy(H5T_C_S1);
+          H5Tset_size(hdfAttrNode->hdfdatatype, MAX_ATTRIBUTE_STRING_SIZE);
+          break;
+      }
     }
     H5Pset_fill_value (hdfAttrNode->hdfcparm, hdfAttrNode->hdfdatatype, this->ptrFillValue );
 
@@ -2210,11 +2220,9 @@ asynStatus NDFileHDF5::createAttributeDataset()
       // add the attribute to this list
 
       // create a memory space of exactly one element dimension to use for writing slabs
-      if (ndAttr->getDataType() < NDAttrString){
-        hdfAttrNode->elementSize[0]  = 1;
-        hdfAttrNode->elementSize[1]  = 1;
-      } else {
-        hdfAttrNode->elementSize[0]  = 1;
+      hdfAttrNode->elementSize[0]  = 1;
+      hdfAttrNode->elementSize[1]  = 1;
+      if ((ndAttr->getDataType() == NDAttrString) && (stringAttributeDataType == hdf5::nativeChar)) {
         hdfAttrNode->elementSize[1]  = MAX_ATTRIBUTE_STRING_SIZE;
       }
       hdfAttrNode->hdfmemspace  = H5Screate_simple(hdfAttrNode->hdfrank, hdfAttrNode->elementSize, NULL);
@@ -2240,11 +2248,9 @@ asynStatus NDFileHDF5::createAttributeDataset()
   
   
         // create a memory space of exactly one element dimension to use for writing slabs
-        if (ndAttr->getDataType() < NDAttrString){
-          hdfAttrNode->elementSize[0]  = 1;
-          hdfAttrNode->elementSize[1]  = 1;
-        } else {
-          hdfAttrNode->elementSize[0]  = 1;
+        hdfAttrNode->elementSize[0]  = 1;
+        hdfAttrNode->elementSize[1]  = 1;
+        if ((ndAttr->getDataType() == NDAttrString) && (stringAttributeDataType == hdf5::nativeChar)) {
           hdfAttrNode->elementSize[1]  = MAX_ATTRIBUTE_STRING_SIZE;
         }
         hdfAttrNode->hdfmemspace  = H5Screate_simple(hdfAttrNode->hdfrank, hdfAttrNode->elementSize, NULL);

--- a/ADApp/pluginSrc/NDFileHDF5.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5.cpp
@@ -1850,6 +1850,7 @@ NDFileHDF5::NDFileHDF5(const char *portName, int queueSize, int blockingCallback
   this->performanceBuf       = NULL;
   this->performancePtr       = NULL;
   this->numPerformancePoints = 0;
+
   this->hostname = (char*)calloc(MAXHOSTNAMELEN, sizeof(char));
   gethostname(this->hostname, MAXHOSTNAMELEN);
 }
@@ -2180,7 +2181,7 @@ asynStatus NDFileHDF5::createAttributeDataset()
           hdfAttrNode->chunk[1]   = MAX_ATTRIBUTE_STRING_SIZE;
           hdfAttrNode->hdfrank    = 2;
           break;
-        
+
         case hdf5::CString:
           hdfAttrNode->hdfdatatype = H5Tcopy(H5T_C_S1);
           H5Tset_size(hdfAttrNode->hdfdatatype, MAX_ATTRIBUTE_STRING_SIZE);

--- a/ADApp/pluginSrc/NDFileHDF5.h
+++ b/ADApp/pluginSrc/NDFileHDF5.h
@@ -30,6 +30,7 @@
 #define str_NDFileHDF5_extraDimNameY     "HDF5_extraDimNameY"
 #define str_NDFileHDF5_extraDimOffsetY   "HDF5_extraDimOffsetY"
 #define str_NDFileHDF5_storeAttributes   "HDF5_storeAttributes"
+#define str_NDFileHDF5_stringAttributeDataType "HDF5_stringAttributeDataType"
 #define str_NDFileHDF5_storePerformance  "HDF5_storePerformance"
 #define str_NDFileHDF5_totalRuntime      "HDF5_totalRuntime"
 #define str_NDFileHDF5_totalIoSpeed      "HDF5_totalIoSpeed"
@@ -130,6 +131,7 @@ class epicsShareClass NDFileHDF5 : public NDPluginFile
     int NDFileHDF5_extraDimNameY;
     int NDFileHDF5_extraDimOffsetY;
     int NDFileHDF5_storeAttributes;
+    int NDFileHDF5_stringAttributeDataType;
     int NDFileHDF5_storePerformance;
     int NDFileHDF5_totalRuntime;
     int NDFileHDF5_totalIoSpeed;

--- a/ADApp/pluginSrc/NDFileHDF5Layout.h
+++ b/ADApp/pluginSrc/NDFileHDF5Layout.h
@@ -41,6 +41,11 @@ namespace hdf5
     float64,
     string
   } DataType_t;
+  
+  typedef enum {
+    nativeChar,
+    CString
+  } StringAttributeDataType_t;
 
   /** Class used for writing a DataSource with the NDFileHDF5 plugin.
     */


### PR DESCRIPTION
Allow writing NDAttributes of type NDAttrString as as 1-D array of type H5_C_S1[NumArrays] and size MAX_ATTRIBUTE_STRING_SIZE rather than a 2-D array of type H5T_NATIVE_CHAR[NumArrays, MAX_ATTRIBUTE_STRING_SIZE].  The default behavior is backwards compatbile, and there is a new EPICS PV that allows changing the behavior at run-time.  Fixes issue #176.