### PR TITLE
wider field for EPICS name PV

### DIFF
--- a/ADApp/op/adl/ADSetup.adl
+++ b/ADApp/op/adl/ADSetup.adl
@@ -355,7 +355,7 @@ text {
 	object {
 		x=175
 		y=60
-		width=72
+		width=165
 		height=18
 	}
 	"basic attribute" {


### PR DESCRIPTION
field is too narrow when converted to caQtDM .ui file