### PR TITLE
startPVAServer won't be called by the plugin anymore. Fixes #219

### DIFF
--- a/ADApp/commonDriverMakefile
+++ b/ADApp/commonDriverMakefile
@@ -13,6 +13,7 @@ $(PROD_NAME)_DBD += NDFileNull.dbd
 
 ifeq ($(WITH_EPICS_V4),YES)
   $(PROD_NAME)_DBD += NDPluginPva.dbd
+  $(PROD_NAME)_DBD += PVAServerRegister.dbd
   PROD_LIBS += ntndArrayConverter
   PROD_LIBS += nt
   PROD_LIBS += pvDatabase

--- a/ADApp/pluginSrc/NDPluginPva.cpp
+++ b/ADApp/pluginSrc/NDPluginPva.cpp
@@ -164,8 +164,6 @@ NDPluginPva::NDPluginPva(const char *portName, int queueSize,
 
     if(!master->addRecord(m_record))
         throw runtime_error("couldn't add record to master database");
-
-    m_server = startPVAServer(PVACCESS_ALL_PROVIDERS, 0, true, true);
 }
 
 /* Configuration routine.  Called directly, or from the iocsh function */

--- a/ADApp/pluginSrc/NDPluginPva.h
+++ b/ADApp/pluginSrc/NDPluginPva.h
@@ -34,7 +34,6 @@ protected:
     int NDPluginPvaPvName;
 
 private:
-    epics::pvAccess::ServerContext::shared_pointer m_server;
     NTNDArrayRecordPtr m_record;
 };
 

--- a/documentation/NDPluginPva.html
+++ b/documentation/NDPluginPva.html
@@ -101,7 +101,7 @@
   <h2 id="PVAServer">Starting the pvAccess server</h2>
   <p>
     In order to actually serve the EPICSv4 PV created by this plugin it is necessary to call 
-    <pre>startPVAServer</pre> after <pre>iocInit</pre> in the IOC startup script.
+    <pre>startPVAServer</pre>. 
   </p>
 </body>
 </html>

--- a/documentation/NDPluginPva.html
+++ b/documentation/NDPluginPva.html
@@ -21,6 +21,7 @@
   <ul>
     <li><a href="#Overview">Overview</a></li>
     <li><a href="#Configuration">Configuration</a></li>
+    <li><a href="#PVAServer">Starting the pvAccess server</a></li>
   </ul>
   <h2 id="Overview">
     Overview
@@ -97,5 +98,10 @@
   <div style="text-align: center; margin-top: 2em; margin-bottom: 2em">
     <img alt="NDPva.png" src="NDPva.png" />
   </div>
+  <h2 id="PVAServer">Starting the pvAccess server</h2>
+  <p>
+    In order to actually serve the EPICSv4 PV created by this plugin it is necessary to call 
+    <pre>startPVAServer</pre> after <pre>iocInit</pre> in the IOC startup script.
+  </p>
 </body>
 </html>


### PR DESCRIPTION
This is an alternative solution to #221. With this change the plugin never calls `startPVAServer`, and it is left to the user to actually call it after `iocInit()` in the startup script. The documentation was updated to reflect this change. The `dbd` file that registers `startPVAServer` is included in the `commonDriverMakefile` file. 