### PR TITLE
Removed sseq

### DIFF
--- a/ADApp/Db/NDStats_settings.req
+++ b/ADApp/Db/NDStats_settings.req
@@ -12,6 +12,3 @@ $(P)$(R)HistMax
 $(P)$(R)TSNumPoints
 $(P)$(R)TSRead.SCAN
 file "NDPluginBase_settings.req", P=$(P), R=$(R)
-file "sseq_settings.req", P=$(P), S=$(R)Reset
-file "sseq_settings.req", P=$(P), S=$(R)Reset1
-file "sseq_settings.req", P=$(P), S=$(R)Reset2


### PR DESCRIPTION
This file sseq_settings.req appears to be no longer in the repo. Not sure if it should be removed from the request file or if it needs to be back in. 

This PR stoped the errors on the IOC shell. 