### PR TITLE
Support for newer versions of Boost and static link of Boost Test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: required
 language: cpp
 compiler: gcc
 

--- a/ADApp/pluginTests/Makefile
+++ b/ADApp/pluginTests/Makefile
@@ -52,7 +52,6 @@ ifeq ($(WITH_BOOST),YES)
   # Add tests for new plugins like this:
   #plugin-test_SRCS += test_<plugin name>.cpp
   
-  plugin-test_LIBS += ADTestUtility
   ifdef BOOST_LIB
     boost_unit_test_framework_DIR=$(BOOST_LIB)
     plugin-test_LIBS += boost_unit_test_framework
@@ -60,11 +59,18 @@ ifeq ($(WITH_BOOST),YES)
     plugin-test_SYS_LIBS += boost_unit_test_framework
   endif
 
+  # Link order matters when doing a static build
+  plugin-test_LIBS += ADTestUtility
+
   USR_INCLUDES += $(HDF5_INCLUDE)
   USR_INCLUDES += $(SZ_INCLUDE)
   USR_INCLUDES += $(XML2_INCLUDE)
   USR_INCLUDES += $(BOOST_INCLUDE)
 
+  ifeq ($(BOOST_USE_STATIC_LINK),YES)
+	USR_CXXFLAGS_Linux += -DBOOST_USE_STATIC_LINK
+	USR_CFLAGS_Linux += -DBOOST_USE_STATIC_LINK
+  endif
 endif
 
 ifeq ($(WITH_HDF5),YES)

--- a/ADApp/pluginTests/plugin-test.cpp
+++ b/ADApp/pluginTests/plugin-test.cpp
@@ -7,8 +7,9 @@
  *  Author: Ulrik Kofoed Pedersen, Diamond Light Source.
  *          20. March 2015
  */
-
+#ifndef BOOST_USE_STATIC_LINK
 #define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE "NDPlugin Tests"
 #include <boost/test/unit_test.hpp>
 

--- a/ADApp/pluginTests/testingutilities.h
+++ b/ADApp/pluginTests/testingutilities.h
@@ -8,6 +8,11 @@
 #ifndef ADAPP_PLUGINTESTS_TESTINGUTILITIES_H_
 #define ADAPP_PLUGINTESTS_TESTINGUTILITIES_H_
 
+// Newer version of boost requires this:
+#if BOOST_VERSION > 105300
+#define BOOST_MESSAGE(msg) BOOST_TEST_MESSAGE(msg)
+#endif
+
 #include <deque>
 #include <string>
 #include <vector>


### PR DESCRIPTION
Here at SLAC we are using Boost 1.63.0 for our development and also static build for deployment.

When trying to build the tests we noticed some issues regarding the order of the libraries that are resolved with the changes on this pull request.

This PR also adds "sudo: required" to .travis.yml which is required to install packages.

See also PR at areaDetector repo: https://github.com/areaDetector/areaDetector/pull/23