### PR TITLE
add support of blosc filter

### DIFF
--- a/ADApp/Db/NDFileHDF5.template
+++ b/ADApp/Db/NDFileHDF5.template
@@ -477,6 +477,8 @@ record(mbbo, "$(P)$(R)Compression")
     field(TWVL, "2")
     field(THST, "zlib")
     field(THVL, "3")
+    field(FRST, "blosc")
+    field(FRVL, "4")
     info(autosaveFields, "VAL")
 }
 
@@ -494,6 +496,8 @@ record(mbbi, "$(P)$(R)Compression_RBV")
     field(TWVL, "2")
     field(THST, "zlib")
     field(THVL, "3")
+    field(FRST, "blosc")
+    field(FRVL, "4")
 }
 
 record(longout, "$(P)$(R)NumDataBits")
@@ -562,6 +566,88 @@ record(longin, "$(P)$(R)ZLevel_RBV")
 {
     field(DTYP, "asynInt32")
     field(INP, "@asyn($(PORT),0)HDF5_zCompressLevel")
+    field(PINI, "NO")
+    field(SCAN, "I/O Intr")
+}
+
+record(mbbo, "$(P)$(R)BloscShuffle")
+{
+    field(DTYP, "asynInt32")
+    field(OUT, "@asyn($(PORT),0)HDF5_bloscShuffleType")
+    field(ZRST, "None")
+    field(ZRVL, "0")
+    field(ONST, "ByteShuffle")
+    field(ONVL, "1")
+    field(TWST, "BitShuffle")
+    field(TWVL, "2")
+    info(autosaveFields, "VAL")
+}
+
+record(mbbi, "$(P)$(R)BloscShuffle_RBV")
+{
+    field(DTYP, "asynInt32")
+    field(INP, "@asyn($(PORT),0)HDF5_bloscShuffleType")
+    field(PINI, "NO")
+    field(SCAN, "I/O Intr")
+    field(ZRST, "None")
+    field(ZRVL, "0")
+    field(ONST, "ByteShuffle")
+    field(ONVL, "1")
+    field(TWST, "BitShuffle")
+    field(TWVL, "2")
+}
+
+record(mbbo, "$(P)$(R)BloscCompressor")
+{
+    field(DTYP, "asynInt32")
+    field(OUT, "@asyn($(PORT),0)HDF5_bloscCompressor")
+    field(ZRST, "blosclz")
+    field(ZRVL, "0")
+    field(ONST, "lz4")
+    field(ONVL, "1")
+    field(TWST, "lz4hc")
+    field(TWVL, "2")
+    field(THST, "snappy")
+    field(THVL, "3")
+    field(FRST, "zlib")
+    field(FRVL, "4")
+    field(FVST, "zstd")
+    field(FVVL, "5")
+    info(autosaveFields, "VAL")
+}
+
+record(mbbi, "$(P)$(R)BloscCompressor_RBV")
+{
+    field(DTYP, "asynInt32")
+    field(INP, "@asyn($(PORT),0)HDF5_bloscCompressor")
+    field(PINI, "NO")
+    field(SCAN, "I/O Intr")
+    field(ZRST, "blosclz")
+    field(ZRVL, "0")
+    field(ONST, "lz4")
+    field(ONVL, "1")
+    field(TWST, "lz4hc")
+    field(TWVL, "2")
+    field(THST, "snappy")
+    field(THVL, "3")
+    field(FRST, "zlib")
+    field(FRVL, "4")
+    field(FVST, "zstd")
+    field(FVVL, "5")
+}
+
+record(longout, "$(P)$(R)BloscLevel")
+{
+    field(DTYP, "asynInt32")
+    field(OUT, "@asyn($(PORT),0)HDF5_bloscCompressLevel")
+    field(PINI, "NO")
+    info(autosaveFields, "VAL")
+}
+
+record(longin, "$(P)$(R)BloscLevel_RBV")
+{
+    field(DTYP, "asynInt32")
+    field(INP, "@asyn($(PORT),0)HDF5_bloscCompressLevel")
     field(PINI, "NO")
     field(SCAN, "I/O Intr")
 }

--- a/ADApp/Db/NDFileHDF5_settings.req
+++ b/ADApp/Db/NDFileHDF5_settings.req
@@ -9,6 +9,9 @@ $(P)$(R)NumDataBits
 $(P)$(R)DataBitsOffset
 $(P)$(R)SZipNumPixels
 $(P)$(R)ZLevel
+$(P)$(R)BloscShuffle
+$(P)$(R)BloscCompressor
+$(P)$(R)BloscLevel
 $(P)$(R)StorePerform
 $(P)$(R)StoreAttr
 $(P)$(R)NumExtraDims

--- a/ADApp/op/adl/NDFileHDF5.adl
+++ b/ADApp/op/adl/NDFileHDF5.adl
@@ -1,7 +1,7 @@
 
 file {
-	name="/home/epics/devel/areaDetector-2-6/ADCore/ADApp/op/adl/NDFileHDF5.adl"
-	version=030109
+	name="/home/scratch/areaDetector-git/ADCore/ADApp/op/adl/NDFileHDF5.adl"
+	version=030105
 }
 display {
 	object {
@@ -140,7 +140,7 @@ composite {
 rectangle {
 	object {
 		x=390
-		y=450
+		y=446
 		width=675
 		height=320
 	}
@@ -876,8 +876,8 @@ composite {
 }
 composite {
 	object {
-		x=800
-		y=595
+		x=823
+		y=586
 		width=155
 		height=20
 	}
@@ -885,8 +885,8 @@ composite {
 	children {
 		text {
 			object {
-				x=800
-				y=595
+				x=823
+				y=586
 				width=40
 				height=20
 			}
@@ -898,8 +898,8 @@ composite {
 		}
 		"related display" {
 			object {
-				x=845
-				y=595
+				x=868
+				y=586
 				width=110
 				height=20
 			}
@@ -1296,4 +1296,153 @@ composite {
 			}
 		}
 	}
+}
+rectangle {
+	object {
+		x=762
+		y=614
+		width=297
+		height=72
+	}
+	"basic attribute" {
+		clr=14
+		fill="outline"
+	}
+}
+text {
+	object {
+		x=767
+		y=663
+		width=90
+		height=18
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Level"
+	align="horiz. right"
+}
+text {
+	object {
+		x=767
+		y=641
+		width=90
+		height=18
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Compressor"
+	align="horiz. right"
+}
+text {
+	object {
+		x=767
+		y=619
+		width=90
+		height=18
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Shuffle"
+	align="horiz. right"
+}
+menu {
+	object {
+		x=862
+		y=641
+		width=95
+		height=20
+	}
+	control {
+		chan="$(P)$(R)BloscCompressor"
+		clr=14
+		bclr=51
+	}
+}
+"text entry" {
+	object {
+		x=862
+		y=663
+		width=95
+		height=20
+	}
+	control {
+		chan="$(P)$(R)BloscLevel"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+menu {
+	object {
+		x=862
+		y=619
+		width=95
+		height=20
+	}
+	control {
+		chan="$(P)$(R)BloscShuffle"
+		clr=14
+		bclr=51
+	}
+}
+"text update" {
+	object {
+		x=965
+		y=619
+		width=90
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)BloscShuffle_RBV"
+		clr=54
+		bclr=4
+	}
+	limits {
+	}
+}
+"text update" {
+	object {
+		x=965
+		y=641
+		width=90
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)BloscCompressor_RBV"
+		clr=54
+		bclr=4
+	}
+	limits {
+	}
+}
+"text update" {
+	object {
+		x=965
+		y=663
+		width=90
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)BloscLevel_RBV"
+		clr=54
+		bclr=4
+	}
+	limits {
+	}
+}
+text {
+	object {
+		x=708
+		y=643
+		width=62
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Blosc"
 }

--- a/ADApp/pluginSrc/NDFileHDF5.h
+++ b/ADApp/pluginSrc/NDFileHDF5.h
@@ -39,6 +39,9 @@
 #define str_NDFileHDF5_nbitsOffset       "HDF5_nbitsOffset"
 #define str_NDFileHDF5_szipNumPixels     "HDF5_szipNumPixels"
 #define str_NDFileHDF5_zCompressLevel    "HDF5_zCompressLevel"
+#define str_NDFileHDF5_bloscShuffleType  "HDF5_bloscShuffleType"
+#define str_NDFileHDF5_bloscCompressor   "HDF5_bloscCompressor"
+#define str_NDFileHDF5_bloscCompressLevel "HDF5_bloscCompressLevel"
 #define str_NDFileHDF5_dimAttDatasets    "HDF5_dimAttDatasets"
 #define str_NDFileHDF5_layoutErrorMsg    "HDF5_layoutErrorMsg"
 #define str_NDFileHDF5_layoutValid       "HDF5_layoutValid"
@@ -141,6 +144,9 @@ class epicsShareClass NDFileHDF5 : public NDPluginFile
     int NDFileHDF5_nbitsOffset;
     int NDFileHDF5_szipNumPixels;
     int NDFileHDF5_zCompressLevel;
+    int NDFileHDF5_bloscCompressor;
+    int NDFileHDF5_bloscCompressLevel;
+    int NDFileHDF5_bloscShuffleType;
     int NDFileHDF5_dimAttDatasets;
     int NDFileHDF5_layoutErrorMsg;
     int NDFileHDF5_layoutValid;


### PR DESCRIPTION
This PR when combined with https://github.com/areaDetector/ADSupport/pull/14, adds support of blosc filter.