### PR TITLE
startPVAServer will be called only once. Fixes #219

### DIFF
--- a/ADApp/pluginSrc/NDPluginPva.cpp
+++ b/ADApp/pluginSrc/NDPluginPva.cpp
@@ -92,6 +92,8 @@ void NTNDArrayRecord::update(NDArray *pArray)
     unlock();
 }
 
+bool NDPluginPva::m_pvaServerStarted = false;
+
 /** Callback function that is called by the NDArray driver with new NDArray
   * data.
   * \param[in] pArray  The NDArray from the callback.
@@ -165,7 +167,11 @@ NDPluginPva::NDPluginPva(const char *portName, int queueSize,
     if(!master->addRecord(m_record))
         throw runtime_error("couldn't add record to master database");
 
-    m_server = startPVAServer(PVACCESS_ALL_PROVIDERS, 0, true, true);
+    if(!m_pvaServerStarted)
+    {
+        m_server = startPVAServer(PVACCESS_ALL_PROVIDERS, 0, true, true);
+        m_pvaServerStarted = true;
+    }
 }
 
 /* Configuration routine.  Called directly, or from the iocsh function */

--- a/ADApp/pluginSrc/NDPluginPva.h
+++ b/ADApp/pluginSrc/NDPluginPva.h
@@ -36,6 +36,7 @@ protected:
 private:
     epics::pvAccess::ServerContext::shared_pointer m_server;
     NTNDArrayRecordPtr m_record;
+    static bool m_pvaServerStarted;
 };
 
 #endif


### PR DESCRIPTION
A new static member in `NDPluginPva` keeps track if `startPVAServer` was already called by another instance and prevents calling it more than once for the process.