### PR TITLE
Change NDAttributes to use std::string

### DIFF
--- a/ADApp/ADSrc/NDAttribute.h
+++ b/ADApp/ADSrc/NDAttribute.h
@@ -9,6 +9,8 @@
 #ifndef NDAttribute_H
 #define NDAttribute_H
 
+#include <string>
+
 #include <stdio.h>
 #include <string.h>
 
@@ -98,8 +100,10 @@ public:
     virtual NDAttrDataType_t getDataType();
     virtual int getValueInfo(NDAttrDataType_t *pDataType, size_t *pDataSize);
     virtual int getValue(NDAttrDataType_t dataType, void *pValue, size_t dataSize=0);
+    virtual int getValue(std::string& value);
     virtual int setDataType(NDAttrDataType_t dataType);
-    virtual int setValue(void *pValue);
+    virtual int setValue(const void *pValue);
+    virtual int setValue(const std::string&);
     virtual int updateValue();
     virtual int report(FILE *fp, int details);
     friend class NDArray;
@@ -108,15 +112,15 @@ public:
 
 private:
     template <typename epicsType> int getValueT(void *pValue, size_t dataSize);
-    char *pName;                   /**< Name string */
-    char *pDescription;            /**< Description string */
-    NDAttrDataType_t dataType;     /**< Data type of attribute */
-    NDAttrValue value;             /**< Value of attribute except for strings */
-    char *pString;                 /**< Value of attribute for strings */
-    char *pSource;                 /**< Source string - EPICS PV name or DRV_INFO string */
-    NDAttrSource_t sourceType;     /**< Source type */
-    char *pSourceTypeString;       /**< Source type string */
-    NDAttributeListNode listNode;  /**< Used for NDAttributeList */
+    std::string name_;              /**< Name string */
+    std::string description_;       /**< Description string */
+    NDAttrDataType_t dataType_;     /**< Data type of attribute */
+    NDAttrValue value_;             /**< Value of attribute except for strings */
+    std::string string_;            /**< Value of attribute for strings */
+    std::string source_;            /**< Source string - EPICS PV name or DRV_INFO string */
+    NDAttrSource_t sourceType_;     /**< Source type */
+    std::string sourceTypeString_;  /**< Source type string */
+    NDAttributeListNode listNode_;  /**< Used for NDAttributeList */
 };
 
 #endif

--- a/ADApp/ADSrc/NDAttributeList.h
+++ b/ADApp/ADSrc/NDAttributeList.h
@@ -35,8 +35,8 @@ public:
     int          report(FILE *fp, int details);
     
 private:
-    ELLLIST      list;   /**< The EPICS ELLLIST  */
-    epicsMutexId lock;  /**< Mutex to protect the ELLLIST */
+    ELLLIST      list_;   /**< The EPICS ELLLIST  */
+    epicsMutexId lock_;  /**< Mutex to protect the ELLLIST */
 };
 
 #endif

--- a/ADApp/ADSrc/paramAttribute.cpp
+++ b/ADApp/ADSrc/paramAttribute.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <string.h>
+#include <string>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -23,9 +24,6 @@
 #include <asynNDArrayDriver.h>
 #include "NDArray.h"
 #include "paramAttribute.h"
-
-// Unfortunately we need to use a maximum string size to read from the asynPortDriver parameter library
-#define MAX_ATTRIBUTE_STRING_SIZE 2048
 
 static const char *driverName = "paramAttribute";
 
@@ -124,7 +122,7 @@ paramAttribute::~paramAttribute()
 int paramAttribute::updateValue()
 {
     int status = asynSuccess;
-    char stringValue[MAX_ATTRIBUTE_STRING_SIZE] = "";
+    std::string stringValue = "";
     epicsInt32 i32Value=0;
     epicsFloat64 f64Value=0.;
     static const char *functionName = "updateValue";
@@ -142,7 +140,7 @@ int paramAttribute::updateValue()
             break;
         case paramAttrTypeString:
             status = this->pDriver->getStringParam(this->paramAddr, this->paramId,
-                                                MAX_ATTRIBUTE_STRING_SIZE, stringValue);
+                                                stringValue);
             this->setValue(stringValue);
             break;
         default:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,7 +19,7 @@ files respectively, in the configure/ directory of the appropriate release of th
 
 Release Notes
 =============
-R2-6 (December XXX, 2016)
+R2-6 (January XXX, 2017)
 ========================
 
 ### NDPluginROI
@@ -28,7 +28,7 @@ R2-6 (December XXX, 2016)
   [256, 256] if CollapseDims=Enable.
   
 ### NDPluginTransform
-* Set the NDArraySize[X,Y,Z] parameters appropriately after the transformation.  This is done
+* Set the NDArraySize[X,Y,Z] parameters appropriately after the transformation.  This is also done
   by the ROI plugin, and is convenient for clients to see the sizes, since the transform can
   swap the X and Y dimensions. 
 
@@ -52,19 +52,23 @@ R2-6 (December XXX, 2016)
   +-SizeX/2 and +-SizeY/2 pixels from the center pixel.  This preserves symmetry when WidthX/Y is 1,
   and the previous behavior is difficult to duplicate for the Ellipse shape.
 
-### NDAttribute.h
-* Removed the line `#define MAX_ATTRIBUTE_STRING_SIZE 256` because it creates the false impression that
-  there is a limit on the size of string attributes.  There is not.  Some drivers and plugins
-  may need to limit the size, but they should do this with local definitions.
+### NDAttribute
+* Removed the line `#define MAX_ATTRIBUTE_STRING_SIZE 256` from NDAttribute.h because it creates the
+  false impression that there is a limit on the size of string attributes.  There is not.
+  Some drivers and plugins may need to limit the size, but they should do this with local definitions.
   The following files were changed to use local definitions, with these symbolic names and values:
 
   | File                           | Symbolic name             | Value |
   | ------------------------------ | ------------------------- | ----- |
-  | paramAttribute.cpp             | MAX_ATTRIBUTE_STRING_SIZE | 2048  |
   | NDFileHDF5AttributeDataset.cpp | MAX_ATTRIBUTE_STRING_SIZE | 256   |
   | NDFileNetCDF.cpp               | MAX_ATTRIBUTE_STRING_SIZE | 256   |
   | NDFileTIFF.cpp                 | STRING_BUFFER_SIZE        | 2048  |
 
+### paramAttribute
+* Changed to read string parameters using the asynPortDriver::getStringParam(int index, std::string&amp;) 
+  method that was added in asyn R4-31.  This removes the requirement that paramAttribute specify a maximum
+  string parameters size, there is now no limit.
+  
 ### NDFileTIFF
 * If there is an NDAttribute of type NDAttrString named TIFFImageDescription then this attribute is written 
   to the TIFFTAG_IMAGEDESCRIPTION tag in the TIFF file.  Note that it will also be written to a user

--- a/ci/build-synapps-deps.sh
+++ b/ci/build-synapps-deps.sh
@@ -5,11 +5,15 @@ set -e
 mkdir external
 cd external
 
-wget -nv https://github.com/epics-modules/asyn/archive/R4-26.tar.gz
-tar -zxf R4-26.tar.gz
-echo "EPICS_BASE=/usr/lib/epics" > asyn-R4-26/configure/RELEASE
-#echo "EPICS_LIBCOM_ONLY=YES" >> asyn-R4-26/configure/CONFIG_SITE
-make -C asyn-R4-26/
+#wget -nv https://github.com/epics-modules/asyn/archive/R4-26.tar.gz
+#tar -zxf R4-26.tar.gz
+git clone https://github.com/epics-modules/asyn asyn-R4-31
+cd asyn
+git checkout asynPortDriver_std_string
+cd ..
+echo "EPICS_BASE=/usr/lib/epics" > asyn-R4-31/configure/RELEASE
+#echo "EPICS_LIBCOM_ONLY=YES" >> asyn-R4-31/configure/CONFIG_SITE
+make -C asyn-R4-31/
 
 git clone https://github.com/areaDetector/ADSupport.git
 echo "EPICS_BASE=/usr/lib/epics" > ADSupport/configure/RELEASE.linux-x86_64.Common

--- a/ci/build-synapps-deps.sh
+++ b/ci/build-synapps-deps.sh
@@ -8,9 +8,6 @@ cd external
 #wget -nv https://github.com/epics-modules/asyn/archive/R4-26.tar.gz
 #tar -zxf R4-26.tar.gz
 git clone https://github.com/epics-modules/asyn asyn-R4-31
-cd asyn-R4-31
-git checkout asynPortDriver_std_string
-cd ..
 echo "EPICS_BASE=/usr/lib/epics" > asyn-R4-31/configure/RELEASE
 #echo "EPICS_LIBCOM_ONLY=YES" >> asyn-R4-31/configure/CONFIG_SITE
 make -C asyn-R4-31/

--- a/ci/build-synapps-deps.sh
+++ b/ci/build-synapps-deps.sh
@@ -8,7 +8,7 @@ cd external
 #wget -nv https://github.com/epics-modules/asyn/archive/R4-26.tar.gz
 #tar -zxf R4-26.tar.gz
 git clone https://github.com/epics-modules/asyn asyn-R4-31
-cd asyn
+cd asyn-R4-31
 git checkout asynPortDriver_std_string
 cd ..
 echo "EPICS_BASE=/usr/lib/epics" > asyn-R4-31/configure/RELEASE

--- a/ci/configure.sh
+++ b/ci/configure.sh
@@ -21,7 +21,7 @@ echo "HOST_OPT=NO"                           >> configure/CONFIG_SITE.linux-x86_
 echo "USR_CXXFLAGS_Linux=--coverage"         >> configure/CONFIG_SITE.linux-x86_64.Common 
 echo "USR_LDFLAGS_Linux=--coverage"          >> configure/CONFIG_SITE.linux-x86_64.Common 
 
-echo "ASYN=`pwd`/external/asyn-R4-26"        >> configure/RELEASE.local
+echo "ASYN=`pwd`/external/asyn-R4-31"        >> configure/RELEASE.local
 echo "ADSUPPORT=`pwd`/external/ADSupport"    >> configure/RELEASE.local
 
 echo "======= configure/RELEASE.local ========================================="


### PR DESCRIPTION
Changed NDAttribute files to use std::string for most of the string variables rather than char *.  Added new methods to set and get attributes of type NDAttrString using std::string rather than char *.

Removed the length limitation of MAX_ATTRIBUTE_STRING_SIZE in paramAttribute.cpp.  

Added trailing underscores to all private member variables for clarity.

These changes requiring using the master branch of asyn until R4-31 is released.  I have changed the files in ci/ to use git to get that branch and call it R4-31.