### PR TITLE
Set severity fields for ArrayCounter, ArrayRate, EnableCallbacks, ...

### DIFF
--- a/ADApp/Db/NDArrayBase.template
+++ b/ADApp/Db/NDArrayBase.template
@@ -591,12 +591,15 @@ record(longin, "$(P)$(R)ArrayCounter_RBV")
     field(DTYP, "asynInt32")
     field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ARRAY_COUNTER")
     field(SCAN, "I/O Intr")
+    field(LOW,  "0" )
+    field(LSV,  "MINOR" )
 }
 
 # Updated rate calculation to use a smoothing factor w/ guard against negative values
+# 0 rate sets alarm state to MINOR
 record(calc, "$(P)$(R)ArrayRate_RBV")
 {
-    field(INPA, "$(P)$(R)ArrayRate_RBV.LB NPP NMS")   # Previous counter value
+    field(INPA, "$(P)$(R)ArrayRate_RBV.LB NPP NMS")   # Previous counter (Last B value)
     field(INPB, "$(P)$(R)ArrayCounter_RBV NPP NMS")   # Current counter value
     field(INPC, "1.0")                                # Delta time in seconds
     field(INPD, "$(P)$(R)ArrayRate_RBV.VAL NPP NMS")  # Previous rate
@@ -605,6 +608,9 @@ record(calc, "$(P)$(R)ArrayRate_RBV")
     field(PREC, "2" )
     field(EGU,  "Hz" )
     field(SCAN, "1 second")
+    field(LOW,  "0")
+    field(LSV,  "MINOR")
+    field(ADEL, "0.1")
 }
 
 ###################################################################

--- a/ADApp/Db/NDFile.template
+++ b/ADApp/Db/NDFile.template
@@ -266,6 +266,8 @@ record(busy, "$(P)$(R)Capture")
     field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))CAPTURE")
     field(ZNAM, "Done")
     field(ONAM, "Capture")
+    field(ZSV,  "NO_ALARM")
+    field(OSV,  "MINOR")
 }
 
 record(bi, "$(P)$(R)Capture_RBV")

--- a/ADApp/Db/NDPluginBase.template
+++ b/ADApp/Db/NDPluginBase.template
@@ -76,8 +76,8 @@ record(bi, "$(P)$(R)EnableCallbacks_RBV")
     field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ENABLE_CALLBACKS")
     field(ZNAM, "Disable")
     field(ONAM, "Enable")
-    field(ZSV,  "NO_ALARM")
-    field(OSV,  "MINOR")
+    field(ZSV,  "MINOR")
+    field(OSV,  "NO_ALARM")
     field(SCAN, "I/O Intr")
 }
 
@@ -144,6 +144,8 @@ record(bi, "$(P)$(R)BlockingCallbacks_RBV")
     field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))BLOCKING_CALLBACKS")
     field(ZNAM, "No")
     field(ONAM, "Yes")
+    field(ZSV,  "NO_ALARM")
+    field(OSV,  "MINOR")
     field(SCAN, "I/O Intr")
 }
 
@@ -161,6 +163,9 @@ record(longin, "$(P)$(R)DroppedArrays_RBV")
     field(DTYP, "asynInt32")
     field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))DROPPED_ARRAYS")
     field(SCAN, "I/O Intr")
+    field(HIGH, "1")
+    field(HSV,  "MINOR")
+    info( autosaveFields, "DESC LOLO LOW HIGH HIHI LLSV LSV HSV HHSV EGU" )
 }
 
 record(longout, "$(P)$(R)QueueSize")


### PR DESCRIPTION
Helps new users to see potential issues w/ their plugins by making all the enabled plugins that are in use and enabled be NO_ALARM, while disabled plugins are in MINOR state.

Not sure if you'll want to merge this as it is the opposite of current usage where enabled plugins are MINOR severity and disabled plugins are NO_ALARM.