### PR TITLE
Process plugin

### DIFF
--- a/ADApp/Db/NDPluginBase.template
+++ b/ADApp/Db/NDPluginBase.template
@@ -114,6 +114,17 @@ record(ai, "$(P)$(R)ExecutionTime_RBV")
 }
 
 ###################################################################
+#  This record requests that the plugin execute again with the    #
+#  same NDArray                                                   #
+###################################################################
+record(bo, "$(P)$(R)ProcessPlugin")
+{
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PROCESS_PLUGIN")
+    field(VAL,  "1")
+}
+
+###################################################################
 #  These records control whether callbacks block or not           #
 ###################################################################
 record(bo, "$(P)$(R)BlockingCallbacks")

--- a/ADApp/op/adl/NDCircularBuff.adl
+++ b/ADApp/op/adl/NDCircularBuff.adl
@@ -1,14 +1,14 @@
 
 file {
 	name="/home/epics/devel/areaDetector/ADCore/ADApp/op/adl/NDCircularBuff.adl"
-	version=030107
+	version=030109
 }
 display {
 	object {
 		x=247
 		y=151
 		width=775
-		height=650
+		height=675
 	}
 	clr=14
 	bclr=4
@@ -116,7 +116,7 @@ composite {
 		x=5
 		y=40
 		width=380
-		height=605
+		height=630
 	}
 	"composite name"=""
 	"composite file"="NDPluginBase.adl"

--- a/ADApp/op/adl/NDColorConvert.adl
+++ b/ADApp/op/adl/NDColorConvert.adl
@@ -1,14 +1,14 @@
 
 file {
 	name="/home/epics/devel/areaDetector/ADCore/ADApp/op/adl/NDColorConvert.adl"
-	version=030107
+	version=030109
 }
 display {
 	object {
 		x=193
 		y=91
 		width=390
-		height=715
+		height=740
 	}
 	clr=14
 	bclr=4
@@ -116,7 +116,7 @@ composite {
 		x=5
 		y=40
 		width=380
-		height=605
+		height=630
 	}
 	"composite name"=""
 	"composite file"="NDPluginBase.adl"
@@ -124,7 +124,7 @@ composite {
 composite {
 	object {
 		x=5
-		y=650
+		y=675
 		width=380
 		height=60
 	}
@@ -133,7 +133,7 @@ composite {
 		rectangle {
 			object {
 				x=5
-				y=650
+				y=675
 				width=380
 				height=60
 			}
@@ -145,7 +145,7 @@ composite {
 		composite {
 			object {
 				x=12
-				y=658
+				y=683
 				width=366
 				height=20
 			}
@@ -154,7 +154,7 @@ composite {
 				text {
 					object {
 						x=12
-						y=658
+						y=683
 						width=150
 						height=20
 					}
@@ -167,7 +167,7 @@ composite {
 				menu {
 					object {
 						x=172
-						y=658
+						y=683
 						width=100
 						height=20
 					}
@@ -180,7 +180,7 @@ composite {
 				"text update" {
 					object {
 						x=278
-						y=659
+						y=684
 						width=100
 						height=18
 					}
@@ -197,7 +197,7 @@ composite {
 		text {
 			object {
 				x=12
-				y=683
+				y=708
 				width=150
 				height=20
 			}
@@ -210,7 +210,7 @@ composite {
 		menu {
 			object {
 				x=172
-				y=683
+				y=708
 				width=100
 				height=20
 			}
@@ -223,7 +223,7 @@ composite {
 		"text update" {
 			object {
 				x=278
-				y=684
+				y=709
 				width=100
 				height=18
 			}

--- a/ADApp/op/adl/NDFFT.adl
+++ b/ADApp/op/adl/NDFFT.adl
@@ -1,14 +1,14 @@
 
 file {
 	name="/home/epics/devel/areaDetector/ADCore/ADApp/op/adl/NDFFT.adl"
-	version=030107
+	version=030109
 }
 display {
 	object {
 		x=362
 		y=68
 		width=390
-		height=830
+		height=855
 	}
 	clr=14
 	bclr=4
@@ -116,7 +116,7 @@ composite {
 		x=5
 		y=35
 		width=380
-		height=605
+		height=630
 	}
 	"composite name"=""
 	"composite file"="NDPluginBase.adl"
@@ -124,7 +124,7 @@ composite {
 composite {
 	object {
 		x=5
-		y=645
+		y=670
 		width=380
 		height=180
 	}
@@ -133,7 +133,7 @@ composite {
 		rectangle {
 			object {
 				x=5
-				y=645
+				y=670
 				width=380
 				height=180
 			}
@@ -146,7 +146,7 @@ composite {
 		text {
 			object {
 				x=15
-				y=700
+				y=725
 				width=180
 				height=20
 			}
@@ -159,7 +159,7 @@ composite {
 		menu {
 			object {
 				x=200
-				y=700
+				y=725
 				width=120
 				height=20
 			}
@@ -172,7 +172,7 @@ composite {
 		"related display" {
 			object {
 				x=200
-				y=725
+				y=750
 				width=120
 				height=20
 			}
@@ -238,7 +238,7 @@ composite {
 		text {
 			object {
 				x=105
-				y=725
+				y=750
 				width=90
 				height=20
 			}
@@ -251,7 +251,7 @@ composite {
 		composite {
 			object {
 				x=65
-				y=675
+				y=700
 				width=255
 				height=20
 			}
@@ -260,7 +260,7 @@ composite {
 				text {
 					object {
 						x=65
-						y=675
+						y=700
 						width=130
 						height=20
 					}
@@ -273,7 +273,7 @@ composite {
 				menu {
 					object {
 						x=200
-						y=675
+						y=700
 						width=120
 						height=20
 					}
@@ -288,7 +288,7 @@ composite {
 		text {
 			object {
 				x=155
-				y=650
+				y=675
 				width=40
 				height=20
 			}
@@ -301,7 +301,7 @@ composite {
 		"text entry" {
 			object {
 				x=200
-				y=650
+				y=675
 				width=120
 				height=20
 			}
@@ -316,7 +316,7 @@ composite {
 		composite {
 			object {
 				x=25
-				y=750
+				y=775
 				width=295
 				height=20
 			}
@@ -325,7 +325,7 @@ composite {
 				text {
 					object {
 						x=25
-						y=750
+						y=775
 						width=170
 						height=20
 					}
@@ -338,7 +338,7 @@ composite {
 				"text entry" {
 					object {
 						x=200
-						y=750
+						y=775
 						width=120
 						height=20
 					}
@@ -355,7 +355,7 @@ composite {
 		composite {
 			object {
 				x=45
-				y=775
+				y=800
 				width=275
 				height=20
 			}
@@ -364,7 +364,7 @@ composite {
 				text {
 					object {
 						x=45
-						y=775
+						y=800
 						width=150
 						height=20
 					}
@@ -377,7 +377,7 @@ composite {
 				"text update" {
 					object {
 						x=200
-						y=776
+						y=801
 						width=120
 						height=18
 					}
@@ -394,7 +394,7 @@ composite {
 		composite {
 			object {
 				x=65
-				y=800
+				y=825
 				width=253
 				height=20
 			}
@@ -403,7 +403,7 @@ composite {
 				text {
 					object {
 						x=65
-						y=800
+						y=825
 						width=130
 						height=20
 					}
@@ -416,7 +416,7 @@ composite {
 				"message button" {
 					object {
 						x=200
-						y=800
+						y=825
 						width=118
 						height=20
 					}

--- a/ADApp/op/adl/NDFileHDF5.adl
+++ b/ADApp/op/adl/NDFileHDF5.adl
@@ -1,14 +1,14 @@
 
 file {
 	name="/home/epics/devel/areaDetector/ADCore/ADApp/op/adl/NDFileHDF5.adl"
-	version=030107
+	version=030109
 }
 display {
 	object {
 		x=256
 		y=75
 		width=1070
-		height=840
+		height=865
 	}
 	clr=14
 	bclr=4
@@ -116,7 +116,7 @@ composite {
 		x=5
 		y=40
 		width=380
-		height=605
+		height=630
 	}
 	"composite name"=""
 	"composite file"="NDPluginBase.adl"
@@ -921,7 +921,7 @@ composite {
 composite {
 	object {
 		x=5
-		y=650
+		y=675
 		width=380
 		height=185
 	}
@@ -930,7 +930,7 @@ composite {
 		rectangle {
 			object {
 				x=5
-				y=650
+				y=675
 				width=380
 				height=185
 			}
@@ -942,7 +942,7 @@ composite {
 		composite {
 			object {
 				x=105
-				y=655
+				y=680
 				width=270
 				height=20
 			}
@@ -951,7 +951,7 @@ composite {
 				text {
 					object {
 						x=105
-						y=655
+						y=680
 						width=140
 						height=20
 					}
@@ -964,7 +964,7 @@ composite {
 				"text entry" {
 					object {
 						x=250
-						y=655
+						y=680
 						width=60
 						height=20
 					}
@@ -979,7 +979,7 @@ composite {
 				"text update" {
 					object {
 						x=315
-						y=656
+						y=681
 						width=60
 						height=18
 					}
@@ -996,7 +996,7 @@ composite {
 		composite {
 			object {
 				x=75
-				y=680
+				y=705
 				width=300
 				height=20
 			}
@@ -1005,7 +1005,7 @@ composite {
 				text {
 					object {
 						x=75
-						y=680
+						y=705
 						width=170
 						height=20
 					}
@@ -1018,7 +1018,7 @@ composite {
 				"text entry" {
 					object {
 						x=250
-						y=680
+						y=705
 						width=60
 						height=20
 					}
@@ -1033,66 +1033,12 @@ composite {
 				"text update" {
 					object {
 						x=315
-						y=681
-						width=60
-						height=18
-					}
-					monitor {
-						chan="$(P)$(R)NumColChunks_RBV"
-						clr=54
-						bclr=4
-					}
-					limits {
-					}
-				}
-			}
-		}
-		composite {
-			object {
-				x=15
-				y=705
-				width=360
-				height=20
-			}
-			"composite name"=""
-			children {
-				text {
-					object {
-						x=15
-						y=705
-						width=230
-						height=20
-					}
-					"basic attribute" {
-						clr=14
-					}
-					textix="Frames cached per chunk"
-					align="horiz. right"
-				}
-				"text entry" {
-					object {
-						x=250
-						y=705
-						width=60
-						height=20
-					}
-					control {
-						chan="$(P)$(R)NumFramesChunks"
-						clr=14
-						bclr=51
-					}
-					limits {
-					}
-				}
-				"text update" {
-					object {
-						x=315
 						y=706
 						width=60
 						height=18
 					}
 					monitor {
-						chan="$(P)$(R)NumFramesChunks_RBV"
+						chan="$(P)$(R)NumColChunks_RBV"
 						clr=54
 						bclr=4
 					}
@@ -1120,7 +1066,7 @@ composite {
 					"basic attribute" {
 						clr=14
 					}
-					textix="Boundary alignment"
+					textix="Frames cached per chunk"
 					align="horiz. right"
 				}
 				"text entry" {
@@ -1131,7 +1077,7 @@ composite {
 						height=20
 					}
 					control {
-						chan="$(P)$(R)BoundaryAlign"
+						chan="$(P)$(R)NumFramesChunks"
 						clr=14
 						bclr=51
 					}
@@ -1146,7 +1092,7 @@ composite {
 						height=18
 					}
 					monitor {
-						chan="$(P)$(R)BoundaryAlign_RBV"
+						chan="$(P)$(R)NumFramesChunks_RBV"
 						clr=54
 						bclr=4
 					}
@@ -1174,13 +1120,67 @@ composite {
 					"basic attribute" {
 						clr=14
 					}
-					textix="Boundary threshold"
+					textix="Boundary alignment"
 					align="horiz. right"
 				}
 				"text entry" {
 					object {
 						x=250
 						y=755
+						width=60
+						height=20
+					}
+					control {
+						chan="$(P)$(R)BoundaryAlign"
+						clr=14
+						bclr=51
+					}
+					limits {
+					}
+				}
+				"text update" {
+					object {
+						x=315
+						y=756
+						width=60
+						height=18
+					}
+					monitor {
+						chan="$(P)$(R)BoundaryAlign_RBV"
+						clr=54
+						bclr=4
+					}
+					limits {
+					}
+				}
+			}
+		}
+		composite {
+			object {
+				x=15
+				y=780
+				width=360
+				height=20
+			}
+			"composite name"=""
+			children {
+				text {
+					object {
+						x=15
+						y=780
+						width=230
+						height=20
+					}
+					"basic attribute" {
+						clr=14
+					}
+					textix="Boundary threshold"
+					align="horiz. right"
+				}
+				"text entry" {
+					object {
+						x=250
+						y=780
 						width=60
 						height=20
 					}
@@ -1195,7 +1195,7 @@ composite {
 				"text update" {
 					object {
 						x=315
-						y=756
+						y=781
 						width=60
 						height=18
 					}
@@ -1212,7 +1212,7 @@ composite {
 		text {
 			object {
 				x=35
-				y=805
+				y=830
 				width=210
 				height=20
 			}
@@ -1225,7 +1225,7 @@ composite {
 		"text update" {
 			object {
 				x=315
-				y=806
+				y=831
 				width=60
 				height=18
 			}
@@ -1240,7 +1240,7 @@ composite {
 		text {
 			object {
 				x=55
-				y=780
+				y=805
 				width=190
 				height=20
 			}
@@ -1253,7 +1253,7 @@ composite {
 		"text entry" {
 			object {
 				x=250
-				y=780
+				y=805
 				width=60
 				height=20
 			}
@@ -1268,7 +1268,7 @@ composite {
 		"text update" {
 			object {
 				x=315
-				y=781
+				y=806
 				width=60
 				height=18
 			}
@@ -1283,7 +1283,7 @@ composite {
 		"text entry" {
 			object {
 				x=250
-				y=805
+				y=830
 				width=60
 				height=20
 			}

--- a/ADApp/op/adl/NDFileJPEG.adl
+++ b/ADApp/op/adl/NDFileJPEG.adl
@@ -1,14 +1,14 @@
 
 file {
 	name="/home/epics/devel/areaDetector/ADCore/ADApp/op/adl/NDFileJPEG.adl"
-	version=030107
+	version=030109
 }
 display {
 	object {
 		x=164
 		y=158
 		width=1070
-		height=650
+		height=675
 	}
 	clr=14
 	bclr=4
@@ -116,7 +116,7 @@ composite {
 		x=5
 		y=40
 		width=380
-		height=605
+		height=630
 	}
 	"composite name"=""
 	"composite file"="NDPluginBase.adl"

--- a/ADApp/op/adl/NDFileMagick.adl
+++ b/ADApp/op/adl/NDFileMagick.adl
@@ -1,14 +1,14 @@
 
 file {
 	name="/home/epics/devel/areaDetector/ADCore/ADApp/op/adl/NDFileMagick.adl"
-	version=030107
+	version=030109
 }
 display {
 	object {
 		x=167
 		y=286
 		width=1070
-		height=650
+		height=675
 	}
 	clr=14
 	bclr=4
@@ -116,7 +116,7 @@ composite {
 		x=5
 		y=40
 		width=380
-		height=605
+		height=630
 	}
 	"composite name"=""
 	"composite file"="NDPluginBase.adl"

--- a/ADApp/op/adl/NDFileNetCDF.adl
+++ b/ADApp/op/adl/NDFileNetCDF.adl
@@ -1,14 +1,14 @@
 
 file {
 	name="/home/epics/devel/areaDetector/ADCore/ADApp/op/adl/NDFileNetCDF.adl"
-	version=030107
+	version=030109
 }
 display {
 	object {
 		x=360
 		y=163
 		width=1070
-		height=650
+		height=675
 	}
 	clr=14
 	bclr=4
@@ -116,7 +116,7 @@ composite {
 		x=5
 		y=40
 		width=380
-		height=605
+		height=630
 	}
 	"composite name"=""
 	"composite file"="NDPluginBase.adl"

--- a/ADApp/op/adl/NDFileNexus.adl
+++ b/ADApp/op/adl/NDFileNexus.adl
@@ -1,14 +1,14 @@
 
 file {
 	name="/home/epics/devel/areaDetector/ADCore/ADApp/op/adl/NDFileNexus.adl"
-	version=030107
+	version=030109
 }
 display {
 	object {
 		x=236
 		y=152
 		width=1070
-		height=650
+		height=675
 	}
 	clr=14
 	bclr=4
@@ -116,7 +116,7 @@ composite {
 		x=5
 		y=40
 		width=380
-		height=605
+		height=630
 	}
 	"composite name"=""
 	"composite file"="NDPluginBase.adl"

--- a/ADApp/op/adl/NDFileNull.adl
+++ b/ADApp/op/adl/NDFileNull.adl
@@ -1,14 +1,14 @@
 
 file {
 	name="/home/epics/devel/areaDetector/ADCore/ADApp/op/adl/NDFileNull.adl"
-	version=030107
+	version=030109
 }
 display {
 	object {
 		x=259
 		y=266
 		width=1070
-		height=650
+		height=675
 	}
 	clr=14
 	bclr=4
@@ -116,7 +116,7 @@ composite {
 		x=5
 		y=40
 		width=380
-		height=605
+		height=630
 	}
 	"composite name"=""
 	"composite file"="NDPluginBase.adl"

--- a/ADApp/op/adl/NDFileTIFF.adl
+++ b/ADApp/op/adl/NDFileTIFF.adl
@@ -1,14 +1,14 @@
 
 file {
 	name="/home/epics/devel/areaDetector/ADCore/ADApp/op/adl/NDFileTIFF.adl"
-	version=030107
+	version=030109
 }
 display {
 	object {
 		x=345
 		y=196
 		width=1070
-		height=650
+		height=675
 	}
 	clr=14
 	bclr=4
@@ -116,7 +116,7 @@ composite {
 		x=5
 		y=40
 		width=380
-		height=605
+		height=630
 	}
 	"composite name"=""
 	"composite file"="NDPluginBase.adl"

--- a/ADApp/op/adl/NDOverlay.adl
+++ b/ADApp/op/adl/NDOverlay.adl
@@ -1,14 +1,14 @@
 
 file {
-	name="/home/epics/devel/areaDetector/ADCore/ADApp/op/adl/NDOverlay.adl"
-	version=030107
+	name="/home/epics/devel/areaDetector-2-6/ADCore/ADApp/op/adl/NDOverlay.adl"
+	version=030109
 }
 display {
 	object {
 		x=353
 		y=59
 		width=390
-		height=740
+		height=765
 	}
 	clr=14
 	bclr=4
@@ -116,7 +116,7 @@ composite {
 		x=5
 		y=40
 		width=380
-		height=605
+		height=630
 	}
 	"composite name"=""
 	"composite file"="NDPluginBase.adl"
@@ -124,7 +124,7 @@ composite {
 composite {
 	object {
 		x=5
-		y=650
+		y=675
 		width=380
 		height=85
 	}
@@ -133,7 +133,7 @@ composite {
 		rectangle {
 			object {
 				x=5
-				y=650
+				y=675
 				width=380
 				height=85
 			}
@@ -145,7 +145,7 @@ composite {
 		"related display" {
 			object {
 				x=172
-				y=680
+				y=705
 				width=160
 				height=20
 			}
@@ -196,7 +196,7 @@ composite {
 		text {
 			object {
 				x=22
-				y=680
+				y=705
 				width=140
 				height=20
 			}
@@ -209,7 +209,7 @@ composite {
 		"related display" {
 			object {
 				x=172
-				y=707
+				y=732
 				width=160
 				height=20
 			}
@@ -230,7 +230,7 @@ composite {
 		text {
 			object {
 				x=138
-				y=655
+				y=680
 				width=150
 				height=20
 			}
@@ -243,7 +243,7 @@ composite {
 		text {
 			object {
 				x=82
-				y=708
+				y=733
 				width=80
 				height=20
 			}

--- a/ADApp/op/adl/NDPluginAttribute.adl
+++ b/ADApp/op/adl/NDPluginAttribute.adl
@@ -1,14 +1,14 @@
 
 file {
 	name="/home/epics/devel/areaDetector/ADCore/ADApp/op/adl/NDPluginAttribute.adl"
-	version=030107
+	version=030109
 }
 display {
 	object {
 		x=208
 		y=85
 		width=775
-		height=650
+		height=675
 	}
 	clr=14
 	bclr=4
@@ -103,7 +103,7 @@ composite {
 		x=5
 		y=40
 		width=380
-		height=605
+		height=630
 	}
 	"composite name"=""
 	"composite file"="NDPluginBase.adl"

--- a/ADApp/op/adl/NDPluginBase.adl
+++ b/ADApp/op/adl/NDPluginBase.adl
@@ -1,14 +1,14 @@
 
 file {
-	name="/home/epics/devel/areaDetector/ADCore/ADApp/op/adl/NDPluginBase.adl"
-	version=030107
+	name="/home/epics/devel/areaDetector-2-6/ADCore/ADApp/op/adl/NDPluginBase.adl"
+	version=030109
 }
 display {
 	object {
 		x=213
 		y=51
 		width=380
-		height=605
+		height=630
 	}
 	clr=14
 	bclr=4
@@ -92,7 +92,7 @@ rectangle {
 		x=0
 		y=0
 		width=380
-		height=605
+		height=630
 	}
 	"basic attribute" {
 		clr=14
@@ -840,7 +840,7 @@ text {
 composite {
 	object {
 		x=47
-		y=579
+		y=604
 		width=220
 		height=20
 	}
@@ -849,7 +849,7 @@ composite {
 		"related display" {
 			object {
 				x=167
-				y=579
+				y=604
 				width=100
 				height=20
 			}
@@ -864,7 +864,7 @@ composite {
 		text {
 			object {
 				x=47
-				y=579
+				y=604
 				width=110
 				height=20
 			}
@@ -985,4 +985,32 @@ text {
 	}
 	textix="msec"
 	align="horiz. right"
+}
+text {
+	object {
+		x=20
+		y=579
+		width=140
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Process plugin"
+	align="horiz. right"
+}
+"message button" {
+	object {
+		x=167
+		y=579
+		width=100
+		height=20
+	}
+	control {
+		chan="$(P)$(R)ReprocessPlugin"
+		clr=14
+		bclr=51
+	}
+	label="Process"
+	press_msg="1"
 }

--- a/ADApp/op/adl/NDPluginBase.adl
+++ b/ADApp/op/adl/NDPluginBase.adl
@@ -1007,7 +1007,7 @@ text {
 		height=20
 	}
 	control {
-		chan="$(P)$(R)ReprocessPlugin"
+		chan="$(P)$(R)ProcessPlugin"
 		clr=14
 		bclr=51
 	}

--- a/ADApp/op/adl/NDPluginTimeSeries.adl
+++ b/ADApp/op/adl/NDPluginTimeSeries.adl
@@ -1,14 +1,14 @@
 
 file {
-	name="/home/epics/devel/areaDetector/ADCore/ADApp/op/adl/NDPluginTimeSeries.adl"
-	version=030107
+	name="/home/epics/devel/areaDetector-2-6/ADCore/ADApp/op/adl/NDPluginTimeSeries.adl"
+	version=030109
 }
 display {
 	object {
 		x=581
 		y=191
 		width=695
-		height=650
+		height=675
 	}
 	clr=14
 	bclr=4
@@ -116,7 +116,7 @@ composite {
 		x=5
 		y=40
 		width=380
-		height=605
+		height=630
 	}
 	"composite name"=""
 	"composite file"="NDPluginBase.adl"

--- a/ADApp/op/adl/NDPos.adl
+++ b/ADApp/op/adl/NDPos.adl
@@ -1,14 +1,14 @@
 
 file {
 	name="/home/epics/devel/areaDetector/ADCore/ADApp/op/adl/NDPos.adl"
-	version=030107
+	version=030109
 }
 display {
 	object {
 		x=253
 		y=180
 		width=825
-		height=650
+		height=675
 	}
 	clr=14
 	bclr=4
@@ -116,7 +116,7 @@ composite {
 		x=5
 		y=40
 		width=380
-		height=605
+		height=630
 	}
 	"composite name"=""
 	"composite file"="NDPluginBase.adl"

--- a/ADApp/op/adl/NDProcess.adl
+++ b/ADApp/op/adl/NDProcess.adl
@@ -1,14 +1,14 @@
 
 file {
-	name="/home/epics/devel/areaDetector/ADCore/ADApp/op/adl/NDProcess.adl"
-	version=030107
+	name="/home/epics/devel/areaDetector-2-6/ADCore/ADApp/op/adl/NDProcess.adl"
+	version=030109
 }
 display {
 	object {
-		x=154
-		y=202
+		x=269
+		y=141
 		width=1150
-		height=660
+		height=675
 	}
 	clr=14
 	bclr=4
@@ -860,7 +860,7 @@ composite {
 		x=5
 		y=40
 		width=380
-		height=605
+		height=630
 	}
 	"composite name"=""
 	"composite file"="NDPluginBase.adl"

--- a/ADApp/op/adl/NDPva.adl
+++ b/ADApp/op/adl/NDPva.adl
@@ -1,14 +1,14 @@
 
 file {
 	name="/home/epics/devel/areaDetector/ADCore/ADApp/op/adl/NDPva.adl"
-	version=030107
+	version=030109
 }
 display {
 	object {
 		x=460
 		y=141
 		width=390
-		height=715
+		height=740
 	}
 	clr=14
 	bclr=4
@@ -116,7 +116,7 @@ composite {
 		x=5
 		y=40
 		width=380
-		height=605
+		height=630
 	}
 	"composite name"=""
 	"composite file"="NDPluginBase.adl"
@@ -124,7 +124,7 @@ composite {
 composite {
 	object {
 		x=5
-		y=650
+		y=675
 		width=380
 		height=60
 	}
@@ -133,7 +133,7 @@ composite {
 		rectangle {
 			object {
 				x=5
-				y=650
+				y=675
 				width=380
 				height=60
 			}
@@ -145,7 +145,7 @@ composite {
 		text {
 			object {
 				x=22
-				y=680
+				y=705
 				width=140
 				height=20
 			}
@@ -158,7 +158,7 @@ composite {
 		text {
 			object {
 				x=115
-				y=655
+				y=680
 				width=160
 				height=20
 			}
@@ -171,7 +171,7 @@ composite {
 		"text update" {
 			object {
 				x=175
-				y=683
+				y=708
 				width=200
 				height=18
 			}

--- a/ADApp/op/adl/NDROI.adl
+++ b/ADApp/op/adl/NDROI.adl
@@ -1,14 +1,14 @@
 
 file {
 	name="/home/epics/devel/areaDetector/ADCore/ADApp/op/adl/NDROI.adl"
-	version=030107
+	version=030109
 }
 display {
 	object {
 		x=452
 		y=60
 		width=755
-		height=650
+		height=675
 	}
 	clr=14
 	bclr=4
@@ -266,7 +266,7 @@ composite {
 		x=5
 		y=40
 		width=380
-		height=605
+		height=630
 	}
 	"composite name"=""
 	"composite file"="NDPluginBase.adl"

--- a/ADApp/op/adl/NDROIStat.adl
+++ b/ADApp/op/adl/NDROIStat.adl
@@ -1,14 +1,14 @@
 
 file {
-	name="/home/epics/devel/areaDetector/ADCore/ADApp/op/adl/NDROIStat.adl"
-	version=030107
+	name="/home/epics/devel/areaDetector-2-6/ADCore/ADApp/op/adl/NDROIStat.adl"
+	version=030109
 }
 display {
 	object {
-		x=391
-		y=67
+		x=156
+		y=69
 		width=775
-		height=650
+		height=675
 	}
 	clr=14
 	bclr=4
@@ -116,7 +116,7 @@ composite {
 		x=5
 		y=40
 		width=380
-		height=605
+		height=630
 	}
 	"composite name"=""
 	"composite file"="NDPluginBase.adl"
@@ -124,7 +124,7 @@ composite {
 composite {
 	object {
 		x=390
-		y=41
+		y=40
 		width=380
 		height=245
 	}
@@ -133,7 +133,7 @@ composite {
 		composite {
 			object {
 				x=390
-				y=131
+				y=130
 				width=380
 				height=155
 			}
@@ -142,7 +142,7 @@ composite {
 				"message button" {
 					object {
 						x=530
-						y=266
+						y=265
 						width=100
 						height=20
 					}
@@ -157,7 +157,7 @@ composite {
 				composite {
 					object {
 						x=390
-						y=131
+						y=130
 						width=380
 						height=130
 					}
@@ -166,7 +166,7 @@ composite {
 						rectangle {
 							object {
 								x=520
-								y=136
+								y=135
 								width=120
 								height=21
 							}
@@ -177,7 +177,7 @@ composite {
 						rectangle {
 							object {
 								x=390
-								y=131
+								y=130
 								width=380
 								height=130
 							}
@@ -189,7 +189,7 @@ composite {
 						text {
 							object {
 								x=525
-								y=136
+								y=135
 								width=110
 								height=20
 							}
@@ -202,7 +202,7 @@ composite {
 						composite {
 							object {
 								x=461
-								y=213
+								y=212
 								width=225
 								height=20
 							}
@@ -211,7 +211,7 @@ composite {
 								text {
 									object {
 										x=461
-										y=213
+										y=212
 										width=130
 										height=20
 									}
@@ -224,7 +224,7 @@ composite {
 								"text update" {
 									object {
 										x=596
-										y=214
+										y=213
 										width=90
 										height=18
 									}
@@ -241,7 +241,7 @@ composite {
 						composite {
 							object {
 								x=501
-								y=238
+								y=237
 								width=240
 								height=20
 							}
@@ -250,7 +250,7 @@ composite {
 								menu {
 									object {
 										x=596
-										y=239
+										y=238
 										width=80
 										height=18
 									}
@@ -263,7 +263,7 @@ composite {
 								"message button" {
 									object {
 										x=681
-										y=238
+										y=237
 										width=60
 										height=20
 									}
@@ -278,7 +278,7 @@ composite {
 								text {
 									object {
 										x=501
-										y=238
+										y=237
 										width=90
 										height=20
 									}
@@ -292,7 +292,7 @@ composite {
 						"message button" {
 							object {
 								x=423
-								y=163
+								y=162
 								width=90
 								height=20
 							}
@@ -307,7 +307,7 @@ composite {
 						"message button" {
 							object {
 								x=518
-								y=163
+								y=162
 								width=60
 								height=20
 							}
@@ -322,7 +322,7 @@ composite {
 						"message button" {
 							object {
 								x=583
-								y=163
+								y=162
 								width=60
 								height=20
 							}
@@ -337,7 +337,7 @@ composite {
 						"text update" {
 							object {
 								x=648
-								y=164
+								y=163
 								width=90
 								height=18
 							}
@@ -353,7 +353,7 @@ composite {
 						composite {
 							object {
 								x=431
-								y=188
+								y=187
 								width=225
 								height=20
 							}
@@ -362,7 +362,7 @@ composite {
 								"text entry" {
 									object {
 										x=596
-										y=189
+										y=188
 										width=60
 										height=19
 									}
@@ -377,7 +377,7 @@ composite {
 								text {
 									object {
 										x=431
-										y=188
+										y=187
 										width=160
 										height=20
 									}
@@ -396,7 +396,7 @@ composite {
 		composite {
 			object {
 				x=390
-				y=41
+				y=40
 				width=380
 				height=85
 			}
@@ -405,7 +405,7 @@ composite {
 				rectangle {
 					object {
 						x=390
-						y=41
+						y=40
 						width=380
 						height=85
 					}
@@ -417,7 +417,7 @@ composite {
 				"related display" {
 					object {
 						x=557
-						y=71
+						y=70
 						width=130
 						height=20
 					}
@@ -468,7 +468,7 @@ composite {
 				text {
 					object {
 						x=407
-						y=71
+						y=70
 						width=140
 						height=20
 					}
@@ -481,7 +481,7 @@ composite {
 				"related display" {
 					object {
 						x=557
-						y=98
+						y=97
 						width=130
 						height=20
 					}
@@ -512,7 +512,7 @@ composite {
 				text {
 					object {
 						x=523
-						y=46
+						y=45
 						width=150
 						height=20
 					}
@@ -525,7 +525,7 @@ composite {
 				text {
 					object {
 						x=467
-						y=99
+						y=98
 						width=80
 						height=20
 					}

--- a/ADApp/op/adl/NDStdArrays.adl
+++ b/ADApp/op/adl/NDStdArrays.adl
@@ -1,14 +1,14 @@
 
 file {
 	name="/home/epics/devel/areaDetector/ADCore/ADApp/op/adl/NDStdArrays.adl"
-	version=030107
+	version=030109
 }
 display {
 	object {
 		x=470
 		y=197
 		width=390
-		height=650
+		height=675
 	}
 	clr=14
 	bclr=4
@@ -116,7 +116,7 @@ composite {
 		x=5
 		y=40
 		width=380
-		height=605
+		height=630
 	}
 	"composite name"=""
 	"composite file"="NDPluginBase.adl"

--- a/ADApp/op/adl/NDTransform.adl
+++ b/ADApp/op/adl/NDTransform.adl
@@ -1,14 +1,14 @@
 
 file {
 	name="/home/epics/devel/areaDetector/ADCore/ADApp/op/adl/NDTransform.adl"
-	version=030107
+	version=030109
 }
 display {
 	object {
 		x=598
 		y=73
 		width=390
-		height=815
+		height=840
 	}
 	clr=14
 	bclr=4
@@ -116,715 +116,726 @@ composite {
 		x=5
 		y=40
 		width=380
-		height=605
+		height=630
 	}
 	"composite name"=""
 	"composite file"="NDPluginBase.adl"
 }
-rectangle {
+composite {
 	object {
 		x=5
-		y=650
+		y=675
 		width=380
 		height=160
 	}
-	"basic attribute" {
-		clr=13
-		fill="outline"
-	}
-}
-text {
-	object {
-		x=15
-		y=657
-		width=140
-		height=20
-	}
-	"basic attribute" {
-		clr=14
-	}
-	textix="Transform Type"
-}
-menu {
-	object {
-		x=160
-		y=657
-		width=120
-		height=20
-	}
-	control {
-		chan="$(P)$(R)Type"
-		clr=14
-		bclr=51
-	}
-}
-composite {
-	object {
-		x=282
-		y=686
-		width=13
-		height=19
-	}
 	"composite name"=""
 	children {
-		polyline {
+		rectangle {
 			object {
-				x=293
-				y=686
-				width=2
-				height=19
+				x=5
+				y=675
+				width=380
+				height=160
 			}
 			"basic attribute" {
-				clr=53
+				clr=13
 				fill="outline"
-				width=2
-			}
-			points {
-				(294,687)
-				(294,704)
 			}
 		}
-		polyline {
-			object {
-				x=282
-				y=686
-				width=13
-				height=2
-			}
-			"basic attribute" {
-				clr=53
-				fill="outline"
-				width=2
-			}
-			points {
-				(294,687)
-				(283,687)
-			}
-		}
-		polyline {
-			object {
-				x=283
-				y=693
-				width=12
-				height=2
-			}
-			"basic attribute" {
-				clr=53
-				fill="outline"
-				width=2
-			}
-			points {
-				(294,694)
-				(284,694)
-			}
-		}
-	}
-}
-composite {
-	object {
-		x=282
-		y=713
-		width=19
-		height=13
-	}
-	"composite name"=""
-	children {
-		polyline {
-			object {
-				x=282
-				y=713
-				width=19
-				height=2
-			}
-			"basic attribute" {
-				clr=53
-				fill="outline"
-				width=2
-			}
-			points {
-				(283,714)
-				(300,714)
-			}
-		}
-		polyline {
-			object {
-				x=282
-				y=713
-				width=2
-				height=13
-			}
-			"basic attribute" {
-				clr=53
-				fill="outline"
-				width=2
-			}
-			points {
-				(283,714)
-				(283,725)
-			}
-		}
-		polyline {
-			object {
-				x=289
-				y=713
-				width=2
-				height=12
-			}
-			"basic attribute" {
-				clr=53
-				fill="outline"
-				width=2
-			}
-			points {
-				(290,714)
-				(290,724)
-			}
-		}
-	}
-}
-composite {
-	object {
-		x=282
-		y=734
-		width=13
-		height=19
-	}
-	"composite name"=""
-	children {
-		polyline {
-			object {
-				x=282
-				y=734
-				width=2
-				height=19
-			}
-			"basic attribute" {
-				clr=53
-				fill="outline"
-				width=2
-			}
-			points {
-				(283,752)
-				(283,735)
-			}
-		}
-		polyline {
-			object {
-				x=282
-				y=751
-				width=13
-				height=2
-			}
-			"basic attribute" {
-				clr=53
-				fill="outline"
-				width=2
-			}
-			points {
-				(283,752)
-				(294,752)
-			}
-		}
-		polyline {
-			object {
-				x=282
-				y=744
-				width=12
-				height=2
-			}
-			"basic attribute" {
-				clr=53
-				fill="outline"
-				width=2
-			}
-			points {
-				(283,745)
-				(293,745)
-			}
-		}
-	}
-}
-composite {
-	object {
-		x=282
-		y=762
-		width=19
-		height=13
-	}
-	"composite name"=""
-	children {
-		polyline {
-			object {
-				x=282
-				y=773
-				width=19
-				height=2
-			}
-			"basic attribute" {
-				clr=53
-				fill="outline"
-				width=2
-			}
-			points {
-				(300,774)
-				(283,774)
-			}
-		}
-		polyline {
-			object {
-				x=299
-				y=762
-				width=2
-				height=13
-			}
-			"basic attribute" {
-				clr=53
-				fill="outline"
-				width=2
-			}
-			points {
-				(300,774)
-				(300,763)
-			}
-		}
-		polyline {
-			object {
-				x=292
-				y=763
-				width=2
-				height=12
-			}
-			"basic attribute" {
-				clr=53
-				fill="outline"
-				width=2
-			}
-			points {
-				(293,774)
-				(293,764)
-			}
-		}
-	}
-}
-text {
-	object {
-		x=200
-		y=685
-		width=77
-		height=20
-	}
-	"basic attribute" {
-		clr=13
-	}
-	textix="Mirror"
-	align="horiz. right"
-}
-text {
-	object {
-		x=200
-		y=710
-		width=77
-		height=20
-	}
-	"basic attribute" {
-		clr=13
-	}
-	textix="Rot90Mirror"
-	align="horiz. right"
-}
-text {
-	object {
-		x=200
-		y=735
-		width=77
-		height=20
-	}
-	"basic attribute" {
-		clr=13
-	}
-	textix="Rot180Mirror"
-	align="horiz. right"
-}
-text {
-	object {
-		x=200
-		y=760
-		width=77
-		height=20
-	}
-	"basic attribute" {
-		clr=13
-	}
-	textix="Rot270Mirror"
-	align="horiz. right"
-}
-text {
-	object {
-		x=20
-		y=685
-		width=77
-		height=20
-	}
-	"basic attribute" {
-		clr=13
-	}
-	textix="None"
-	align="horiz. right"
-}
-text {
-	object {
-		x=20
-		y=710
-		width=77
-		height=20
-	}
-	"basic attribute" {
-		clr=13
-	}
-	textix="Rot90"
-	align="horiz. right"
-}
-text {
-	object {
-		x=20
-		y=735
-		width=77
-		height=20
-	}
-	"basic attribute" {
-		clr=13
-	}
-	textix="Rot180"
-	align="horiz. right"
-}
-text {
-	object {
-		x=20
-		y=760
-		width=77
-		height=20
-	}
-	"basic attribute" {
-		clr=13
-	}
-	textix="Rot270"
-	align="horiz. right"
-}
-composite {
-	object {
-		x=102
-		y=686
-		width=13
-		height=19
-	}
-	"composite name"=""
-	children {
-		polyline {
-			object {
-				x=102
-				y=686
-				width=2
-				height=19
-			}
-			"basic attribute" {
-				clr=53
-				fill="outline"
-				width=2
-			}
-			points {
-				(103,687)
-				(103,704)
-			}
-		}
-		polyline {
-			object {
-				x=102
-				y=686
-				width=13
-				height=2
-			}
-			"basic attribute" {
-				clr=53
-				fill="outline"
-				width=2
-			}
-			points {
-				(103,687)
-				(114,687)
-			}
-		}
-		polyline {
-			object {
-				x=102
-				y=693
-				width=12
-				height=2
-			}
-			"basic attribute" {
-				clr=53
-				fill="outline"
-				width=2
-			}
-			points {
-				(103,694)
-				(113,694)
-			}
-		}
-	}
-}
-composite {
-	object {
-		x=102
-		y=713
-		width=19
-		height=13
-	}
-	"composite name"=""
-	children {
-		polyline {
-			object {
-				x=102
-				y=713
-				width=19
-				height=2
-			}
-			"basic attribute" {
-				clr=53
-				fill="outline"
-				width=2
-			}
-			points {
-				(120,714)
-				(103,714)
-			}
-		}
-		polyline {
-			object {
-				x=119
-				y=713
-				width=2
-				height=13
-			}
-			"basic attribute" {
-				clr=53
-				fill="outline"
-				width=2
-			}
-			points {
-				(120,714)
-				(120,725)
-			}
-		}
-		polyline {
-			object {
-				x=112
-				y=713
-				width=2
-				height=12
-			}
-			"basic attribute" {
-				clr=53
-				fill="outline"
-				width=2
-			}
-			points {
-				(113,714)
-				(113,724)
-			}
-		}
-	}
-}
-composite {
-	object {
-		x=102
-		y=734
-		width=13
-		height=19
-	}
-	"composite name"=""
-	children {
-		polyline {
-			object {
-				x=113
-				y=734
-				width=2
-				height=19
-			}
-			"basic attribute" {
-				clr=53
-				fill="outline"
-				width=2
-			}
-			points {
-				(114,752)
-				(114,735)
-			}
-		}
-		polyline {
-			object {
-				x=102
-				y=751
-				width=13
-				height=2
-			}
-			"basic attribute" {
-				clr=53
-				fill="outline"
-				width=2
-			}
-			points {
-				(114,752)
-				(103,752)
-			}
-		}
-		polyline {
-			object {
-				x=103
-				y=744
-				width=12
-				height=2
-			}
-			"basic attribute" {
-				clr=53
-				fill="outline"
-				width=2
-			}
-			points {
-				(114,745)
-				(104,745)
-			}
-		}
-	}
-}
-composite {
-	object {
-		x=102
-		y=762
-		width=19
-		height=13
-	}
-	"composite name"=""
-	children {
-		polyline {
-			object {
-				x=102
-				y=773
-				width=19
-				height=2
-			}
-			"basic attribute" {
-				clr=53
-				fill="outline"
-				width=2
-			}
-			points {
-				(103,774)
-				(120,774)
-			}
-		}
-		polyline {
-			object {
-				x=102
-				y=762
-				width=2
-				height=13
-			}
-			"basic attribute" {
-				clr=53
-				fill="outline"
-				width=2
-			}
-			points {
-				(103,774)
-				(103,763)
-			}
-		}
-		polyline {
-			object {
-				x=109
-				y=763
-				width=2
-				height=12
-			}
-			"basic attribute" {
-				clr=53
-				fill="outline"
-				width=2
-			}
-			points {
-				(110,774)
-				(110,764)
-			}
-		}
-	}
-}
-composite {
-	object {
-		x=10
-		y=785
-		width=368
-		height=20
-	}
-	"composite name"=""
-	children {
 		text {
 			object {
-				x=10
-				y=785
-				width=170
+				x=15
+				y=682
+				width=140
 				height=20
 			}
 			"basic attribute" {
 				clr=14
 			}
-			textix="Output array size"
+			textix="Transform Type"
 		}
-		"text update" {
+		menu {
 			object {
-				x=251
-				y=786
-				width=61
-				height=18
+				x=160
+				y=682
+				width=120
+				height=20
 			}
-			monitor {
-				chan="$(P)$(R)ArraySizeY_RBV"
-				clr=54
-				bclr=4
-			}
-			align="horiz. centered"
-			limits {
+			control {
+				chan="$(P)$(R)Type"
+				clr=14
+				bclr=51
 			}
 		}
-		"text update" {
+		composite {
 			object {
-				x=317
-				y=786
-				width=61
-				height=18
+				x=282
+				y=711
+				width=13
+				height=19
 			}
-			monitor {
-				chan="$(P)$(R)ArraySizeZ_RBV"
-				clr=54
-				bclr=4
-			}
-			align="horiz. centered"
-			limits {
+			"composite name"=""
+			children {
+				polyline {
+					object {
+						x=293
+						y=711
+						width=2
+						height=19
+					}
+					"basic attribute" {
+						clr=53
+						fill="outline"
+						width=2
+					}
+					points {
+						(294,712)
+						(294,729)
+					}
+				}
+				polyline {
+					object {
+						x=282
+						y=711
+						width=13
+						height=2
+					}
+					"basic attribute" {
+						clr=53
+						fill="outline"
+						width=2
+					}
+					points {
+						(294,712)
+						(283,712)
+					}
+				}
+				polyline {
+					object {
+						x=283
+						y=718
+						width=12
+						height=2
+					}
+					"basic attribute" {
+						clr=53
+						fill="outline"
+						width=2
+					}
+					points {
+						(294,719)
+						(284,719)
+					}
+				}
 			}
 		}
-		"text update" {
+		composite {
 			object {
-				x=185
-				y=786
-				width=61
-				height=18
+				x=282
+				y=738
+				width=19
+				height=13
 			}
-			monitor {
-				chan="$(P)$(R)ArraySizeX_RBV"
-				clr=54
-				bclr=4
+			"composite name"=""
+			children {
+				polyline {
+					object {
+						x=282
+						y=738
+						width=19
+						height=2
+					}
+					"basic attribute" {
+						clr=53
+						fill="outline"
+						width=2
+					}
+					points {
+						(283,739)
+						(300,739)
+					}
+				}
+				polyline {
+					object {
+						x=282
+						y=738
+						width=2
+						height=13
+					}
+					"basic attribute" {
+						clr=53
+						fill="outline"
+						width=2
+					}
+					points {
+						(283,739)
+						(283,750)
+					}
+				}
+				polyline {
+					object {
+						x=289
+						y=738
+						width=2
+						height=12
+					}
+					"basic attribute" {
+						clr=53
+						fill="outline"
+						width=2
+					}
+					points {
+						(290,739)
+						(290,749)
+					}
+				}
 			}
-			align="horiz. centered"
-			limits {
+		}
+		composite {
+			object {
+				x=282
+				y=759
+				width=13
+				height=19
+			}
+			"composite name"=""
+			children {
+				polyline {
+					object {
+						x=282
+						y=759
+						width=2
+						height=19
+					}
+					"basic attribute" {
+						clr=53
+						fill="outline"
+						width=2
+					}
+					points {
+						(283,777)
+						(283,760)
+					}
+				}
+				polyline {
+					object {
+						x=282
+						y=776
+						width=13
+						height=2
+					}
+					"basic attribute" {
+						clr=53
+						fill="outline"
+						width=2
+					}
+					points {
+						(283,777)
+						(294,777)
+					}
+				}
+				polyline {
+					object {
+						x=282
+						y=769
+						width=12
+						height=2
+					}
+					"basic attribute" {
+						clr=53
+						fill="outline"
+						width=2
+					}
+					points {
+						(283,770)
+						(293,770)
+					}
+				}
+			}
+		}
+		composite {
+			object {
+				x=282
+				y=787
+				width=19
+				height=13
+			}
+			"composite name"=""
+			children {
+				polyline {
+					object {
+						x=282
+						y=798
+						width=19
+						height=2
+					}
+					"basic attribute" {
+						clr=53
+						fill="outline"
+						width=2
+					}
+					points {
+						(300,799)
+						(283,799)
+					}
+				}
+				polyline {
+					object {
+						x=299
+						y=787
+						width=2
+						height=13
+					}
+					"basic attribute" {
+						clr=53
+						fill="outline"
+						width=2
+					}
+					points {
+						(300,799)
+						(300,788)
+					}
+				}
+				polyline {
+					object {
+						x=292
+						y=788
+						width=2
+						height=12
+					}
+					"basic attribute" {
+						clr=53
+						fill="outline"
+						width=2
+					}
+					points {
+						(293,799)
+						(293,789)
+					}
+				}
+			}
+		}
+		text {
+			object {
+				x=200
+				y=710
+				width=77
+				height=20
+			}
+			"basic attribute" {
+				clr=13
+			}
+			textix="Mirror"
+			align="horiz. right"
+		}
+		text {
+			object {
+				x=200
+				y=735
+				width=77
+				height=20
+			}
+			"basic attribute" {
+				clr=13
+			}
+			textix="Rot90Mirror"
+			align="horiz. right"
+		}
+		text {
+			object {
+				x=200
+				y=760
+				width=77
+				height=20
+			}
+			"basic attribute" {
+				clr=13
+			}
+			textix="Rot180Mirror"
+			align="horiz. right"
+		}
+		text {
+			object {
+				x=200
+				y=785
+				width=77
+				height=20
+			}
+			"basic attribute" {
+				clr=13
+			}
+			textix="Rot270Mirror"
+			align="horiz. right"
+		}
+		text {
+			object {
+				x=20
+				y=710
+				width=77
+				height=20
+			}
+			"basic attribute" {
+				clr=13
+			}
+			textix="None"
+			align="horiz. right"
+		}
+		text {
+			object {
+				x=20
+				y=735
+				width=77
+				height=20
+			}
+			"basic attribute" {
+				clr=13
+			}
+			textix="Rot90"
+			align="horiz. right"
+		}
+		text {
+			object {
+				x=20
+				y=760
+				width=77
+				height=20
+			}
+			"basic attribute" {
+				clr=13
+			}
+			textix="Rot180"
+			align="horiz. right"
+		}
+		text {
+			object {
+				x=20
+				y=785
+				width=77
+				height=20
+			}
+			"basic attribute" {
+				clr=13
+			}
+			textix="Rot270"
+			align="horiz. right"
+		}
+		composite {
+			object {
+				x=102
+				y=711
+				width=13
+				height=19
+			}
+			"composite name"=""
+			children {
+				polyline {
+					object {
+						x=102
+						y=711
+						width=2
+						height=19
+					}
+					"basic attribute" {
+						clr=53
+						fill="outline"
+						width=2
+					}
+					points {
+						(103,712)
+						(103,729)
+					}
+				}
+				polyline {
+					object {
+						x=102
+						y=711
+						width=13
+						height=2
+					}
+					"basic attribute" {
+						clr=53
+						fill="outline"
+						width=2
+					}
+					points {
+						(103,712)
+						(114,712)
+					}
+				}
+				polyline {
+					object {
+						x=102
+						y=718
+						width=12
+						height=2
+					}
+					"basic attribute" {
+						clr=53
+						fill="outline"
+						width=2
+					}
+					points {
+						(103,719)
+						(113,719)
+					}
+				}
+			}
+		}
+		composite {
+			object {
+				x=102
+				y=738
+				width=19
+				height=13
+			}
+			"composite name"=""
+			children {
+				polyline {
+					object {
+						x=102
+						y=738
+						width=19
+						height=2
+					}
+					"basic attribute" {
+						clr=53
+						fill="outline"
+						width=2
+					}
+					points {
+						(120,739)
+						(103,739)
+					}
+				}
+				polyline {
+					object {
+						x=119
+						y=738
+						width=2
+						height=13
+					}
+					"basic attribute" {
+						clr=53
+						fill="outline"
+						width=2
+					}
+					points {
+						(120,739)
+						(120,750)
+					}
+				}
+				polyline {
+					object {
+						x=112
+						y=738
+						width=2
+						height=12
+					}
+					"basic attribute" {
+						clr=53
+						fill="outline"
+						width=2
+					}
+					points {
+						(113,739)
+						(113,749)
+					}
+				}
+			}
+		}
+		composite {
+			object {
+				x=102
+				y=759
+				width=13
+				height=19
+			}
+			"composite name"=""
+			children {
+				polyline {
+					object {
+						x=113
+						y=759
+						width=2
+						height=19
+					}
+					"basic attribute" {
+						clr=53
+						fill="outline"
+						width=2
+					}
+					points {
+						(114,777)
+						(114,760)
+					}
+				}
+				polyline {
+					object {
+						x=102
+						y=776
+						width=13
+						height=2
+					}
+					"basic attribute" {
+						clr=53
+						fill="outline"
+						width=2
+					}
+					points {
+						(114,777)
+						(103,777)
+					}
+				}
+				polyline {
+					object {
+						x=103
+						y=769
+						width=12
+						height=2
+					}
+					"basic attribute" {
+						clr=53
+						fill="outline"
+						width=2
+					}
+					points {
+						(114,770)
+						(104,770)
+					}
+				}
+			}
+		}
+		composite {
+			object {
+				x=102
+				y=787
+				width=19
+				height=13
+			}
+			"composite name"=""
+			children {
+				polyline {
+					object {
+						x=102
+						y=798
+						width=19
+						height=2
+					}
+					"basic attribute" {
+						clr=53
+						fill="outline"
+						width=2
+					}
+					points {
+						(103,799)
+						(120,799)
+					}
+				}
+				polyline {
+					object {
+						x=102
+						y=787
+						width=2
+						height=13
+					}
+					"basic attribute" {
+						clr=53
+						fill="outline"
+						width=2
+					}
+					points {
+						(103,799)
+						(103,788)
+					}
+				}
+				polyline {
+					object {
+						x=109
+						y=788
+						width=2
+						height=12
+					}
+					"basic attribute" {
+						clr=53
+						fill="outline"
+						width=2
+					}
+					points {
+						(110,799)
+						(110,789)
+					}
+				}
+			}
+		}
+		composite {
+			object {
+				x=10
+				y=810
+				width=368
+				height=20
+			}
+			"composite name"=""
+			children {
+				text {
+					object {
+						x=10
+						y=810
+						width=170
+						height=20
+					}
+					"basic attribute" {
+						clr=14
+					}
+					textix="Output array size"
+				}
+				"text update" {
+					object {
+						x=251
+						y=811
+						width=61
+						height=18
+					}
+					monitor {
+						chan="$(P)$(R)ArraySizeY_RBV"
+						clr=54
+						bclr=4
+					}
+					align="horiz. centered"
+					limits {
+					}
+				}
+				"text update" {
+					object {
+						x=317
+						y=811
+						width=61
+						height=18
+					}
+					monitor {
+						chan="$(P)$(R)ArraySizeZ_RBV"
+						clr=54
+						bclr=4
+					}
+					align="horiz. centered"
+					limits {
+					}
+				}
+				"text update" {
+					object {
+						x=185
+						y=811
+						width=61
+						height=18
+					}
+					monitor {
+						chan="$(P)$(R)ArraySizeX_RBV"
+						clr=54
+						bclr=4
+					}
+					align="horiz. centered"
+					limits {
+					}
+				}
 			}
 		}
 	}

--- a/ADApp/pluginSrc/NDPluginDriver.h
+++ b/ADApp/pluginSrc/NDPluginDriver.h
@@ -17,6 +17,7 @@
 #define NDPluginDriverQueueFreeString           "QUEUE_FREE"            /**< (asynInt32,    r/w) Free queue elements */
 #define NDPluginDriverEnableCallbacksString     "ENABLE_CALLBACKS"      /**< (asynInt32,    r/w) Enable callbacks from driver (1=Yes, 0=No) */
 #define NDPluginDriverBlockingCallbacksString   "BLOCKING_CALLBACKS"    /**< (asynInt32,    r/w) Callbacks block (1=Yes, 0=No) */
+#define NDPluginDriverProcessPluginString       "PROCESS_PLUGIN"        /**< (asynInt32,    r/w) Process plugin with last callback array */
 #define NDPluginDriverExecutionTimeString       "EXECUTION_TIME"        /**< (asynFloat64,  r/o) The last execution time (milliseconds) */
 #define NDPluginDriverMinCallbackTimeString     "MIN_CALLBACK_TIME"     /**< (asynFloat64,  r/w) Minimum time between calling processCallbacks 
                                                                          *  to execute plugin code */
@@ -57,9 +58,9 @@ protected:
     int NDPluginDriverQueueFree;
     int NDPluginDriverEnableCallbacks;
     int NDPluginDriverBlockingCallbacks;
+    int NDPluginDriverProcessPlugin;
     int NDPluginDriverExecutionTime;
     int NDPluginDriverMinCallbackTime;
-    #define LAST_NDPLUGIN_PARAM NDPluginDriverMinCallbackTime
 
 private:
     virtual asynStatus setArrayInterrupt(int connect);
@@ -81,8 +82,8 @@ private:
     epicsTimeStamp lastProcessTime;
     int dimsPrev[ND_ARRAY_MAX_DIMS];
     int newQueueSize_;
+    NDArray *pInputArray_;
 };
-#define NUM_NDPLUGIN_PARAMS ((int)(&LAST_NDPLUGIN_PARAM - &FIRST_NDPLUGIN_PARAM + 1))
 
     
 #endif

--- a/ADApp/pluginSrc/NDPluginFile.cpp
+++ b/ADApp/pluginSrc/NDPluginFile.cpp
@@ -874,7 +874,7 @@ asynStatus NDPluginFile::writeInt32(asynUser *pasynUser, epicsInt32 value)
         }
     } else {
         /* This was not a parameter that this driver understands, try the base class */
-        if (function <= LAST_NDPLUGIN_PARAM) status = NDPluginDriver::writeInt32(pasynUser, value);
+        status = NDPluginDriver::writeInt32(pasynUser, value);
     }
     
     /* Do callbacks so higher layers see any changes */
@@ -921,6 +921,7 @@ asynStatus NDPluginFile::writeNDArray(asynUser *pasynUser, void *genericPointer)
   * \param[in] NDArrayAddr asyn port driver address for initial source of NDArray callbacks.
   * \param[in] maxAddr The maximum  number of asyn addr addresses this driver supports. 1 is minimum.
   * \param[in] numParams The number of parameters supported by the derived class calling this constructor.
+  *            No longer used.
   * \param[in] maxBuffers The maximum number of NDArray buffers that the NDArrayPool for this driver is 
   *            allowed to allocate. Set this to -1 to allow an unlimited number of buffers.
   * \param[in] maxMemory The maximum amount of memory that the NDArrayPool for this driver is 
@@ -942,7 +943,7 @@ NDPluginFile::NDPluginFile(const char *portName, int queueSize, int blockingCall
      * This driver can block (because writing a file can be slow), and it is not multi-device.  
      * Set autoconnect to 1.  priority and stacksize can be 0, which will use defaults. */
     : NDPluginDriver(portName, queueSize, blockingCallbacks, 
-                     NDArrayPort, NDArrayAddr, maxAddr, numParams+NUM_NDPLUGIN_FILE_PARAMS, maxBuffers, maxMemory, 
+                     NDArrayPort, NDArrayAddr, maxAddr, 0, maxBuffers, maxMemory, 
                      asynGenericPointerMask, asynGenericPointerMask,
                      asynFlags, autoConnect, priority, stackSize),
     pCapture(NULL), captureBufferSize(0)

--- a/ADApp/pluginSrc/NDPluginFile.h
+++ b/ADApp/pluginSrc/NDPluginFile.h
@@ -89,6 +89,4 @@ private:
                                       *  Used to check against changes in incoming frames dimensions or datatype */
 };
 
-#define NUM_NDPLUGIN_FILE_PARAMS 0
-    
 #endif

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,6 +19,29 @@ files respectively, in the configure/ directory of the appropriate release of th
 
 Release Notes
 =============
+R2-7 (March XXX, 2017)
+======================
+
+### NDPluginDriver, NDPluginBase.template, NDPluginBase.adl
+* Added new parameter NDPluginProcessPlugin and new bo record ProcessPlugin.  NDPlugDriver now stores
+  the last NDArray it receives.  If the ProcessPlugin record is processed then the plugin will execute
+  again with this last NDArray.  This allows modifying plugin behaviour and observing the results
+  without required the underlying detector to collect another NDArray.  If the plugin is disabled then
+  the NDArray is released and returned to the pool.
+
+### Viewers/ImageJ/EPICS_AD_Viewer.java 
+* Previously this ImageJ plugin monitored the UniqueId_RBV PV in the NDPluginStdArrays plugin, 
+  and read the new image from this plugin when UniqueId_RBV changed.  
+  However, this does not work correctly with the new ProcessPlugin feature in NDPluginDriver, 
+  because that does not increment the UniqueId.
+  EPICS_AD_Viewer.java was changed so that it now monitors the ArrayCounter_RBV PV in NDPluginStdArrays
+  rather than UniqueId_RBV.  ArrayCounter_RBV will increment every time the plugin receives 
+  a new NDArray, which fixes the problem.  
+  Note that ArrayCounter_RBV will also change if the user manually changes ArrayCounter, for example by
+  setting it back to 0.  This will also cause ImageJ to display the image, when it would not have done 
+  so previously.  This should not be a problem.
+
+
 R2-6 (February 19, 2017)
 ========================
 

--- a/documentation/pluginDoc.html
+++ b/documentation/pluginDoc.html
@@ -300,6 +300,28 @@
       <tr>
         <td>
           NDPluginDriver<br />
+          ProcessPlugin</td>
+        <td>
+          asynInt32</td>
+        <td>
+          r/w</td>
+        <td>
+          NDPluginDriver maintains a pointer to the last NDArray that the plugin received.
+          If the ProcessPlugin record is processed then the plugin runs again using this same
+          NDArray. This can be used to change the plugin parameters and observe the effects
+          on downstream plugins and image viewers without requiring the underlying detector
+          to collect another NDArray. When the plugin is disabled the cached NDArray is released
+          back to the NDArrayPool.</td>
+        <td>
+          PROCESS_PLUGIN</td>
+        <td>
+          $(P)$(R)ProcessPlugin</td>
+        <td>
+          bo</td>
+      </tr>
+      <tr>
+        <td>
+          NDPluginDriver<br />
           ExecutionTime</td>
         <td>
           asynFloat64</td>
@@ -368,12 +390,11 @@
         <td>
           N/A</td>
         <td>
-          <td>
-            N/A</td>
-          <td>
-            $(P)$(R)AsynIO</td>
-          <td>
-            asyn</td>
+          N/A</td>
+        <td>
+          $(P)$(R)AsynIO</td>
+        <td>
+          asyn</td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
This pull request addresses issue #249 .

The NDPluginDriver base class now stores a pointer to the last NDArray it received.  There is a new ProcessPlugin parameter and record.  When the plugin receives the ProcessPlugin command it executes again with the previous NDArray input.  

All plugin medm screens are changed to be 25 pixels taller to display the new ProcessPlugin PV.

When a plugin reprocesses it does not change the UniqueId of the NDArray.  This resulted in the ImageJ viewer not displaying the image, because it was trigggered by the UniqueID PV in the NDPluginStdArrays plugin.  This was fixed by changing the ImageJ viewer to trigger on the ArrayCounter PV in the NDPluginStdArrays plugin instead of UniqueID.

Removed the parameter counting in NDPluginDriver, which is a nice feature of ADCore R2-6, but one which  has not be used yet.  This required a change to the NDPluginFile PV, which was really misusing the counter from NDPluginDriver.
