### PR TITLE
build qsrv service into IOC

### DIFF
--- a/ADApp/commonDriverMakefile
+++ b/ADApp/commonDriverMakefile
@@ -20,9 +20,11 @@ $(DBD_NAME)_DBD += NDFileNull.dbd
 ifeq ($(WITH_PVA),YES)
   $(DBD_NAME)_DBD += NDPluginPva.dbd
   $(DBD_NAME)_DBD += PVAServerRegister.dbd
+  $(DBD_NAME)_DBD += qsrv.dbd
   PROD_LIBS += ntndArrayConverter
   PROD_LIBS += nt
   PROD_LIBS += pvDatabase
+  PROD_LIBS += qsrv
   ifdef EPICS_BASE_PVA_CORE_LIBS
     PROD_LIBS += $(EPICS_BASE_PVA_CORE_LIBS)
   else


### PR DESCRIPTION
see http://epics-pvdata.sourceforge.net/informative/developerGuide/developerGuide.html

qsrv allows clients to get, put and monitor V3 PVs (fields of EPICS DB records) via pvAccess.