### PR TITLE
Travis tweaks

### DIFF
--- a/ADApp/pluginTests/Makefile
+++ b/ADApp/pluginTests/Makefile
@@ -9,7 +9,7 @@ USR_CXXFLAGS_Linux += -DH5_NO_DEPRECATED_SYMBOLS -DH5Dopen_vers=2 -DH5Gcreate_ve
 
 # The plugin-test executable with the actual unittests depend on the boost 
 # unittest framework so we can only build it if boost has been configured
-ifdef BOOST
+ifeq ($(WITH_BOOST),YES)
   # The ADTestUtility library contain a number of helper functions to generate test
   # data, asyn port names, record output NDArrays etc etc.
   # This utility library can be used by external modules that provides unittests.
@@ -18,9 +18,12 @@ ifdef BOOST
   ADTestUtility_SRCS += testingutilities.cpp
   ADTestUtility_SRCS += AsynPortClientContainer.cpp
   ADTestUtility_SRCS += AsynException.cpp
-  ADTestUtility_SRCS += HDF5PluginWrapper.cpp
+  
+  ifeq ($(WITH_HDF5),YES)
+    ADTestUtility_SRCS += HDF5PluginWrapper.cpp
+    ADTestUtility_SRCS += HDF5FileReader.cpp
+  endif
   ADTestUtility_SRCS += PosPluginWrapper.cpp
-  ADTestUtility_SRCS += HDF5FileReader.cpp
   ADTestUtility_SRCS += TimeSeriesPluginWrapper.cpp
   ADTestUtility_SRCS += FFTPluginWrapper.cpp
 
@@ -28,10 +31,12 @@ ifdef BOOST
   PROD_IOC_Darwin += plugin-test
   plugin-test_SRCS += plugin-test.cpp
   plugin-test_SRCS += test_NDPluginCircularBuff.cpp
-  plugin-test_SRCS += test_NDFileHDF5.cpp
-  plugin-test_SRCS += test_NDFileHDF5AttributeDataset.cpp
+  ifeq ($(WITH_HDF5),YES)
+    plugin-test_SRCS += test_NDFileHDF5.cpp
+    plugin-test_SRCS += test_NDFileHDF5AttributeDataset.cpp
+    plugin-test_SRCS += test_NDFileHDF5ExtraDimensions.cpp
+  endif
   plugin-test_SRCS += test_NDPosPlugin.cpp
-  plugin-test_SRCS += test_NDFileHDF5ExtraDimensions.cpp
   plugin-test_SRCS += test_NDPluginTimeSeries.cpp
   plugin-test_SRCS += test_NDPluginFFT.cpp
 
@@ -54,20 +59,26 @@ USR_INCLUDES += $(BOOST_INCLUDE)
 
 PROD_LIBS += NDPlugin ADBase asyn
 
-ifdef HDF5_LIB
-  hdf5_DIR = $(HDF5_LIB)
-  PROD_LIBS += hdf5
-else
-  PROD_SYS_LIBS += hdf5
+ifeq ($(WITH_HDF5),YES)
+  ifdef HDF5_LIB
+    hdf5_DIR = $(HDF5_LIB)
+    PROD_LIBS += hdf5
+  else
+    PROD_SYS_LIBS += hdf5
+  endif
 endif
 
-ifdef SZIP
+ifeq ($(WITH_SZIP),YES)
   ifdef SZIP_LIB
     sz_DIR = $(SZIP_LIB)
     PROD_LIBS += sz
   else
     PROD_SYS_LIBS += sz
   endif
+endif
+
+ifdef XML2_INCLUDE
+  USR_INCLUDES += $(XML2_INCLUDE)
 endif
 
 PROD_LIBS += $(EPICS_BASE_IOC_LIBS)

--- a/ci/configure.sh
+++ b/ci/configure.sh
@@ -6,13 +6,17 @@ set -e
 # Generate the configure/RELEASE.local and configure/CONFIG_SITE.linux-x86_64.Common
 # with the details of where to find various external libraries.
 echo "EPICS_BASE=/usr/lib/epics"             >> configure/RELEASE.local
-echo "HDF5=/usr"                             >> configure/CONFIG_SITE.linux-x86_64.Common
-#echo "HDF5_LIB=/usr/lib"                     >> configure/CONFIG_SITE.linux-x86_64.Common
-#echo "HDF5_INCLUDE=-I/usr/include"           >> configure/CONFIG_SITE.linux-x86_64.Common
+
+echo "WITH_HDF5 = YES"                       >> configure/CONFIG_SITE.linux-x86_64.Common
+echo "HDF5_EXTERNAL = YES"                   >> configure/CONFIG_SITE.linux-x86_64.Common
+
+echo "WITH_XML2     = YES"                   >> configure/CONFIG_SITE.linux-x86_64.Common
+echo "XML2_EXTERNAL = YES"                   >> configure/CONFIG_SITE.linux-x86_64.Common
 echo "XML2_INCLUDE=-I/usr/include/libxml2"   >> configure/CONFIG_SITE.linux-x86_64.Common
-echo "BOOST=/usr"                            >> configure/CONFIG_SITE.linux-x86_64.Common
-#echo "BOOST_LIB=/usr/lib"                    >> configure/CONFIG_SITE.linux-x86_64.Common
-#echo "BOOST_INCLUDE=-I/usr/include"          >> configure/CONFIG_SITE.linux-x86_64.Common
+
+echo "WITH_BOOST     = YES"                  >> configure/CONFIG_SITE.linux-x86_64.Common
+echo "BOOST_EXTERNAL = YES"                  >> configure/CONFIG_SITE.linux-x86_64.Common
+
 echo "HOST_OPT=NO"                           >> configure/CONFIG_SITE.linux-x86_64.Common 
 echo "USR_CXXFLAGS_Linux=--coverage"         >> configure/CONFIG_SITE.linux-x86_64.Common 
 echo "USR_LDFLAGS_Linux=--coverage"          >> configure/CONFIG_SITE.linux-x86_64.Common 


### PR DESCRIPTION
Update the pluginTest/Makefile to use the new `WITH_*` macro to enable/disable 3rd party dependencies. 

Make the travis-ci configuration define WITH_HDF5=YES and WITH_BOOST=YES so that the HDF5 plugin and Boost-based unittest suite is built.

This fixes #206 (although the original issue was fixed already, this PR takes care of the secondary issue [mentioned in the thread](https://github.com/areaDetector/ADCore/issues/206#issuecomment-252762884) )