### PR TITLE
add LZF and bitshuffle+lz4 compression

### DIFF
--- a/ADApp/Db/NDFileHDF5.template
+++ b/ADApp/Db/NDFileHDF5.template
@@ -477,6 +477,10 @@ record(mbbo, "$(P)$(R)Compression")
     field(TWVL, "2")
     field(THST, "zlib")
     field(THVL, "3")
+    field(FRST, "lzf")
+    field(FRVL, "4")
+    field(FVST, "bshuf")
+    field(FVVL, "5")
     info(autosaveFields, "VAL")
 }
 
@@ -494,6 +498,10 @@ record(mbbi, "$(P)$(R)Compression_RBV")
     field(TWVL, "2")
     field(THST, "zlib")
     field(THVL, "3")
+    field(FRST, "lzf")
+    field(FRVL, "4")
+    field(FVST, "bshuf")
+    field(FVVL, "5")
 }
 
 record(longout, "$(P)$(R)NumDataBits")


### PR DESCRIPTION
Both these two filters claim fast compression. This could be useful for fast detectors.

A preliminary setup with simDetector creating 1024x1024 int32 image at 100 Hz (400MB/s), and HDF5 plugin writing to a ramdisk. With bitshuffle+lz4, the writing speed is as fast as no compression.

