### PR TITLE
Allow datatype to be set at iocInit

### DIFF
--- a/ADApp/ADSrc/asynNDArrayDriver.cpp
+++ b/ADApp/ADSrc/asynNDArrayDriver.cpp
@@ -675,7 +675,6 @@ asynNDArrayDriver::asynNDArrayDriver(const char *portName, int maxAddr, int numP
     setIntegerParam(NDArraySizeZ,   0);
     setIntegerParam(NDArraySize,    0);
     setIntegerParam(NDNDimensions,  0);
-    setIntegerParam(NDDataType,     NDUInt8);
     setIntegerParam(NDColorMode,    NDColorModeMono);
     setIntegerParam(NDUniqueId,     0);
     setDoubleParam (NDTimeStamp,    0.);

--- a/ADApp/Db/NDArrayBase.template
+++ b/ADApp/Db/NDArrayBase.template
@@ -168,6 +168,7 @@ record(mbbo, "$(P)$(R)DataType")
    field(SXVL, "6")
    field(SVST, "Float64")
    field(SVVL, "7")
+   field(VAL,  "$(DATATYPE=0)")
    info(autosaveFields, "VAL")
 }
 


### PR DESCRIPTION
I think it is good practice to allow user to set reasonable default values at iocInit. I know that most people probably use autosave and if available this fulfill their needs. However when writing startup scripts without autosave infrastructure this can greatly speed up the process of testing.

In principal I think that all setters should be macrofied, and default values should be removed from the cpp code. Although this a much bigger chunk of work and you have to know about implications this can have. In my opinion datatype is an essential setting which is not likely to change during run-time, hence it makes sense having a macro to allow it to be set once at iocInit. Currently this is the only one I am missing, but it's likely I will run in to more.

What is your take on this?  