### PR TITLE
Added ifdef __cplusplus extern C

### DIFF
--- a/ADApp/pluginSrc/NDFileJPEG.h
+++ b/ADApp/pluginSrc/NDFileJPEG.h
@@ -9,7 +9,15 @@
 #define DRV_NDFileJPEG_H
 
 #include "NDPluginFile.h"
+
+#ifdef __cplusplus
+// Force C interface for jpeg functions
+extern "C" {
+#endif
 #include "jpeglib.h"
+#ifdef __cplusplus
+}
+#endif
 
 #define JPEG_BUF_SIZE 4096 /* choose an efficiently fwrite'able size */
 


### PR DESCRIPTION
We're using jpeg version 6b, and jpeglib.h doesn't specify extern "C" when included by cplusplus code.
This adds ifdef __cplusplus  extern "C" around the include of jpeglib.h to avoid warnings and build errors.