### PR TITLE
Count number of NDArrays queued or processing in plugins

### DIFF
--- a/ADApp/ADSrc/ADDriver.cpp
+++ b/ADApp/ADSrc/ADDriver.cpp
@@ -100,7 +100,7 @@ ADDriver::ADDriver(const char *portName, int maxAddr, int numParams, int maxBuff
                    int interfaceMask, int interruptMask,
                    int asynFlags, int autoConnect, int priority, int stackSize)
 
-    : asynNDArrayDriver(portName, maxAddr, maxBuffers, maxMemory,
+    : asynNDArrayDriver(portName, maxAddr, true, maxMemory,
           interfaceMask | asynInt32Mask | asynFloat64Mask | asynOctetMask | asynGenericPointerMask | asynDrvUserMask,
           interruptMask | asynInt32Mask | asynFloat64Mask | asynOctetMask | asynGenericPointerMask,
           asynFlags, autoConnect, priority, stackSize)

--- a/ADApp/ADSrc/ADDriver.cpp
+++ b/ADApp/ADSrc/ADDriver.cpp
@@ -100,7 +100,7 @@ ADDriver::ADDriver(const char *portName, int maxAddr, int numParams, int maxBuff
                    int interfaceMask, int interruptMask,
                    int asynFlags, int autoConnect, int priority, int stackSize)
 
-    : asynNDArrayDriver(portName, maxAddr, true, maxMemory,
+    : asynNDArrayDriver(portName, maxAddr, maxBuffers, maxMemory,
           interfaceMask | asynInt32Mask | asynFloat64Mask | asynOctetMask | asynGenericPointerMask | asynDrvUserMask,
           interruptMask | asynInt32Mask | asynFloat64Mask | asynOctetMask | asynGenericPointerMask,
           asynFlags, autoConnect, priority, stackSize)

--- a/ADApp/ADSrc/ADDriver.h
+++ b/ADApp/ADSrc/ADDriver.h
@@ -190,9 +190,7 @@ protected:
     int ADReadStatus;
     int ADStatusMessage;
     int ADStringToServer;
-    int ADStringFromServer; 
-    #define LAST_AD_PARAM ADStringFromServer   
+    int ADStringFromServer;
 };
-#define NUM_AD_PARAMS ((int)(&LAST_AD_PARAM - &FIRST_AD_PARAM + 1))
 
 #endif

--- a/ADApp/ADSrc/NDArray.h
+++ b/ADApp/ADSrc/NDArray.h
@@ -91,6 +91,7 @@ class epicsShareClass NDArray {
 public:
     /* Methods */
     NDArray();
+    NDArray(int ndims, size_t *dims, NDDataType_t dataType, size_t dataSize, void *pData);
     ~NDArray();
     int          initDimension   (NDDimension_t *pDimension, size_t size);
     int          getInfo         (NDArrayInfo_t *pInfo);
@@ -104,7 +105,8 @@ private:
     int          referenceCount;    /**< Reference count for this NDArray=number of clients who are using it */
 
 public:
-    class NDArrayPool *pNDArrayPool; /**< The NDArrayPool object that created this array */
+    class NDArrayPool *pNDArrayPool;  /**< The NDArrayPool object that created this array */
+    class asynNDArrayDriver *pDriver; /**< The asynNDArrayDriver that created this array */
     int           uniqueId;     /**< A number that must be unique for all NDArrays produced by a driver after is has started */
     double        timeStamp;    /**< The time stamp in seconds for this array; seconds since EPICS epoch (00:00:00 UTC, January 1, 1990)
                                   * is recommended, but some drivers may use a different start time.*/
@@ -130,7 +132,7 @@ public:
   */
 class epicsShareClass NDArrayPool {
 public:
-    NDArrayPool  (int maxBuffers, size_t maxMemory);
+    NDArrayPool  (class asynNDArrayDriver *pDriver, size_t maxMemory);
     NDArray*     alloc     (int ndims, size_t *dims, NDDataType_t dataType, size_t dataSize, void *pData);
     NDArray*     copy      (NDArray *pIn, NDArray *pOut, int copyData);
 
@@ -144,19 +146,18 @@ public:
                             NDArray **ppOut,
                             NDDataType_t dataTypeOut);
     int          report     (FILE  *fp, int details);
-    int          maxBuffers ();
-    int          numBuffers ();
-    size_t       maxMemory  ();
-    size_t       memorySize ();
-    int          numFree    ();
+    int          getNumBuffers ();
+    size_t       getMaxMemory  ();
+    size_t       getMemorySize ();
+    int          getNumFree    ();
 private:
     ELLLIST      freeList_;      /**< Linked list of free NDArray objects that form the pool */
     epicsMutexId listLock_;      /**< Mutex to protect the free list */
-    int          maxBuffers_;    /**< Maximum number of buffers this object is allowed to allocate; -1=unlimited */
-    int          numBuffers_;    /**< Number of buffers this object has currently allocated */
+    int          numBuffers_;
     size_t       maxMemory_;     /**< Maximum bytes of memory this object is allowed to allocate; -1=unlimited */
     size_t       memorySize_;    /**< Number of bytes of memory this object has currently allocated */
     int          numFree_;       /**< Number of NDArray objects in the free list */
+    class asynNDArrayDriver *pDriver_; /**< The asynNDArrayDriver that created this object */
 };
 
 #endif

--- a/ADApp/ADSrc/NDArrayPool.cpp
+++ b/ADApp/ADSrc/NDArrayPool.cpp
@@ -29,12 +29,12 @@ volatile int eraseNDAttributes=0;
 extern "C" {epicsExportAddress(int, eraseNDAttributes);}
 
 /** NDArrayPool constructor
-  * \param[in] maxBuffers Maximum number of NDArray objects that the pool is allowed to contain; 0=unlimited.
+  * \param[in] pDriver Pointer to the asynNDArrayDriver that created this object.
   * \param[in] maxMemory Maxiumum number of bytes of memory the the pool is allowed to use, summed over
   * all of the NDArray objects; 0=unlimited.
   */
-NDArrayPool::NDArrayPool(int maxBuffers, size_t maxMemory)
-  : maxBuffers_(maxBuffers), numBuffers_(0), maxMemory_(maxMemory), memorySize_(0), numFree_(0)
+NDArrayPool::NDArrayPool(class asynNDArrayDriver *pDriver, size_t maxMemory)
+  : numBuffers_(0), maxMemory_(maxMemory), memorySize_(0), numFree_(0), pDriver_(pDriver)
 {
   ellInit(&freeList_);
   listLock_ = epicsMutexCreate();
@@ -53,8 +53,7 @@ NDArrayPool::NDArrayPool(int maxBuffers, size_t maxMemory)
   * array, and this array must be large enough to hold the array data. 
   * alloc() searches
   * its free list to find a free NDArray buffer. If is cannot find one then it will
-  * allocate a new one and add it to the free list. If doing so would exceed maxBuffers
-  * then alloc() will return an error. Similarly if allocating the memory required for
+  * allocate a new one and add it to the free list. If allocating the memory required for
   * this NDArray would cause the cumulative memory allocated for the pool to exceed
   * maxMemory then an error will be returned. alloc() sets the reference count for the
   * returned NDArray to 1.
@@ -72,23 +71,18 @@ NDArray* NDArrayPool::alloc(int ndims, size_t *dims, NDDataType_t dataType, size
   pArray = (NDArray *)ellFirst(&freeList_);
 
   if (!pArray) {
-    /* We did not find a free image.
-     * Allocate a new one if we have not exceeded the limit */
-    if ((maxBuffers_ > 0) && (numBuffers_ >= maxBuffers_)) {
-      printf("%s: error: reached limit of %d buffers (memory use=%ld/%ld bytes)\n",
-             functionName, maxBuffers_, (long)memorySize_, (long)maxMemory_);
-    } else {
-      numBuffers_++;
-      pArray = new NDArray;
-      ellAdd(&freeList_, &pArray->node);
-      numFree_++;
-    }
+    /* We did not find a free image, allocate a new one */
+    numBuffers_++;
+    pArray = new NDArray;
+    ellAdd(&freeList_, &pArray->node);
+    numFree_++;
   }
 
   if (pArray) {
     /* We have a frame */
     /* Initialize fields */
     pArray->pNDArrayPool = this;
+    pArray->pDriver = pDriver_;
     pArray->dataType = dataType;
     pArray->ndims = ndims;
     memset(pArray->dims, 0, sizeof(pArray->dims));
@@ -140,8 +134,8 @@ NDArray* NDArrayPool::alloc(int ndims, size_t *dims, NDDataType_t dataType, size
           }
         }
         if ((maxMemory_ > 0) && ((memorySize_ + dataSize) > maxMemory_)) {
-          printf("%s: error: reached limit of %ld memory (%d/%d buffers)\n",
-                 functionName, (long)maxMemory_, numBuffers_, maxBuffers_);
+          printf("%s: error: reached limit of %ld memory (%d buffers)\n",
+                 functionName, (long)maxMemory_, numBuffers_);
           pArray = NULL;
         } else {
           pArray->pData = malloc(dataSize);
@@ -599,32 +593,26 @@ int NDArrayPool::convert(NDArray *pIn,
   return ND_SUCCESS;
 }
 
-/** Returns maximum number of buffers this object is allowed to allocate; 0=unlimited */
-int NDArrayPool::maxBuffers()
-{  
-return maxBuffers_;
-}
-
 /** Returns number of buffers this object has currently allocated */
-int NDArrayPool::numBuffers()
+int NDArrayPool::getNumBuffers()
 {  
 return numBuffers_;
 }
 
 /** Returns maximum bytes of memory this object is allowed to allocate; 0=unlimited */
-size_t NDArrayPool::maxMemory()
+size_t NDArrayPool::getMaxMemory()
 {  
 return maxMemory_;
 }
 
 /** Returns mumber of bytes of memory this object has currently allocated */
-size_t NDArrayPool::memorySize()
+size_t NDArrayPool::getMemorySize()
 {
   return memorySize_;
 }
 
 /** Returns number of NDArray objects in the free list */
-int NDArrayPool::numFree()
+int NDArrayPool::getNumFree()
 {
   return numFree_;
 }
@@ -638,12 +626,10 @@ int NDArrayPool::report(FILE *fp, int details)
 {
   fprintf(fp, "\n");
   fprintf(fp, "NDArrayPool:\n");
-  fprintf(fp, "  numBuffers=%d, maxBuffers=%d\n",
-         numBuffers_, maxBuffers_);
+  fprintf(fp, "  numBuffers=%d, numFree=%d\n",
+         numBuffers_, numFree_);
   fprintf(fp, "  memorySize=%ld, maxMemory=%ld\n",
         (long)memorySize_, (long)maxMemory_);
-  fprintf(fp, "  numFree=%d\n",
-         numFree_);
       
   return ND_SUCCESS;
 }

--- a/ADApp/ADSrc/asynNDArrayDriver.cpp
+++ b/ADApp/ADSrc/asynNDArrayDriver.cpp
@@ -573,7 +573,7 @@ asynStatus asynNDArrayDriver::readGenericPointer(asynUser *pasynUser, void *gene
                     driverName, functionName, pArray->pData);
         status = asynError;
     } else {
-        this->pNDArrayPool->copy(myArray, pArray, 0);
+        myArray->pNDArrayPool->copy(myArray, pArray, 0);
         myArray->getInfo(&arrayInfo);
         if (arrayInfo.totalBytes > pArray->dataSize) arrayInfo.totalBytes = pArray->dataSize;
         memcpy(pArray->pData, myArray->pData, arrayInfo.totalBytes);
@@ -609,12 +609,10 @@ asynStatus asynNDArrayDriver::readInt32(asynUser *pasynUser, epicsInt32 *value)
     asynStatus status = asynSuccess;
 
     // Just read the status of the NDArrayPool
-    if (function == NDPoolMaxBuffers) {
-        setIntegerParam(function, this->pNDArrayPool->maxBuffers());
-    } else if (function == NDPoolAllocBuffers) {
-        setIntegerParam(function, this->pNDArrayPool->numBuffers());
-    } else if (function == NDPoolFreeBuffers) {
-        setIntegerParam(function, this->pNDArrayPool->numFree());
+    if (function == NDPoolAllocBuffers && this->pNDArrayPool) {
+        setIntegerParam(function, this->pNDArrayPool->getNumBuffers());
+    } else if (function == NDPoolFreeBuffers && this->pNDArrayPool) {
+        setIntegerParam(function, this->pNDArrayPool->getNumFree());
     }
 
     // Call base class
@@ -629,10 +627,10 @@ asynStatus asynNDArrayDriver::readFloat64(asynUser *pasynUser, epicsFloat64 *val
     asynStatus status = asynSuccess;
 
     // Just read the status of the NDArrayPool
-    if (function == NDPoolMaxMemory) {
-        setDoubleParam(function, this->pNDArrayPool->maxMemory() / MEGABYTE_DBL);
-    } else if (function == NDPoolUsedMemory) {
-        setDoubleParam(function, this->pNDArrayPool->memorySize() / MEGABYTE_DBL);
+    if (function == NDPoolMaxMemory && this->pNDArrayPool) {
+        setDoubleParam(function, this->pNDArrayPool->getMaxMemory() / MEGABYTE_DBL);
+    } else if (function == NDPoolUsedMemory && this->pNDArrayPool) {
+        setDoubleParam(function, this->pNDArrayPool->getMemorySize() / MEGABYTE_DBL);
     }
 
     // Call base class
@@ -665,6 +663,33 @@ void asynNDArrayDriver::report(FILE *fp, int details)
     }
 }
 
+asynStatus asynNDArrayDriver::incrementPluginCount() {
+	int pluginCount;
+	
+	getIntegerParam(NDNumActivePlugins, &pluginCount);
+	pluginCount++;
+	setIntegerParam(NDNumActivePlugins, pluginCount);
+	callParamCallbacks();
+	return asynSuccess;
+}
+
+asynStatus asynNDArrayDriver::decrementPluginCount() {
+	static const char *functionName = "decrementPluginCount";
+	int pluginCount;
+
+	getIntegerParam(NDNumActivePlugins, &pluginCount);
+	if (pluginCount <= 0) {
+		asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, 
+		"%s::%s error, numActivePlugins already 0 or less (%d)\n",
+		driverName, functionName, pluginCount);
+	    return asynError;
+	}
+	pluginCount--;
+	setIntegerParam(NDNumActivePlugins, pluginCount);
+	callParamCallbacks();
+	return asynSuccess;
+}
+
 
 /** This is the constructor for the asynNDArrayDriver class.
   * portName, maxAddr, interfaceMask, interruptMask, asynFlags, autoConnect, priority and stackSize
@@ -687,14 +712,14 @@ void asynNDArrayDriver::report(FILE *fp, int details)
   *            This value should also be used for any other threads this object creates.
   */
 
-asynNDArrayDriver::asynNDArrayDriver(const char *portName, int maxAddr, int maxBuffers,
+asynNDArrayDriver::asynNDArrayDriver(const char *portName, int maxAddr, bool isDriver,
                                      size_t maxMemory, int interfaceMask, int interruptMask,
                                      int asynFlags, int autoConnect, int priority, int stackSize)
     : asynPortDriver(portName, maxAddr, 
                      interfaceMask | asynInt32Mask | asynFloat64Mask | asynOctetMask | asynInt32ArrayMask | asynGenericPointerMask | asynDrvUserMask, 
                      interruptMask | asynInt32Mask | asynFloat64Mask | asynOctetMask | asynInt32ArrayMask | asynGenericPointerMask,
                      asynFlags, autoConnect, priority, stackSize),
-      pNDArrayPool(NULL)
+      pNDArrayPool(0)
 {
     char versionString[20];
 
@@ -704,7 +729,9 @@ asynNDArrayDriver::asynNDArrayDriver(const char *portName, int maxAddr, int maxB
     if (priority <= 0) priority = epicsThreadPriorityMedium;
     threadPriority_ = priority;
 
-    this->pNDArrayPool = new NDArrayPool(maxBuffers, maxMemory);
+    if (isDriver) {
+        this->pNDArrayPool = new NDArrayPool(this, maxMemory);
+    }
 
     /* Allocate pArray pointer array */
     this->pArrays = (NDArray **)calloc(maxAddr, sizeof(NDArray *));
@@ -758,6 +785,7 @@ asynNDArrayDriver::asynNDArrayDriver(const char *portName, int maxAddr, int maxB
     createParam(NDPoolFreeBuffersString,      asynParamInt32,           &NDPoolFreeBuffers);
     createParam(NDPoolMaxMemoryString,        asynParamFloat64,         &NDPoolMaxMemory);
     createParam(NDPoolUsedMemoryString,       asynParamFloat64,         &NDPoolUsedMemory);
+    createParam(NDNumActivePluginsString,     asynParamInt32,           &NDNumActivePlugins);
 
     /* Here we set the values of read-only parameters and of read/write parameters that cannot
      * or should not get their values from the database.  Note that values set here will override
@@ -804,16 +832,24 @@ asynNDArrayDriver::asynNDArrayDriver(const char *portName, int maxAddr, int maxB
     setIntegerParam(NDAttributesStatus, NDAttributesFileNotFound);
     setStringParam (NDAttributesMacros, "");
 
-    setIntegerParam(NDPoolMaxBuffers, this->pNDArrayPool->maxBuffers());
-    setIntegerParam(NDPoolAllocBuffers, this->pNDArrayPool->numBuffers());
-    setIntegerParam(NDPoolFreeBuffers, this->pNDArrayPool->numFree());
+    if (this->pNDArrayPool) {
+        setIntegerParam(NDPoolAllocBuffers, this->pNDArrayPool->getNumBuffers());
+        setIntegerParam(NDPoolFreeBuffers, this->pNDArrayPool->getNumFree());
+    } else {
+        setIntegerParam(NDPoolAllocBuffers, 0);
+        setIntegerParam(NDPoolFreeBuffers, 0);
+        setDoubleParam(NDPoolMaxMemory, 0);
+        setDoubleParam(NDPoolUsedMemory, 0);
+    }
+
+    setIntegerParam(NDNumActivePlugins, 0);
 
 }
 
 
 asynNDArrayDriver::~asynNDArrayDriver()
 { 
-    delete this->pNDArrayPool;
+    if (this->pNDArrayPool) delete this->pNDArrayPool;
     free(this->pArrays);
     delete this->pAttributeList;
 }    

--- a/ADApp/ADSrc/asynNDArrayDriver.cpp
+++ b/ADApp/ADSrc/asynNDArrayDriver.cpp
@@ -724,7 +724,7 @@ asynNDArrayDriver::asynNDArrayDriver(const char *portName, int maxAddr, bool isD
                      interfaceMask | asynInt32Mask | asynFloat64Mask | asynOctetMask | asynInt32ArrayMask | asynGenericPointerMask | asynDrvUserMask, 
                      interruptMask | asynInt32Mask | asynFloat64Mask | asynOctetMask | asynInt32ArrayMask | asynGenericPointerMask,
                      asynFlags, autoConnect, priority, stackSize),
-      pNDArrayPool(0), pluginCountMutex_(0)
+      pNDArrayPool(0), isDriver_(isDriver), pluginCountMutex_(0)
 {
     char versionString[20];
 
@@ -734,7 +734,7 @@ asynNDArrayDriver::asynNDArrayDriver(const char *portName, int maxAddr, bool isD
     if (priority <= 0) priority = epicsThreadPriorityMedium;
     threadPriority_ = priority;
 
-    if (isDriver) {
+    if (isDriver_) {
         this->pNDArrayPool = new NDArrayPool(this, maxMemory);
         this->pluginCountMutex_ = new epicsMutex();
     }
@@ -855,7 +855,7 @@ asynNDArrayDriver::asynNDArrayDriver(const char *portName, int maxAddr, bool isD
 
 asynNDArrayDriver::~asynNDArrayDriver()
 { 
-    if (this->pNDArrayPool) delete this->pNDArrayPool;
+    if (isDriver_ && this->pNDArrayPool) delete this->pNDArrayPool;
     free(this->pArrays);
     delete this->pAttributeList;
     if (this->pluginCountMutex_) delete this->pluginCountMutex_;

--- a/ADApp/ADSrc/asynNDArrayDriver.h
+++ b/ADApp/ADSrc/asynNDArrayDriver.h
@@ -195,6 +195,7 @@ protected:
     NDArray **pArrays;             /**< An array of NDArray pointers used to store data in the driver */
     class NDAttributeList *pAttributeList;  /**< An NDAttributeList object used to obtain the current values of a set of
                                           *  attributes */
+    epicsMutex *pluginCountMutex_;
     int threadStackSize_;
     int threadPriority_;
 

--- a/ADApp/ADSrc/asynNDArrayDriver.h
+++ b/ADApp/ADSrc/asynNDArrayDriver.h
@@ -194,7 +194,6 @@ protected:
 
     NDArray **pArrays;             /**< An array of NDArray pointers used to store data in the driver */
     class NDAttributeList *pAttributeList;  /**< An NDAttributeList object used to obtain the current values of a set of attributes */
-private:
     NDArrayPool *pNDArrayPoolPvt_;
     epicsMutex *pluginCountMutex_;
     int threadStackSize_;

--- a/ADApp/ADSrc/asynNDArrayDriver.h
+++ b/ADApp/ADSrc/asynNDArrayDriver.h
@@ -102,6 +102,9 @@ typedef enum {
 #define NDPoolMaxMemoryString       "POOL_MAX_MEMORY"
 #define NDPoolUsedMemoryString      "POOL_USED_MEMORY"
 
+/* Active plugin counter */
+#define NDNumActivePluginsString   "NUM_ACTIVE_PLUGINS"
+
 /** This is the class from which NDArray drivers are derived; implements the asynGenericPointer functions 
   * for NDArray objects. 
   * For areaDetector, both plugins and detector drivers are indirectly derived from this class.
@@ -109,7 +112,7 @@ typedef enum {
   */
 class epicsShareFunc asynNDArrayDriver : public asynPortDriver {
 public:
-    asynNDArrayDriver(const char *portName, int maxAddr, int maxBuffers, size_t maxMemory,
+    asynNDArrayDriver(const char *portName, int maxAddr, bool isDriver, size_t maxMemory,
                       int interfaceMask, int interruptMask,
                       int asynFlags, int autoConnect, int priority, int stackSize);
     virtual ~asynNDArrayDriver();
@@ -130,6 +133,12 @@ public:
     virtual asynStatus createFileName(int maxChars, char *filePath, char *fileName);
     virtual asynStatus readNDAttributesFile();
     virtual asynStatus getAttributes(NDAttributeList *pAttributeList);
+
+    asynStatus incrementPluginCount();
+    asynStatus decrementPluginCount();
+    
+    // This only needs to be public because of the unit tests
+    NDArrayPool *pNDArrayPool;     /**< An NDArrayPool object used to allocate and manipulate NDArray objects */
 
 protected:
     int NDPortNameSelf;
@@ -181,9 +190,9 @@ protected:
     int NDPoolFreeBuffers;
     int NDPoolMaxMemory;
     int NDPoolUsedMemory;
+    int NDNumActivePlugins;
 
     NDArray **pArrays;             /**< An array of NDArray pointers used to store data in the driver */
-    NDArrayPool *pNDArrayPool;     /**< An NDArrayPool object used to allocate and manipulate NDArray objects */
     class NDAttributeList *pAttributeList;  /**< An NDAttributeList object used to obtain the current values of a set of
                                           *  attributes */
     int threadStackSize_;

--- a/ADApp/ADSrc/asynNDArrayDriver.h
+++ b/ADApp/ADSrc/asynNDArrayDriver.h
@@ -112,7 +112,7 @@ typedef enum {
   */
 class epicsShareFunc asynNDArrayDriver : public asynPortDriver {
 public:
-    asynNDArrayDriver(const char *portName, int maxAddr, bool isDriver, size_t maxMemory,
+    asynNDArrayDriver(const char *portName, int maxAddr, int maxBuffers, size_t maxMemory,
                       int interfaceMask, int interruptMask,
                       int asynFlags, int autoConnect, int priority, int stackSize);
     virtual ~asynNDArrayDriver();
@@ -195,7 +195,7 @@ protected:
     NDArray **pArrays;             /**< An array of NDArray pointers used to store data in the driver */
     class NDAttributeList *pAttributeList;  /**< An NDAttributeList object used to obtain the current values of a set of
                                           *  attributes */
-    bool isDriver_;
+    NDArrayPool *pNDArrayPoolPvt_;
     epicsMutex *pluginCountMutex_;
     int threadStackSize_;
     int threadPriority_;

--- a/ADApp/ADSrc/asynNDArrayDriver.h
+++ b/ADApp/ADSrc/asynNDArrayDriver.h
@@ -195,6 +195,7 @@ protected:
     NDArray **pArrays;             /**< An array of NDArray pointers used to store data in the driver */
     class NDAttributeList *pAttributeList;  /**< An NDAttributeList object used to obtain the current values of a set of
                                           *  attributes */
+    bool isDriver_;
     epicsMutex *pluginCountMutex_;
     int threadStackSize_;
     int threadPriority_;

--- a/ADApp/ADSrc/asynNDArrayDriver.h
+++ b/ADApp/ADSrc/asynNDArrayDriver.h
@@ -137,8 +137,8 @@ public:
     asynStatus incrementPluginCount();
     asynStatus decrementPluginCount();
     
-    // This only needs to be public because of the unit tests
-    NDArrayPool *pNDArrayPool;     /**< An NDArrayPool object used to allocate and manipulate NDArray objects */
+    NDArrayPool *pNDArrayPool;     /**< An NDArrayPool pointer that is initialized to pNDArrayPoolPvt_ in the constructor.
+                                     * Plugins change this pointer to the one passed in NDArray::pNDArrayPool */
 
 protected:
     int NDPortNameSelf;
@@ -193,8 +193,8 @@ protected:
     int NDNumActivePlugins;
 
     NDArray **pArrays;             /**< An array of NDArray pointers used to store data in the driver */
-    class NDAttributeList *pAttributeList;  /**< An NDAttributeList object used to obtain the current values of a set of
-                                          *  attributes */
+    class NDAttributeList *pAttributeList;  /**< An NDAttributeList object used to obtain the current values of a set of attributes */
+private:
     NDArrayPool *pNDArrayPoolPvt_;
     epicsMutex *pluginCountMutex_;
     int threadStackSize_;

--- a/ADApp/Db/ADBase.template
+++ b/ADApp/Db/ADBase.template
@@ -423,12 +423,14 @@ record(longin, "$(P)$(R)NumImagesCounter_RBV")
 #  and stop                                                       #
 ###################################################################
 
-record(busy, "$(P)$(R)Acquire") {
+record(bo, "$(P)$(R)Acquire") {
    field(DTYP, "asynInt32")
    field(OUT, "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))ACQUIRE")
    field(ZNAM, "Done")
    field(ONAM, "Acquire")
    field(VAL,  "0")
+   field(FLNK, "$(P)$(R)SetAcquireBusy")
+   info(asyn:READBACK, "1")
 }
 
 record(bi, "$(P)$(R)Acquire_RBV") {
@@ -439,6 +441,38 @@ record(bi, "$(P)$(R)Acquire_RBV") {
    field(ONAM, "Acquiring")
    field(OSV,  "MINOR")
    field(SCAN, "I/O Intr")
+}
+
+record(calcout, "$(P)$(R)SetAcquireBusy")
+{
+    field(INPA, "$(P)$(R)Acquire NPP")
+    field(CALC, "A")
+    field(OOPT, "Transition To Non-zero")
+    field(OUT,  "$(P)$(R)AcquireBusy PP")
+}
+
+record(busy, "$(P)$(R)AcquireBusy") {
+   field(ZNAM, "Done")
+   field(ZSV,  "NO_ALARM")
+   field(ONAM, "Acquiring")
+   field(OSV,  "MINOR")
+   field(VAL,  "0")
+}
+
+record(calcout, "$(P)$(R)ClearAcquireBusy")
+{
+    field(INPA, "$(P)$(R)WaitForPlugins CP")
+    field(INPB, "$(P)$(R)Acquire_RBV CP")
+    field(INPC, "$(P)$(R)NumActivePlugins CP")
+    field(CALC, "A ? B || (C > 0) : B")
+    field(OOPT, "Transition To Zero")
+    field(OUT,  "$(P)$(R)AcquireBusy PP")
+}
+
+record(bo, "$(P)$(R)WaitForPlugins") {
+   field(ZNAM, "No")
+   field(ONAM, "Yes")
+   field(VAL,  "0")
 }
 
 ###################################################################

--- a/ADApp/Db/ADBase_settings.req
+++ b/ADApp/Db/ADBase_settings.req
@@ -14,6 +14,7 @@ $(P)$(R)ImageMode
 $(P)$(R)TriggerMode
 $(P)$(R)NumExposures
 $(P)$(R)NumImages
+$(P)$(R)WaitForPlugins
 $(P)$(R)ShutterMode
 $(P)$(R)ShutterOpenDelay
 $(P)$(R)ShutterCloseDelay

--- a/ADApp/Db/NDArrayBase.template
+++ b/ADApp/Db/NDArrayBase.template
@@ -699,14 +699,6 @@ record(ai, "$(P)$(R)PoolMaxMem")
    field(PINI, "YES")
 }
 
-record(longin, "$(P)$(R)PoolMaxBuffers")
-{
-   field(DTYP, "asynInt32")
-   field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))POOL_MAX_BUFFERS")
-   field(SCAN, "Passive")
-   field(PINI, "YES")
-}
-
 record(ai, "$(P)$(R)PoolUsedMem")
 {
    field(DTYP, "asynFloat64")
@@ -737,4 +729,11 @@ record(calc, "$(P)$(R)PoolUsedBuffers")
     field(INPA, "$(P)$(R)PoolAllocBuffers NPP MS")
     field(INPB, "$(P)$(R)PoolFreeBuffers NPP MS")
     field(CALC, "A-B")
+}
+
+record(longin, "$(P)$(R)NumActivePlugins")
+{
+   field(DTYP, "asynInt32")
+   field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))NUM_ACTIVE_PLUGINS")
+   field(SCAN, "I/O Intr")
 }

--- a/ADApp/op/adl/ADBase.adl
+++ b/ADApp/op/adl/ADBase.adl
@@ -1,6 +1,6 @@
 
 file {
-	name="/home/epics/devel/areaDetector-3-2/ADCore/ADApp/op/adl/ADBase.adl"
+	name="/home/epics/devel/areaDetector/ADCore/ADApp/op/adl/ADBase.adl"
 	version=030109
 }
 display {
@@ -8,7 +8,7 @@ display {
 		x=670
 		y=172
 		width=715
-		height=915
+		height=945
 	}
 	clr=14
 	bclr=4
@@ -121,7 +121,7 @@ composite {
 composite {
 	object {
 		x=360
-		y=780
+		y=830
 		width=350
 		height=110
 	}
@@ -153,7 +153,7 @@ composite {
 		x=360
 		y=205
 		width=350
-		height=405
+		height=480
 	}
 	"composite name"=""
 	"composite file"="ADCollect.adl"
@@ -171,9 +171,9 @@ composite {
 composite {
 	object {
 		x=360
-		y=615
+		y=690
 		width=350
-		height=160
+		height=135
 	}
 	"composite name"=""
 	"composite file"="ADBuffers.adl"

--- a/ADApp/op/adl/ADBase.adl
+++ b/ADApp/op/adl/ADBase.adl
@@ -8,7 +8,7 @@ display {
 		x=670
 		y=172
 		width=715
-		height=935
+		height=915
 	}
 	clr=14
 	bclr=4
@@ -121,7 +121,7 @@ composite {
 composite {
 	object {
 		x=360
-		y=820
+		y=780
 		width=350
 		height=110
 	}
@@ -130,8 +130,8 @@ composite {
 }
 composite {
 	object {
-		x=360
-		y=755
+		x=5
+		y=850
 		width=350
 		height=60
 	}
@@ -173,7 +173,7 @@ composite {
 		x=360
 		y=615
 		width=350
-		height=135
+		height=160
 	}
 	"composite name"=""
 	"composite file"="ADBuffers.adl"

--- a/ADApp/op/adl/ADBuffers.adl
+++ b/ADApp/op/adl/ADBuffers.adl
@@ -8,7 +8,7 @@ display {
 		x=603
 		y=111
 		width=350
-		height=160
+		height=135
 	}
 	clr=14
 	bclr=4
@@ -201,7 +201,7 @@ rectangle {
 		x=0
 		y=0
 		width=350
-		height=160
+		height=135
 	}
 	"basic attribute" {
 		clr=14
@@ -211,7 +211,7 @@ rectangle {
 menu {
 	object {
 		x=245
-		y=130
+		y=105
 		width=90
 		height=20
 	}
@@ -224,7 +224,7 @@ menu {
 text {
 	object {
 		x=10
-		y=130
+		y=105
 		width=230
 		height=20
 	}
@@ -277,34 +277,5 @@ text {
 		clr=14
 	}
 	textix="Memory max/used (MB)"
-	align="horiz. right"
-}
-"text update" {
-	object {
-		x=215
-		y=106
-		width=60
-		height=18
-	}
-	monitor {
-		chan="$(P)$(R)NumActivePlugins"
-		clr=54
-		bclr=4
-	}
-	align="horiz. right"
-	limits {
-	}
-}
-text {
-	object {
-		x=10
-		y=105
-		width=200
-		height=20
-	}
-	"basic attribute" {
-		clr=14
-	}
-	textix="# active plugins"
 	align="horiz. right"
 }

--- a/ADApp/op/adl/ADBuffers.adl
+++ b/ADApp/op/adl/ADBuffers.adl
@@ -1,14 +1,14 @@
 
 file {
-	name="/home/epics/devel/areaDetector/ADCore/ADApp/op/adl/ADBuffers.adl"
-	version=030107
+	name="/home/epics/devel/areaDetector-3-2/ADCore/ADApp/op/adl/ADBuffers.adl"
+	version=030109
 }
 display {
 	object {
 		x=603
 		y=111
 		width=350
-		height=135
+		height=160
 	}
 	clr=14
 	bclr=4
@@ -122,38 +122,6 @@ text {
 	textix="Buffers"
 	align="horiz. centered"
 }
-"text update" {
-	object {
-		x=215
-		y=81
-		width=60
-		height=18
-	}
-	monitor {
-		chan="$(P)$(R)PoolMaxMem"
-		clr=54
-		bclr=4
-	}
-	align="horiz. right"
-	limits {
-	}
-}
-"text update" {
-	object {
-		x=280
-		y=81
-		width=60
-		height=18
-	}
-	monitor {
-		chan="$(P)$(R)PoolUsedMem"
-		clr=54
-		bclr=4
-	}
-	align="horiz. right"
-	limits {
-	}
-}
 text {
 	object {
 		x=50
@@ -164,28 +132,12 @@ text {
 	"basic attribute" {
 		clr=14
 	}
-	textix="Buffers max/used"
+	textix="Buffers used"
 	align="horiz. right"
 }
 "text update" {
 	object {
 		x=215
-		y=31
-		width=50
-		height=18
-	}
-	monitor {
-		chan="$(P)$(R)PoolMaxBuffers"
-		clr=54
-		bclr=4
-	}
-	align="horiz. right"
-	limits {
-	}
-}
-"text update" {
-	object {
-		x=270
 		y=31
 		width=50
 		height=18
@@ -244,10 +196,22 @@ text {
 	limits {
 	}
 }
+rectangle {
+	object {
+		x=0
+		y=0
+		width=350
+		height=160
+	}
+	"basic attribute" {
+		clr=14
+		fill="outline"
+	}
+}
 menu {
 	object {
 		x=245
-		y=105
+		y=130
 		width=90
 		height=20
 	}
@@ -260,7 +224,7 @@ menu {
 text {
 	object {
 		x=10
-		y=105
+		y=130
 		width=230
 		height=20
 	}
@@ -270,16 +234,36 @@ text {
 	textix="Buffer & memory polling"
 	align="horiz. right"
 }
-rectangle {
+"text update" {
 	object {
-		x=0
-		y=0
-		width=350
-		height=135
+		x=215
+		y=81
+		width=60
+		height=18
 	}
-	"basic attribute" {
-		clr=14
-		fill="outline"
+	monitor {
+		chan="$(P)$(R)PoolMaxMem"
+		clr=54
+		bclr=4
+	}
+	align="horiz. right"
+	limits {
+	}
+}
+"text update" {
+	object {
+		x=280
+		y=81
+		width=60
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)PoolUsedMem"
+		clr=54
+		bclr=4
+	}
+	align="horiz. right"
+	limits {
 	}
 }
 text {
@@ -293,5 +277,34 @@ text {
 		clr=14
 	}
 	textix="Memory max/used (MB)"
+	align="horiz. right"
+}
+"text update" {
+	object {
+		x=215
+		y=106
+		width=60
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)NumActivePlugins"
+		clr=54
+		bclr=4
+	}
+	align="horiz. right"
+	limits {
+	}
+}
+text {
+	object {
+		x=10
+		y=105
+		width=200
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="# active plugins"
 	align="horiz. right"
 }

--- a/ADApp/op/adl/ADCollect.adl
+++ b/ADApp/op/adl/ADCollect.adl
@@ -1,14 +1,14 @@
 
 file {
-	name="/home/epics/devel/areaDetector-3-2/ADCore/ADApp/op/adl/ADCollect.adl"
+	name="/home/epics/devel/areaDetector/ADCore/ADApp/op/adl/ADCollect.adl"
 	version=030109
 }
 display {
 	object {
-		x=44
-		y=221
+		x=446
+		y=331
 		width=350
-		height=405
+		height=480
 	}
 	clr=14
 	bclr=4
@@ -92,7 +92,7 @@ rectangle {
 		x=0
 		y=0
 		width=350
-		height=405
+		height=480
 	}
 	"basic attribute" {
 		clr=14
@@ -301,48 +301,6 @@ text {
 }
 text {
 	object {
-		x=5
-		y=180
-		width=120
-		height=20
-	}
-	"basic attribute" {
-		clr=14
-	}
-	textix="Trigger mode"
-	align="horiz. right"
-}
-menu {
-	object {
-		x=130
-		y=180
-		width=120
-		height=20
-	}
-	control {
-		chan="$(P)$(R)TriggerMode"
-		clr=14
-		bclr=51
-	}
-}
-"text update" {
-	object {
-		x=255
-		y=181
-		width=80
-		height=18
-	}
-	monitor {
-		chan="$(P)$(R)TriggerMode_RBV"
-		clr=54
-		bclr=4
-	}
-	format="string"
-	limits {
-	}
-}
-text {
-	object {
 		x=223
 		y=210
 		width=40
@@ -420,206 +378,6 @@ text {
 	textix="Acquire"
 	align="horiz. right"
 }
-text {
-	object {
-		x=35
-		y=255
-		width=140
-		height=20
-	}
-	"basic attribute" {
-		clr=14
-	}
-	textix="Detector state"
-	align="horiz. right"
-}
-"text update" {
-	object {
-		x=180
-		y=255
-		width=158
-		height=18
-	}
-	monitor {
-		chan="$(P)$(R)DetectorState_RBV"
-		clr=54
-		bclr=2
-	}
-	clrmod="alarm"
-	limits {
-	}
-}
-text {
-	object {
-		x=35
-		y=305
-		width=140
-		height=20
-	}
-	"basic attribute" {
-		clr=14
-	}
-	textix="Time remaining"
-	align="horiz. right"
-}
-"text update" {
-	object {
-		x=180
-		y=306
-		width=67
-		height=18
-	}
-	monitor {
-		chan="$(P)$(R)TimeRemaining_RBV"
-		clr=54
-		bclr=4
-	}
-	limits {
-	}
-}
-"text entry" {
-	object {
-		x=180
-		y=330
-		width=60
-		height=20
-	}
-	control {
-		chan="$(P)$(R)ArrayCounter"
-		clr=14
-		bclr=51
-	}
-	limits {
-	}
-}
-text {
-	object {
-		x=45
-		y=330
-		width=130
-		height=20
-	}
-	"basic attribute" {
-		clr=14
-	}
-	textix="Image counter"
-	align="horiz. right"
-}
-"text update" {
-	object {
-		x=245
-		y=331
-		width=80
-		height=18
-	}
-	monitor {
-		chan="$(P)$(R)ArrayCounter_RBV"
-		clr=54
-		bclr=4
-	}
-	limits {
-	}
-}
-text {
-	object {
-		x=75
-		y=355
-		width=100
-		height=20
-	}
-	"basic attribute" {
-		clr=14
-	}
-	textix="Image rate"
-	align="horiz. right"
-}
-"text update" {
-	object {
-		x=180
-		y=356
-		width=100
-		height=18
-	}
-	monitor {
-		chan="$(P)$(R)ArrayRate_RBV"
-		clr=54
-		bclr=4
-	}
-	limits {
-	}
-}
-text {
-	object {
-		x=5
-		y=380
-		width=150
-		height=20
-	}
-	"basic attribute" {
-		clr=14
-	}
-	textix="Array callbacks"
-	align="horiz. right"
-}
-menu {
-	object {
-		x=160
-		y=380
-		width=90
-		height=20
-	}
-	control {
-		chan="$(P)$(R)ArrayCallbacks"
-		clr=14
-		bclr=51
-	}
-}
-"text update" {
-	object {
-		x=255
-		y=382
-		width=80
-		height=18
-	}
-	monitor {
-		chan="$(P)$(R)ArrayCallbacks_RBV"
-		clr=54
-		bclr=4
-	}
-	align="horiz. centered"
-	format="string"
-	limits {
-	}
-}
-text {
-	object {
-		x=5
-		y=280
-		width=60
-		height=20
-	}
-	"basic attribute" {
-		clr=14
-	}
-	textix="Status"
-	align="horiz. right"
-}
-"text update" {
-	object {
-		x=70
-		y=280
-		width=275
-		height=18
-	}
-	monitor {
-		chan="$(P)$(R)StatusMessage_RBV"
-		clr=54
-		bclr=2
-	}
-	format="string"
-	limits {
-	}
-}
 rectangle {
 	object {
 		x=123
@@ -682,6 +440,333 @@ menu {
 		clr=54
 		bclr=4
 	}
+	format="string"
+	limits {
+	}
+}
+text {
+	object {
+		x=35
+		y=330
+		width=140
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Detector state"
+	align="horiz. right"
+}
+"text update" {
+	object {
+		x=180
+		y=330
+		width=160
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)DetectorState_RBV"
+		clr=54
+		bclr=2
+	}
+	clrmod="alarm"
+	limits {
+	}
+}
+text {
+	object {
+		x=35
+		y=380
+		width=140
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Time remaining"
+	align="horiz. right"
+}
+"text update" {
+	object {
+		x=180
+		y=381
+		width=67
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)TimeRemaining_RBV"
+		clr=54
+		bclr=4
+	}
+	limits {
+	}
+}
+"text entry" {
+	object {
+		x=180
+		y=405
+		width=60
+		height=20
+	}
+	control {
+		chan="$(P)$(R)ArrayCounter"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+text {
+	object {
+		x=45
+		y=405
+		width=130
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Image counter"
+	align="horiz. right"
+}
+"text update" {
+	object {
+		x=245
+		y=406
+		width=80
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)ArrayCounter_RBV"
+		clr=54
+		bclr=4
+	}
+	limits {
+	}
+}
+text {
+	object {
+		x=75
+		y=430
+		width=100
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Image rate"
+	align="horiz. right"
+}
+"text update" {
+	object {
+		x=180
+		y=431
+		width=100
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)ArrayRate_RBV"
+		clr=54
+		bclr=4
+	}
+	limits {
+	}
+}
+text {
+	object {
+		x=5
+		y=455
+		width=150
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Array callbacks"
+	align="horiz. right"
+}
+menu {
+	object {
+		x=160
+		y=455
+		width=90
+		height=20
+	}
+	control {
+		chan="$(P)$(R)ArrayCallbacks"
+		clr=14
+		bclr=51
+	}
+}
+"text update" {
+	object {
+		x=255
+		y=457
+		width=80
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)ArrayCallbacks_RBV"
+		clr=54
+		bclr=4
+	}
+	align="horiz. centered"
+	format="string"
+	limits {
+	}
+}
+text {
+	object {
+		x=5
+		y=355
+		width=60
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Status"
+	align="horiz. right"
+}
+"text update" {
+	object {
+		x=70
+		y=355
+		width=275
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)StatusMessage_RBV"
+		clr=54
+		bclr=2
+	}
+	format="string"
+	limits {
+	}
+}
+text {
+	object {
+		x=15
+		y=255
+		width=160
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="# active plugins"
+	align="horiz. right"
+}
+"text update" {
+	object {
+		x=180
+		y=256
+		width=60
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)NumActivePlugins"
+		clr=54
+		bclr=4
+	}
+	align="horiz. right"
+	limits {
+	}
+}
+text {
+	object {
+		x=5
+		y=180
+		width=120
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Trigger mode"
+	align="horiz. right"
+}
+menu {
+	object {
+		x=130
+		y=180
+		width=120
+		height=20
+	}
+	control {
+		chan="$(P)$(R)TriggerMode"
+		clr=14
+		bclr=51
+	}
+}
+"text update" {
+	object {
+		x=255
+		y=181
+		width=80
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)TriggerMode_RBV"
+		clr=54
+		bclr=4
+	}
+	format="string"
+	limits {
+	}
+}
+text {
+	object {
+		x=15
+		y=280
+		width=160
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Wait for plugins"
+	align="horiz. right"
+}
+menu {
+	object {
+		x=180
+		y=280
+		width=80
+		height=20
+	}
+	control {
+		chan="$(P)$(R)WaitForPlugins"
+		clr=14
+		bclr=51
+	}
+}
+text {
+	object {
+		x=55
+		y=305
+		width=120
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Acquire busy"
+	align="horiz. right"
+}
+"text update" {
+	object {
+		x=180
+		y=306
+		width=160
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)AcquireBusy"
+		clr=54
+		bclr=2
+	}
+	clrmod="alarm"
 	format="string"
 	limits {
 	}

--- a/ADApp/op/edl/autoconvert/ADBase.edl
+++ b/ADApp/op/edl/autoconvert/ADBase.edl
@@ -6,7 +6,7 @@ release 0
 x 670
 y 172
 w 715
-h 915
+h 945
 font "helvetica-medium-r-18.0"
 ctlFont "helvetica-medium-r-8.0"
 btnFont "helvetica-medium-r-18.0"
@@ -129,7 +129,7 @@ major 4
 minor 0
 release 0
 x 360
-y 780
+y 830
 w 350
 h 110
 
@@ -142,7 +142,7 @@ major 4
 minor 0
 release 0
 x 360
-y 780
+y 830
 w 350
 h 110
 fgColor index 14
@@ -254,7 +254,7 @@ release 0
 x 360
 y 205
 w 350
-h 405
+h 480
 
 beginGroup
 
@@ -267,7 +267,7 @@ release 0
 x 360
 y 205
 w 350
-h 405
+h 480
 fgColor index 14
 bgColor index 0
 topShadowColor index 0
@@ -334,9 +334,9 @@ major 4
 minor 0
 release 0
 x 360
-y 615
+y 690
 w 350
-h 160
+h 135
 
 beginGroup
 
@@ -347,9 +347,9 @@ major 4
 minor 0
 release 0
 x 360
-y 615
+y 690
 w 350
-h 160
+h 135
 fgColor index 14
 bgColor index 0
 topShadowColor index 0

--- a/ADApp/op/edl/autoconvert/ADBase.edl
+++ b/ADApp/op/edl/autoconvert/ADBase.edl
@@ -6,7 +6,7 @@ release 0
 x 670
 y 172
 w 715
-h 935
+h 915
 font "helvetica-medium-r-18.0"
 ctlFont "helvetica-medium-r-8.0"
 btnFont "helvetica-medium-r-18.0"
@@ -129,7 +129,7 @@ major 4
 minor 0
 release 0
 x 360
-y 820
+y 780
 w 350
 h 110
 
@@ -142,7 +142,7 @@ major 4
 minor 0
 release 0
 x 360
-y 820
+y 780
 w 350
 h 110
 fgColor index 14
@@ -169,8 +169,8 @@ beginObjectProperties
 major 4
 minor 0
 release 0
-x 360
-y 755
+x 5
+y 850
 w 350
 h 60
 
@@ -182,8 +182,8 @@ beginObjectProperties
 major 4
 minor 0
 release 0
-x 360
-y 755
+x 5
+y 850
 w 350
 h 60
 fgColor index 14
@@ -336,7 +336,7 @@ release 0
 x 360
 y 615
 w 350
-h 135
+h 160
 
 beginGroup
 
@@ -349,7 +349,7 @@ release 0
 x 360
 y 615
 w 350
-h 135
+h 160
 fgColor index 14
 bgColor index 0
 topShadowColor index 0

--- a/ADApp/op/edl/autoconvert/ADBuffers.edl
+++ b/ADApp/op/edl/autoconvert/ADBuffers.edl
@@ -6,7 +6,7 @@ release 0
 x 603
 y 111
 w 350
-h 160
+h 135
 font "helvetica-medium-r-18.0"
 ctlFont "helvetica-medium-r-8.0"
 btnFont "helvetica-medium-r-18.0"
@@ -200,7 +200,7 @@ release 0
 x 0
 y 0
 w 350
-h 160
+h 135
 lineColor index 14
 fillColor index 14
 lineWidth 0
@@ -213,7 +213,7 @@ major 4
 minor 0
 release 0
 x 10
-y 130
+y 105
 w 230
 h 20
 font "helvetica-medium-r-8.0"
@@ -293,50 +293,6 @@ value {
  "Memory max/used (MB)"
 }
 endObjectProperties
-
-# (Text Control)
-object activeXTextDspClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 215
-y 106
-w 60
-h 18
-controlPv "$(P)$(R)NumActivePlugins"
-font "helvetica-medium-r-8.0"
-fontAlign "right"
-smartRefresh
-fastUpdate
-fgColor index 54
-bgColor index 4
-autoHeight
-format decimal
-nullColor index 32
-useHexPrefix
-objType "controls"
-newPos
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 10
-y 105
-w 200
-h 20
-font "helvetica-medium-r-8.0"
-fontAlign "right"
-fgColor index 14
-useDisplayBg
-value {
- "# active plugins"
-}
-endObjectProperties
 # (Group)
 object activeGroupClass
 beginObjectProperties
@@ -363,7 +319,7 @@ major 4
 minor 0
 release 0
 x 245
-y 130
+y 105
 w 90
 h 20
 fgColor index 14

--- a/ADApp/op/edl/autoconvert/ADBuffers.edl
+++ b/ADApp/op/edl/autoconvert/ADBuffers.edl
@@ -6,7 +6,7 @@ release 0
 x 603
 y 111
 w 350
-h 135
+h 160
 font "helvetica-medium-r-18.0"
 ctlFont "helvetica-medium-r-8.0"
 btnFont "helvetica-medium-r-18.0"
@@ -78,56 +78,6 @@ value {
 }
 endObjectProperties
 
-# (Text Control)
-object activeXTextDspClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 215
-y 81
-w 60
-h 18
-controlPv "$(P)$(R)PoolMaxMem"
-font "helvetica-medium-r-8.0"
-fontAlign "right"
-smartRefresh
-fastUpdate
-fgColor index 54
-bgColor index 4
-autoHeight
-format decimal
-nullColor index 32
-useHexPrefix
-objType "controls"
-newPos
-endObjectProperties
-
-# (Text Control)
-object activeXTextDspClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 280
-y 81
-w 60
-h 18
-controlPv "$(P)$(R)PoolUsedMem"
-font "helvetica-medium-r-8.0"
-fontAlign "right"
-smartRefresh
-fastUpdate
-fgColor index 54
-bgColor index 4
-autoHeight
-format decimal
-nullColor index 32
-useHexPrefix
-objType "controls"
-newPos
-endObjectProperties
-
 # (Static Text)
 object activeXTextClass
 beginObjectProperties
@@ -143,7 +93,7 @@ fontAlign "right"
 fgColor index 14
 useDisplayBg
 value {
- "Buffers max/used"
+ "Buffers used"
 }
 endObjectProperties
 
@@ -154,31 +104,6 @@ major 4
 minor 0
 release 0
 x 215
-y 31
-w 50
-h 18
-controlPv "$(P)$(R)PoolMaxBuffers"
-font "helvetica-medium-r-8.0"
-fontAlign "right"
-smartRefresh
-fastUpdate
-fgColor index 54
-bgColor index 4
-autoHeight
-format decimal
-nullColor index 32
-useHexPrefix
-objType "controls"
-newPos
-endObjectProperties
-
-# (Text Control)
-object activeXTextDspClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 270
 y 31
 w 50
 h 18
@@ -266,6 +191,21 @@ objType "controls"
 newPos
 endObjectProperties
 
+# (Rectangle)
+object activeRectangleClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 0
+y 0
+w 350
+h 160
+lineColor index 14
+fillColor index 14
+lineWidth 0
+endObjectProperties
+
 # (Static Text)
 object activeXTextClass
 beginObjectProperties
@@ -273,7 +213,7 @@ major 4
 minor 0
 release 0
 x 10
-y 105
+y 130
 w 230
 h 20
 font "helvetica-medium-r-8.0"
@@ -285,19 +225,54 @@ value {
 }
 endObjectProperties
 
-# (Rectangle)
-object activeRectangleClass
+# (Text Control)
+object activeXTextDspClass
 beginObjectProperties
 major 4
 minor 0
 release 0
-x 0
-y 0
-w 350
-h 135
-lineColor index 14
-fillColor index 14
-lineWidth 0
+x 215
+y 81
+w 60
+h 18
+controlPv "$(P)$(R)PoolMaxMem"
+font "helvetica-medium-r-8.0"
+fontAlign "right"
+smartRefresh
+fastUpdate
+fgColor index 54
+bgColor index 4
+autoHeight
+format decimal
+nullColor index 32
+useHexPrefix
+objType "controls"
+newPos
+endObjectProperties
+
+# (Text Control)
+object activeXTextDspClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 280
+y 81
+w 60
+h 18
+controlPv "$(P)$(R)PoolUsedMem"
+font "helvetica-medium-r-8.0"
+fontAlign "right"
+smartRefresh
+fastUpdate
+fgColor index 54
+bgColor index 4
+autoHeight
+format decimal
+nullColor index 32
+useHexPrefix
+objType "controls"
+newPos
 endObjectProperties
 
 # (Static Text)
@@ -316,6 +291,50 @@ fgColor index 14
 useDisplayBg
 value {
  "Memory max/used (MB)"
+}
+endObjectProperties
+
+# (Text Control)
+object activeXTextDspClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 215
+y 106
+w 60
+h 18
+controlPv "$(P)$(R)NumActivePlugins"
+font "helvetica-medium-r-8.0"
+fontAlign "right"
+smartRefresh
+fastUpdate
+fgColor index 54
+bgColor index 4
+autoHeight
+format decimal
+nullColor index 32
+useHexPrefix
+objType "controls"
+newPos
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 10
+y 105
+w 200
+h 20
+font "helvetica-medium-r-8.0"
+fontAlign "right"
+fgColor index 14
+useDisplayBg
+value {
+ "# active plugins"
 }
 endObjectProperties
 # (Group)
@@ -344,7 +363,7 @@ major 4
 minor 0
 release 0
 x 245
-y 105
+y 130
 w 90
 h 20
 fgColor index 14

--- a/ADApp/op/edl/autoconvert/ADCollect.edl
+++ b/ADApp/op/edl/autoconvert/ADCollect.edl
@@ -892,30 +892,6 @@ value {
 }
 endObjectProperties
 
-# (Text Control)
-object activeXTextDspClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 265
-y 281
-w 60
-h 18
-controlPv "$(P)$(R)TriggerMode_RBV"
-font "helvetica-medium-r-8.0"
-smartRefresh
-fastUpdate
-fgColor index 54
-bgColor index 4
-autoHeight
-format "string"
-nullColor index 32
-useHexPrefix
-objType "controls"
-newPos
-endObjectProperties
-
 # (Static Text)
 object activeXTextClass
 beginObjectProperties
@@ -1085,8 +1061,8 @@ bgColor index 51
 inconsistentColor index 12
 topShadowColor index 2
 botShadowColor index 12
-controlPv "$(P)$(R)TriggerMode"
-indicatorPv "$(P)$(R)TriggerMode"
+controlPv "$(P)$(R)WaitForPlugins"
+indicatorPv "$(P)$(R)WaitForPlugins"
 font "helvetica-medium-r-10.0"
 endObjectProperties
 

--- a/ADApp/op/edl/autoconvert/ADCollect.edl
+++ b/ADApp/op/edl/autoconvert/ADCollect.edl
@@ -3,10 +3,10 @@ beginScreenProperties
 major 4
 minor 0
 release 0
-x 44
-y 221
+x 446
+y 331
 w 350
-h 405
+h 480
 font "helvetica-medium-r-18.0"
 ctlFont "helvetica-medium-r-8.0"
 btnFont "helvetica-medium-r-18.0"
@@ -33,7 +33,7 @@ release 0
 x 0
 y 0
 w 350
-h 405
+h 480
 lineColor index 14
 fillColor index 14
 lineWidth 0
@@ -364,49 +364,6 @@ beginObjectProperties
 major 4
 minor 0
 release 0
-x 5
-y 180
-w 120
-h 20
-font "helvetica-medium-r-8.0"
-fontAlign "right"
-fgColor index 14
-useDisplayBg
-value {
- "Trigger mode"
-}
-endObjectProperties
-
-# (Text Control)
-object activeXTextDspClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 255
-y 181
-w 80
-h 18
-controlPv "$(P)$(R)TriggerMode_RBV"
-font "helvetica-medium-r-8.0"
-smartRefresh
-fastUpdate
-fgColor index 54
-bgColor index 4
-autoHeight
-format "string"
-nullColor index 32
-useHexPrefix
-objType "controls"
-newPos
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 0
-release 0
 x 223
 y 210
 w 40
@@ -463,292 +420,6 @@ useDisplayBg
 value {
  "Acquire"
 }
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 35
-y 255
-w 140
-h 20
-font "helvetica-medium-r-8.0"
-fontAlign "right"
-fgColor index 14
-useDisplayBg
-value {
- "Detector state"
-}
-endObjectProperties
-
-# (Text Control)
-object activeXTextDspClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 180
-y 255
-w 158
-h 18
-controlPv "$(P)$(R)DetectorState_RBV"
-font "helvetica-medium-r-8.0"
-smartRefresh
-fastUpdate
-fgColor index 54
-fgAlarm
-bgColor index 2
-autoHeight
-format decimal
-nullColor index 32
-useHexPrefix
-objType "controls"
-newPos
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 35
-y 305
-w 140
-h 20
-font "helvetica-medium-r-8.0"
-fontAlign "right"
-fgColor index 14
-useDisplayBg
-value {
- "Time remaining"
-}
-endObjectProperties
-
-# (Text Control)
-object activeXTextDspClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 180
-y 306
-w 67
-h 18
-controlPv "$(P)$(R)TimeRemaining_RBV"
-font "helvetica-medium-r-8.0"
-smartRefresh
-fastUpdate
-fgColor index 54
-bgColor index 4
-autoHeight
-format decimal
-nullColor index 32
-useHexPrefix
-objType "controls"
-newPos
-endObjectProperties
-
-# (Text Control)
-object activeXTextDspClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 180
-y 330
-w 60
-h 20
-controlPv "$(P)$(R)ArrayCounter"
-font "helvetica-medium-r-8.0"
-smartRefresh
-fastUpdate
-fgColor index 14
-bgColor index 51
-editable
-autoHeight
-format decimal
-motifWidget
-nullColor index 32
-useHexPrefix
-objType "controls"
-newPos
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 45
-y 330
-w 130
-h 20
-font "helvetica-medium-r-8.0"
-fontAlign "right"
-fgColor index 14
-useDisplayBg
-value {
- "Image counter"
-}
-endObjectProperties
-
-# (Text Control)
-object activeXTextDspClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 245
-y 331
-w 80
-h 18
-controlPv "$(P)$(R)ArrayCounter_RBV"
-font "helvetica-medium-r-8.0"
-smartRefresh
-fastUpdate
-fgColor index 54
-bgColor index 4
-autoHeight
-format decimal
-nullColor index 32
-useHexPrefix
-objType "controls"
-newPos
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 75
-y 355
-w 100
-h 20
-font "helvetica-medium-r-8.0"
-fontAlign "right"
-fgColor index 14
-useDisplayBg
-value {
- "Image rate"
-}
-endObjectProperties
-
-# (Text Control)
-object activeXTextDspClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 180
-y 356
-w 100
-h 18
-controlPv "$(P)$(R)ArrayRate_RBV"
-font "helvetica-medium-r-8.0"
-smartRefresh
-fastUpdate
-fgColor index 54
-bgColor index 4
-autoHeight
-format decimal
-nullColor index 32
-useHexPrefix
-objType "controls"
-newPos
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 5
-y 380
-w 150
-h 20
-font "helvetica-medium-r-8.0"
-fontAlign "right"
-fgColor index 14
-useDisplayBg
-value {
- "Array callbacks"
-}
-endObjectProperties
-
-# (Text Control)
-object activeXTextDspClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 255
-y 382
-w 80
-h 18
-controlPv "$(P)$(R)ArrayCallbacks_RBV"
-font "helvetica-medium-r-8.0"
-fontAlign "center"
-smartRefresh
-fastUpdate
-fgColor index 54
-bgColor index 4
-autoHeight
-format "string"
-nullColor index 32
-useHexPrefix
-objType "controls"
-newPos
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 5
-y 280
-w 60
-h 20
-font "helvetica-medium-r-8.0"
-fontAlign "right"
-fgColor index 14
-useDisplayBg
-value {
- "Status"
-}
-endObjectProperties
-
-# (Text Control)
-object activeXTextDspClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 70
-y 280
-w 275
-h 18
-controlPv "$(P)$(R)StatusMessage_RBV"
-font "helvetica-medium-r-8.0"
-smartRefresh
-fastUpdate
-fgColor index 54
-bgColor index 2
-autoHeight
-format "string"
-nullColor index 32
-useHexPrefix
-objType "controls"
-newPos
 endObjectProperties
 
 # (Rectangle)
@@ -829,24 +500,464 @@ objType "controls"
 newPos
 endObjectProperties
 
-# (Menu Button)
-object activeMenuButtonClass
+# (Static Text)
+object activeXTextClass
 beginObjectProperties
 major 4
 minor 0
 release 0
-x 130
+x 35
+y 330
+w 140
+h 20
+font "helvetica-medium-r-8.0"
+fontAlign "right"
+fgColor index 14
+useDisplayBg
+value {
+ "Detector state"
+}
+endObjectProperties
+
+# (Text Control)
+object activeXTextDspClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 180
+y 330
+w 160
+h 18
+controlPv "$(P)$(R)DetectorState_RBV"
+font "helvetica-medium-r-8.0"
+smartRefresh
+fastUpdate
+fgColor index 54
+fgAlarm
+bgColor index 2
+autoHeight
+format decimal
+nullColor index 32
+useHexPrefix
+objType "controls"
+newPos
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 35
+y 380
+w 140
+h 20
+font "helvetica-medium-r-8.0"
+fontAlign "right"
+fgColor index 14
+useDisplayBg
+value {
+ "Time remaining"
+}
+endObjectProperties
+
+# (Text Control)
+object activeXTextDspClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 180
+y 381
+w 67
+h 18
+controlPv "$(P)$(R)TimeRemaining_RBV"
+font "helvetica-medium-r-8.0"
+smartRefresh
+fastUpdate
+fgColor index 54
+bgColor index 4
+autoHeight
+format decimal
+nullColor index 32
+useHexPrefix
+objType "controls"
+newPos
+endObjectProperties
+
+# (Text Control)
+object activeXTextDspClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 180
+y 405
+w 60
+h 20
+controlPv "$(P)$(R)ArrayCounter"
+font "helvetica-medium-r-8.0"
+smartRefresh
+fastUpdate
+fgColor index 14
+bgColor index 51
+editable
+autoHeight
+format decimal
+motifWidget
+nullColor index 32
+useHexPrefix
+objType "controls"
+newPos
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 45
+y 405
+w 130
+h 20
+font "helvetica-medium-r-8.0"
+fontAlign "right"
+fgColor index 14
+useDisplayBg
+value {
+ "Image counter"
+}
+endObjectProperties
+
+# (Text Control)
+object activeXTextDspClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 245
+y 406
+w 80
+h 18
+controlPv "$(P)$(R)ArrayCounter_RBV"
+font "helvetica-medium-r-8.0"
+smartRefresh
+fastUpdate
+fgColor index 54
+bgColor index 4
+autoHeight
+format decimal
+nullColor index 32
+useHexPrefix
+objType "controls"
+newPos
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 75
+y 430
+w 100
+h 20
+font "helvetica-medium-r-8.0"
+fontAlign "right"
+fgColor index 14
+useDisplayBg
+value {
+ "Image rate"
+}
+endObjectProperties
+
+# (Text Control)
+object activeXTextDspClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 180
+y 431
+w 100
+h 18
+controlPv "$(P)$(R)ArrayRate_RBV"
+font "helvetica-medium-r-8.0"
+smartRefresh
+fastUpdate
+fgColor index 54
+bgColor index 4
+autoHeight
+format decimal
+nullColor index 32
+useHexPrefix
+objType "controls"
+newPos
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 5
+y 455
+w 150
+h 20
+font "helvetica-medium-r-8.0"
+fontAlign "right"
+fgColor index 14
+useDisplayBg
+value {
+ "Array callbacks"
+}
+endObjectProperties
+
+# (Text Control)
+object activeXTextDspClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 255
+y 457
+w 80
+h 18
+controlPv "$(P)$(R)ArrayCallbacks_RBV"
+font "helvetica-medium-r-8.0"
+fontAlign "center"
+smartRefresh
+fastUpdate
+fgColor index 54
+bgColor index 4
+autoHeight
+format "string"
+nullColor index 32
+useHexPrefix
+objType "controls"
+newPos
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 5
+y 355
+w 60
+h 20
+font "helvetica-medium-r-8.0"
+fontAlign "right"
+fgColor index 14
+useDisplayBg
+value {
+ "Status"
+}
+endObjectProperties
+
+# (Text Control)
+object activeXTextDspClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 70
+y 355
+w 275
+h 18
+controlPv "$(P)$(R)StatusMessage_RBV"
+font "helvetica-medium-r-8.0"
+smartRefresh
+fastUpdate
+fgColor index 54
+bgColor index 2
+autoHeight
+format "string"
+nullColor index 32
+useHexPrefix
+objType "controls"
+newPos
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 15
+y 255
+w 160
+h 20
+font "helvetica-medium-r-8.0"
+fontAlign "right"
+fgColor index 14
+useDisplayBg
+value {
+ "# active plugins"
+}
+endObjectProperties
+
+# (Text Control)
+object activeXTextDspClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 180
+y 256
+w 60
+h 18
+controlPv "$(P)$(R)NumActivePlugins"
+font "helvetica-medium-r-8.0"
+fontAlign "right"
+smartRefresh
+fastUpdate
+fgColor index 54
+bgColor index 4
+autoHeight
+format decimal
+nullColor index 32
+useHexPrefix
+objType "controls"
+newPos
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 5
 y 180
 w 120
 h 20
+font "helvetica-medium-r-8.0"
+fontAlign "right"
 fgColor index 14
-bgColor index 51
-inconsistentColor index 12
-topShadowColor index 2
-botShadowColor index 12
-controlPv "$(P)$(R)TriggerMode"
-indicatorPv "$(P)$(R)TriggerMode"
-font "helvetica-medium-r-10.0"
+useDisplayBg
+value {
+ "Trigger mode"
+}
+endObjectProperties
+
+# (Text Control)
+object activeXTextDspClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 255
+y 181
+w 80
+h 18
+controlPv "$(P)$(R)TriggerMode_RBV"
+font "helvetica-medium-r-8.0"
+smartRefresh
+fastUpdate
+fgColor index 54
+bgColor index 4
+autoHeight
+format "string"
+nullColor index 32
+useHexPrefix
+objType "controls"
+newPos
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 15
+y 280
+w 160
+h 20
+font "helvetica-medium-r-8.0"
+fontAlign "right"
+fgColor index 14
+useDisplayBg
+value {
+ "Wait for plugins"
+}
+endObjectProperties
+
+# (Text Control)
+object activeXTextDspClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 265
+y 281
+w 60
+h 18
+controlPv "$(P)$(R)TriggerMode_RBV"
+font "helvetica-medium-r-8.0"
+smartRefresh
+fastUpdate
+fgColor index 54
+bgColor index 4
+autoHeight
+format "string"
+nullColor index 32
+useHexPrefix
+objType "controls"
+newPos
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 55
+y 305
+w 120
+h 20
+font "helvetica-medium-r-8.0"
+fontAlign "right"
+fgColor index 14
+useDisplayBg
+value {
+ "Acquire busy"
+}
+endObjectProperties
+
+# (Text Control)
+object activeXTextDspClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 180
+y 306
+w 160
+h 18
+controlPv "$(P)$(R)AcquireBusy"
+font "helvetica-medium-r-8.0"
+smartRefresh
+fastUpdate
+fgColor index 54
+fgAlarm
+bgColor index 2
+autoHeight
+format "string"
+nullColor index 32
+useHexPrefix
+objType "controls"
+newPos
 endObjectProperties
 
 # (Message Button)
@@ -905,8 +1016,28 @@ beginObjectProperties
 major 4
 minor 0
 release 0
+x 130
+y 155
+w 120
+h 20
+fgColor index 14
+bgColor index 51
+inconsistentColor index 12
+topShadowColor index 2
+botShadowColor index 12
+controlPv "$(P)$(R)ImageMode"
+indicatorPv "$(P)$(R)ImageMode"
+font "helvetica-medium-r-10.0"
+endObjectProperties
+
+# (Menu Button)
+object activeMenuButtonClass
+beginObjectProperties
+major 4
+minor 0
+release 0
 x 160
-y 380
+y 455
 w 90
 h 20
 fgColor index 14
@@ -926,7 +1057,7 @@ major 4
 minor 0
 release 0
 x 130
-y 155
+y 180
 w 120
 h 20
 fgColor index 14
@@ -934,8 +1065,28 @@ bgColor index 51
 inconsistentColor index 12
 topShadowColor index 2
 botShadowColor index 12
-controlPv "$(P)$(R)ImageMode"
-indicatorPv "$(P)$(R)ImageMode"
+controlPv "$(P)$(R)TriggerMode"
+indicatorPv "$(P)$(R)TriggerMode"
+font "helvetica-medium-r-10.0"
+endObjectProperties
+
+# (Menu Button)
+object activeMenuButtonClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 180
+y 280
+w 80
+h 20
+fgColor index 14
+bgColor index 51
+inconsistentColor index 12
+topShadowColor index 2
+botShadowColor index 12
+controlPv "$(P)$(R)TriggerMode"
+indicatorPv "$(P)$(R)TriggerMode"
 font "helvetica-medium-r-10.0"
 endObjectProperties
 

--- a/ADApp/op/opi/autoconvert/ADBase.opi
+++ b/ADApp/op/opi/autoconvert/ADBase.opi
@@ -14,7 +14,7 @@
     <color red="0" green="0" blue="0" />
   </foreground_color>
   <grid_space>5</grid_space>
-  <height>915</height>
+  <height>945</height>
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
@@ -202,7 +202,7 @@ $(pv_value)</tooltip>
     <widget_type>Linking Container</widget_type>
     <width>350</width>
     <x>360</x>
-    <y>780</y>
+    <y>830</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
     <actions hook="false" hook_all="false" />
@@ -300,7 +300,7 @@ $(pv_value)</tooltip>
       <color red="0" green="0" blue="0" />
     </foreground_color>
     <group_name></group_name>
-    <height>405</height>
+    <height>480</height>
     <macros>
       <include_parent_macros>true</include_parent_macros>
     </macros>
@@ -378,7 +378,7 @@ $(pv_value)</tooltip>
       <color red="0" green="0" blue="0" />
     </foreground_color>
     <group_name></group_name>
-    <height>160</height>
+    <height>135</height>
     <macros>
       <include_parent_macros>true</include_parent_macros>
     </macros>
@@ -397,7 +397,7 @@ $(pv_value)</tooltip>
     <widget_type>Linking Container</widget_type>
     <width>350</width>
     <x>360</x>
-    <y>615</y>
+    <y>690</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <actions hook="false" hook_all="false" />

--- a/ADApp/op/opi/autoconvert/ADBase.opi
+++ b/ADApp/op/opi/autoconvert/ADBase.opi
@@ -14,7 +14,7 @@
     <color red="0" green="0" blue="0" />
   </foreground_color>
   <grid_space>5</grid_space>
-  <height>935</height>
+  <height>915</height>
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
@@ -202,7 +202,7 @@ $(pv_value)</tooltip>
     <widget_type>Linking Container</widget_type>
     <width>350</width>
     <x>360</x>
-    <y>820</y>
+    <y>780</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
     <actions hook="false" hook_all="false" />
@@ -240,8 +240,8 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <widget_type>Linking Container</widget_type>
     <width>350</width>
-    <x>360</x>
-    <y>755</y>
+    <x>5</x>
+    <y>850</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
     <actions hook="false" hook_all="false" />
@@ -378,7 +378,7 @@ $(pv_value)</tooltip>
       <color red="0" green="0" blue="0" />
     </foreground_color>
     <group_name></group_name>
-    <height>135</height>
+    <height>160</height>
     <macros>
       <include_parent_macros>true</include_parent_macros>
     </macros>

--- a/ADApp/op/opi/autoconvert/ADBuffers.opi
+++ b/ADApp/op/opi/autoconvert/ADBuffers.opi
@@ -14,7 +14,7 @@
     <color red="0" green="0" blue="0" />
   </foreground_color>
   <grid_space>5</grid_space>
-  <height>160</height>
+  <height>135</height>
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
@@ -61,7 +61,7 @@
       <color red="0" green="0" blue="0" />
     </foreground_color>
     <gradient>false</gradient>
-    <height>160</height>
+    <height>135</height>
     <horizontal_fill>true</horizontal_fill>
     <line_color>
       <color red="0" green="0" blue="0" />
@@ -499,7 +499,7 @@ $(pv_value)</tooltip>
     <widget_type>Menu Button</widget_type>
     <width>90</width>
     <x>245</x>
-    <y>130</y>
+    <y>105</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <actions hook="false" hook_all="false" />
@@ -539,7 +539,7 @@ $(pv_value)</tooltip>
     <width>230</width>
     <wrap_words>false</wrap_words>
     <x>10</x>
-    <y>130</y>
+    <y>105</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
     <actions hook="false" hook_all="false" />
@@ -682,96 +682,5 @@ $(pv_value)</tooltip>
     <wrap_words>false</wrap_words>
     <x>10</x>
     <y>80</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <alarm_pulsing>false</alarm_pulsing>
-    <auto_size>false</auto_size>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="187" green="187" blue="187" />
-    </background_color>
-    <border_alarm_sensitive>true</border_alarm_sensitive>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
-    </font>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <foreground_color>
-      <color red="10" green="0" blue="184" />
-    </foreground_color>
-    <format_type>1</format_type>
-    <height>18</height>
-    <horizontal_alignment>2</horizontal_alignment>
-    <name>Text Update</name>
-    <precision>0</precision>
-    <precision_from_pv>true</precision_from_pv>
-    <pv_name>$(P)$(R)NumActivePlugins</pv_name>
-    <pv_value />
-    <rotation_angle>0.0</rotation_angle>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_units>false</show_units>
-    <text>######</text>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <transparent>false</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Text Update</widget_type>
-    <width>60</width>
-    <wrap_words>false</wrap_words>
-    <x>215</x>
-    <y>106</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <auto_size>false</auto_size>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
-    </font>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <height>20</height>
-    <horizontal_alignment>2</horizontal_alignment>
-    <name>Label</name>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_scrollbar>false</show_scrollbar>
-    <text># active plugins</text>
-    <tooltip></tooltip>
-    <transparent>true</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Label</widget_type>
-    <width>200</width>
-    <wrap_words>false</wrap_words>
-    <x>10</x>
-    <y>105</y>
   </widget>
 </display>

--- a/ADApp/op/opi/autoconvert/ADBuffers.opi
+++ b/ADApp/op/opi/autoconvert/ADBuffers.opi
@@ -14,7 +14,7 @@
     <color red="0" green="0" blue="0" />
   </foreground_color>
   <grid_space>5</grid_space>
-  <height>135</height>
+  <height>160</height>
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
@@ -61,7 +61,7 @@
       <color red="0" green="0" blue="0" />
     </foreground_color>
     <gradient>false</gradient>
-    <height>135</height>
+    <height>160</height>
     <horizontal_fill>true</horizontal_fill>
     <line_color>
       <color red="0" green="0" blue="0" />
@@ -224,108 +224,6 @@ $(pv_value)</tooltip>
     <x>97</x>
     <y>3</y>
   </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <alarm_pulsing>false</alarm_pulsing>
-    <auto_size>false</auto_size>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="187" green="187" blue="187" />
-    </background_color>
-    <border_alarm_sensitive>true</border_alarm_sensitive>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
-    </font>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <foreground_color>
-      <color red="10" green="0" blue="184" />
-    </foreground_color>
-    <format_type>1</format_type>
-    <height>18</height>
-    <horizontal_alignment>2</horizontal_alignment>
-    <name>Text Update</name>
-    <precision>0</precision>
-    <precision_from_pv>true</precision_from_pv>
-    <pv_name>$(P)$(R)PoolMaxMem</pv_name>
-    <pv_value />
-    <rotation_angle>0.0</rotation_angle>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_units>false</show_units>
-    <text>######</text>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <transparent>false</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Text Update</widget_type>
-    <width>60</width>
-    <wrap_words>false</wrap_words>
-    <x>215</x>
-    <y>81</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <alarm_pulsing>false</alarm_pulsing>
-    <auto_size>false</auto_size>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="187" green="187" blue="187" />
-    </background_color>
-    <border_alarm_sensitive>true</border_alarm_sensitive>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
-    </font>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <foreground_color>
-      <color red="10" green="0" blue="184" />
-    </foreground_color>
-    <format_type>1</format_type>
-    <height>18</height>
-    <horizontal_alignment>2</horizontal_alignment>
-    <name>Text Update</name>
-    <precision>0</precision>
-    <precision_from_pv>true</precision_from_pv>
-    <pv_name>$(P)$(R)PoolUsedMem</pv_name>
-    <pv_value />
-    <rotation_angle>0.0</rotation_angle>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_units>false</show_units>
-    <text>######</text>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <transparent>false</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Text Update</widget_type>
-    <width>60</width>
-    <wrap_words>false</wrap_words>
-    <x>280</x>
-    <y>81</y>
-  </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <actions hook="false" hook_all="false" />
     <auto_size>false</auto_size>
@@ -355,7 +253,7 @@ $(pv_value)</tooltip>
     </scale_options>
     <scripts />
     <show_scrollbar>false</show_scrollbar>
-    <text>Buffers max/used</text>
+    <text>Buffers used</text>
     <tooltip></tooltip>
     <transparent>true</transparent>
     <vertical_alignment>1</vertical_alignment>
@@ -365,57 +263,6 @@ $(pv_value)</tooltip>
     <wrap_words>false</wrap_words>
     <x>50</x>
     <y>30</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <alarm_pulsing>false</alarm_pulsing>
-    <auto_size>false</auto_size>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="187" green="187" blue="187" />
-    </background_color>
-    <border_alarm_sensitive>true</border_alarm_sensitive>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
-    </font>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <foreground_color>
-      <color red="10" green="0" blue="184" />
-    </foreground_color>
-    <format_type>1</format_type>
-    <height>18</height>
-    <horizontal_alignment>2</horizontal_alignment>
-    <name>Text Update</name>
-    <precision>0</precision>
-    <precision_from_pv>true</precision_from_pv>
-    <pv_name>$(P)$(R)PoolMaxBuffers</pv_name>
-    <pv_value />
-    <rotation_angle>0.0</rotation_angle>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_units>false</show_units>
-    <text>######</text>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <transparent>false</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Text Update</widget_type>
-    <width>50</width>
-    <wrap_words>false</wrap_words>
-    <x>215</x>
-    <y>31</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
     <actions hook="false" hook_all="false" />
@@ -465,7 +312,7 @@ $(pv_value)</tooltip>
     <widget_type>Text Update</widget_type>
     <width>50</width>
     <wrap_words>false</wrap_words>
-    <x>270</x>
+    <x>215</x>
     <y>31</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
@@ -652,7 +499,7 @@ $(pv_value)</tooltip>
     <widget_type>Menu Button</widget_type>
     <width>90</width>
     <x>245</x>
-    <y>105</y>
+    <y>130</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <actions hook="false" hook_all="false" />
@@ -692,7 +539,109 @@ $(pv_value)</tooltip>
     <width>230</width>
     <wrap_words>false</wrap_words>
     <x>10</x>
-    <y>105</y>
+    <y>130</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color red="187" green="187" blue="187" />
+    </background_color>
+    <border_alarm_sensitive>true</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color red="10" green="0" blue="184" />
+    </foreground_color>
+    <format_type>1</format_type>
+    <height>18</height>
+    <horizontal_alignment>2</horizontal_alignment>
+    <name>Text Update</name>
+    <precision>0</precision>
+    <precision_from_pv>true</precision_from_pv>
+    <pv_name>$(P)$(R)PoolMaxMem</pv_name>
+    <pv_value />
+    <rotation_angle>0.0</rotation_angle>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_units>false</show_units>
+    <text>######</text>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Text Update</widget_type>
+    <width>60</width>
+    <wrap_words>false</wrap_words>
+    <x>215</x>
+    <y>81</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color red="187" green="187" blue="187" />
+    </background_color>
+    <border_alarm_sensitive>true</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color red="10" green="0" blue="184" />
+    </foreground_color>
+    <format_type>1</format_type>
+    <height>18</height>
+    <horizontal_alignment>2</horizontal_alignment>
+    <name>Text Update</name>
+    <precision>0</precision>
+    <precision_from_pv>true</precision_from_pv>
+    <pv_name>$(P)$(R)PoolUsedMem</pv_name>
+    <pv_value />
+    <rotation_angle>0.0</rotation_angle>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_units>false</show_units>
+    <text>######</text>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Text Update</widget_type>
+    <width>60</width>
+    <wrap_words>false</wrap_words>
+    <x>280</x>
+    <y>81</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <actions hook="false" hook_all="false" />
@@ -733,5 +682,96 @@ $(pv_value)</tooltip>
     <wrap_words>false</wrap_words>
     <x>10</x>
     <y>80</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color red="187" green="187" blue="187" />
+    </background_color>
+    <border_alarm_sensitive>true</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color red="10" green="0" blue="184" />
+    </foreground_color>
+    <format_type>1</format_type>
+    <height>18</height>
+    <horizontal_alignment>2</horizontal_alignment>
+    <name>Text Update</name>
+    <precision>0</precision>
+    <precision_from_pv>true</precision_from_pv>
+    <pv_name>$(P)$(R)NumActivePlugins</pv_name>
+    <pv_value />
+    <rotation_angle>0.0</rotation_angle>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_units>false</show_units>
+    <text>######</text>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Text Update</widget_type>
+    <width>60</width>
+    <wrap_words>false</wrap_words>
+    <x>215</x>
+    <y>106</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color red="255" green="255" blue="255" />
+    </background_color>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
+    </font>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <horizontal_alignment>2</horizontal_alignment>
+    <name>Label</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_scrollbar>false</show_scrollbar>
+    <text># active plugins</text>
+    <tooltip></tooltip>
+    <transparent>true</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>200</width>
+    <wrap_words>false</wrap_words>
+    <x>10</x>
+    <y>105</y>
   </widget>
 </display>

--- a/ADApp/op/opi/autoconvert/ADCollect.opi
+++ b/ADApp/op/opi/autoconvert/ADCollect.opi
@@ -14,7 +14,7 @@
     <color red="0" green="0" blue="0" />
   </foreground_color>
   <grid_space>5</grid_space>
-  <height>405</height>
+  <height>480</height>
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
@@ -28,8 +28,8 @@
   <snap_to_geometry>false</snap_to_geometry>
   <widget_type>Display</widget_type>
   <width>350</width>
-  <x>44</x>
-  <y>221</y>
+  <x>446</x>
+  <y>331</y>
   <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
     <actions hook="false" hook_all="false" />
     <alarm_pulsing>false</alarm_pulsing>
@@ -61,7 +61,7 @@
       <color red="0" green="0" blue="0" />
     </foreground_color>
     <gradient>false</gradient>
-    <height>405</height>
+    <height>480</height>
     <horizontal_fill>true</horizontal_fill>
     <line_color>
       <color red="0" green="0" blue="0" />
@@ -863,141 +863,6 @@ $(pv_value)</tooltip>
       <fontdata fontName="Sans" height="11" style="0" pixels="false" />
     </font>
     <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <height>20</height>
-    <horizontal_alignment>2</horizontal_alignment>
-    <name>Label</name>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_scrollbar>false</show_scrollbar>
-    <text>Trigger mode</text>
-    <tooltip></tooltip>
-    <transparent>true</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Label</widget_type>
-    <width>120</width>
-    <wrap_words>false</wrap_words>
-    <x>5</x>
-    <y>180</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.MenuButton" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <actions_from_pv>true</actions_from_pv>
-    <alarm_pulsing>false</alarm_pulsing>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="115" green="223" blue="255" />
-    </background_color>
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>6</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <opifont.name fontName="Sans" height="10" style="0" pixels="false">Default</opifont.name>
-    </font>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <height>20</height>
-    <label></label>
-    <name>Menu Button</name>
-    <pv_name>$(P)$(R)TriggerMode</pv_name>
-    <pv_value />
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_down_arrow>false</show_down_arrow>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <transparent>false</transparent>
-    <visible>true</visible>
-    <widget_type>Menu Button</widget_type>
-    <width>120</width>
-    <x>130</x>
-    <y>180</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <alarm_pulsing>false</alarm_pulsing>
-    <auto_size>false</auto_size>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="187" green="187" blue="187" />
-    </background_color>
-    <border_alarm_sensitive>true</border_alarm_sensitive>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
-    </font>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <foreground_color>
-      <color red="10" green="0" blue="184" />
-    </foreground_color>
-    <format_type>4</format_type>
-    <height>18</height>
-    <horizontal_alignment>0</horizontal_alignment>
-    <name>Text Update</name>
-    <precision>0</precision>
-    <precision_from_pv>true</precision_from_pv>
-    <pv_name>$(P)$(R)TriggerMode_RBV</pv_name>
-    <pv_value />
-    <rotation_angle>0.0</rotation_angle>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_units>false</show_units>
-    <text>######</text>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <transparent>false</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Text Update</widget_type>
-    <width>80</width>
-    <wrap_words>false</wrap_words>
-    <x>255</x>
-    <y>181</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <auto_size>false</auto_size>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
-    </font>
-    <foreground_color>
       <color red="40" green="147" blue="21" />
     </foreground_color>
     <height>20</height>
@@ -1244,658 +1109,6 @@ $(pv_value)</tooltip>
       <fontdata fontName="Sans" height="11" style="0" pixels="false" />
     </font>
     <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <height>20</height>
-    <horizontal_alignment>2</horizontal_alignment>
-    <name>Label</name>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_scrollbar>false</show_scrollbar>
-    <text>Detector state</text>
-    <tooltip></tooltip>
-    <transparent>true</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Label</widget_type>
-    <width>140</width>
-    <wrap_words>false</wrap_words>
-    <x>35</x>
-    <y>255</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <alarm_pulsing>false</alarm_pulsing>
-    <auto_size>false</auto_size>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="218" green="218" blue="218" />
-    </background_color>
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
-    </font>
-    <forecolor_alarm_sensitive>true</forecolor_alarm_sensitive>
-    <foreground_color>
-      <color name="OK" red="0" green="255" blue="0" />
-    </foreground_color>
-    <format_type>1</format_type>
-    <height>18</height>
-    <horizontal_alignment>0</horizontal_alignment>
-    <name>Text Update</name>
-    <precision>0</precision>
-    <precision_from_pv>true</precision_from_pv>
-    <pv_name>$(P)$(R)DetectorState_RBV</pv_name>
-    <pv_value />
-    <rotation_angle>0.0</rotation_angle>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_units>false</show_units>
-    <text>######</text>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <transparent>false</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Text Update</widget_type>
-    <width>158</width>
-    <wrap_words>false</wrap_words>
-    <x>180</x>
-    <y>255</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <auto_size>false</auto_size>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
-    </font>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <height>20</height>
-    <horizontal_alignment>2</horizontal_alignment>
-    <name>Label</name>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_scrollbar>false</show_scrollbar>
-    <text>Time remaining</text>
-    <tooltip></tooltip>
-    <transparent>true</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Label</widget_type>
-    <width>140</width>
-    <wrap_words>false</wrap_words>
-    <x>35</x>
-    <y>305</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <alarm_pulsing>false</alarm_pulsing>
-    <auto_size>false</auto_size>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="187" green="187" blue="187" />
-    </background_color>
-    <border_alarm_sensitive>true</border_alarm_sensitive>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
-    </font>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <foreground_color>
-      <color red="10" green="0" blue="184" />
-    </foreground_color>
-    <format_type>1</format_type>
-    <height>18</height>
-    <horizontal_alignment>0</horizontal_alignment>
-    <name>Text Update</name>
-    <precision>0</precision>
-    <precision_from_pv>true</precision_from_pv>
-    <pv_name>$(P)$(R)TimeRemaining_RBV</pv_name>
-    <pv_value />
-    <rotation_angle>0.0</rotation_angle>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_units>false</show_units>
-    <text>######</text>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <transparent>false</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Text Update</widget_type>
-    <width>67</width>
-    <wrap_words>false</wrap_words>
-    <x>180</x>
-    <y>306</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.TextInput" version="2.0.0">
-    <actions hook="false" hook_all="false" />
-    <alarm_pulsing>false</alarm_pulsing>
-    <auto_size>false</auto_size>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="115" green="223" blue="255" />
-    </background_color>
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>3</border_style>
-    <border_width>1</border_width>
-    <confirm_message></confirm_message>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
-    </font>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <format_type>1</format_type>
-    <height>20</height>
-    <horizontal_alignment>0</horizontal_alignment>
-    <limits_from_pv>false</limits_from_pv>
-    <maximum>Infinity</maximum>
-    <minimum>-Infinity</minimum>
-    <multiline_input>false</multiline_input>
-    <name>Text Input</name>
-    <next_focus>0</next_focus>
-    <password_input>false</password_input>
-    <precision>0</precision>
-    <precision_from_pv>true</precision_from_pv>
-    <pv_name>$(P)$(R)ArrayCounter</pv_name>
-    <pv_value />
-    <read_only>false</read_only>
-    <rotation_angle>0.0</rotation_angle>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <selector_type>0</selector_type>
-    <show_h_scroll>false</show_h_scroll>
-    <show_native_border>true</show_native_border>
-    <show_units>false</show_units>
-    <show_v_scroll>false</show_v_scroll>
-    <style>0</style>
-    <text></text>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <transparent>false</transparent>
-    <visible>true</visible>
-    <widget_type>Text Input</widget_type>
-    <width>60</width>
-    <x>180</x>
-    <y>330</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <auto_size>false</auto_size>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
-    </font>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <height>20</height>
-    <horizontal_alignment>2</horizontal_alignment>
-    <name>Label</name>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_scrollbar>false</show_scrollbar>
-    <text>Image counter</text>
-    <tooltip></tooltip>
-    <transparent>true</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Label</widget_type>
-    <width>130</width>
-    <wrap_words>false</wrap_words>
-    <x>45</x>
-    <y>330</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <alarm_pulsing>false</alarm_pulsing>
-    <auto_size>false</auto_size>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="187" green="187" blue="187" />
-    </background_color>
-    <border_alarm_sensitive>true</border_alarm_sensitive>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
-    </font>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <foreground_color>
-      <color red="10" green="0" blue="184" />
-    </foreground_color>
-    <format_type>1</format_type>
-    <height>18</height>
-    <horizontal_alignment>0</horizontal_alignment>
-    <name>Text Update</name>
-    <precision>0</precision>
-    <precision_from_pv>true</precision_from_pv>
-    <pv_name>$(P)$(R)ArrayCounter_RBV</pv_name>
-    <pv_value />
-    <rotation_angle>0.0</rotation_angle>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_units>false</show_units>
-    <text>######</text>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <transparent>false</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Text Update</widget_type>
-    <width>80</width>
-    <wrap_words>false</wrap_words>
-    <x>245</x>
-    <y>331</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <auto_size>false</auto_size>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
-    </font>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <height>20</height>
-    <horizontal_alignment>2</horizontal_alignment>
-    <name>Label</name>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_scrollbar>false</show_scrollbar>
-    <text>Image rate</text>
-    <tooltip></tooltip>
-    <transparent>true</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Label</widget_type>
-    <width>100</width>
-    <wrap_words>false</wrap_words>
-    <x>75</x>
-    <y>355</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <alarm_pulsing>false</alarm_pulsing>
-    <auto_size>false</auto_size>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="187" green="187" blue="187" />
-    </background_color>
-    <border_alarm_sensitive>true</border_alarm_sensitive>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
-    </font>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <foreground_color>
-      <color red="10" green="0" blue="184" />
-    </foreground_color>
-    <format_type>1</format_type>
-    <height>18</height>
-    <horizontal_alignment>0</horizontal_alignment>
-    <name>Text Update</name>
-    <precision>0</precision>
-    <precision_from_pv>true</precision_from_pv>
-    <pv_name>$(P)$(R)ArrayRate_RBV</pv_name>
-    <pv_value />
-    <rotation_angle>0.0</rotation_angle>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_units>false</show_units>
-    <text>######</text>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <transparent>false</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Text Update</widget_type>
-    <width>100</width>
-    <wrap_words>false</wrap_words>
-    <x>180</x>
-    <y>356</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <auto_size>false</auto_size>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
-    </font>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <height>20</height>
-    <horizontal_alignment>2</horizontal_alignment>
-    <name>Label</name>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_scrollbar>false</show_scrollbar>
-    <text>Array callbacks</text>
-    <tooltip></tooltip>
-    <transparent>true</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Label</widget_type>
-    <width>150</width>
-    <wrap_words>false</wrap_words>
-    <x>5</x>
-    <y>380</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.MenuButton" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <actions_from_pv>true</actions_from_pv>
-    <alarm_pulsing>false</alarm_pulsing>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="115" green="223" blue="255" />
-    </background_color>
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>6</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <opifont.name fontName="Sans" height="10" style="0" pixels="false">Default</opifont.name>
-    </font>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <height>20</height>
-    <label></label>
-    <name>Menu Button</name>
-    <pv_name>$(P)$(R)ArrayCallbacks</pv_name>
-    <pv_value />
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_down_arrow>false</show_down_arrow>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <transparent>false</transparent>
-    <visible>true</visible>
-    <widget_type>Menu Button</widget_type>
-    <width>90</width>
-    <x>160</x>
-    <y>380</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <alarm_pulsing>false</alarm_pulsing>
-    <auto_size>false</auto_size>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="187" green="187" blue="187" />
-    </background_color>
-    <border_alarm_sensitive>true</border_alarm_sensitive>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
-    </font>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <foreground_color>
-      <color red="10" green="0" blue="184" />
-    </foreground_color>
-    <format_type>4</format_type>
-    <height>18</height>
-    <horizontal_alignment>1</horizontal_alignment>
-    <name>Text Update</name>
-    <precision>0</precision>
-    <precision_from_pv>true</precision_from_pv>
-    <pv_name>$(P)$(R)ArrayCallbacks_RBV</pv_name>
-    <pv_value />
-    <rotation_angle>0.0</rotation_angle>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_units>false</show_units>
-    <text>######</text>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <transparent>false</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Text Update</widget_type>
-    <width>80</width>
-    <wrap_words>false</wrap_words>
-    <x>255</x>
-    <y>382</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <auto_size>false</auto_size>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
-    </font>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <height>20</height>
-    <horizontal_alignment>2</horizontal_alignment>
-    <name>Label</name>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_scrollbar>false</show_scrollbar>
-    <text>Status</text>
-    <tooltip></tooltip>
-    <transparent>true</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Label</widget_type>
-    <width>60</width>
-    <wrap_words>false</wrap_words>
-    <x>5</x>
-    <y>280</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <alarm_pulsing>false</alarm_pulsing>
-    <auto_size>false</auto_size>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="218" green="218" blue="218" />
-    </background_color>
-    <border_alarm_sensitive>true</border_alarm_sensitive>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
-    </font>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <foreground_color>
-      <color red="10" green="0" blue="184" />
-    </foreground_color>
-    <format_type>4</format_type>
-    <height>18</height>
-    <horizontal_alignment>0</horizontal_alignment>
-    <name>Text Update</name>
-    <precision>0</precision>
-    <precision_from_pv>true</precision_from_pv>
-    <pv_name>$(P)$(R)StatusMessage_RBV</pv_name>
-    <pv_value />
-    <rotation_angle>0.0</rotation_angle>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_units>false</show_units>
-    <text>######</text>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <transparent>false</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Text Update</widget_type>
-    <width>275</width>
-    <wrap_words>false</wrap_words>
-    <x>70</x>
-    <y>280</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <auto_size>false</auto_size>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
-    </font>
-    <foreground_color>
       <color red="10" green="0" blue="184" />
     </foreground_color>
     <height>20</height>
@@ -2054,5 +1267,1109 @@ $(pv_value)</tooltip>
     <wrap_words>false</wrap_words>
     <x>255</x>
     <y>157</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color red="255" green="255" blue="255" />
+    </background_color>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
+    </font>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <horizontal_alignment>2</horizontal_alignment>
+    <name>Label</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_scrollbar>false</show_scrollbar>
+    <text>Detector state</text>
+    <tooltip></tooltip>
+    <transparent>true</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>140</width>
+    <wrap_words>false</wrap_words>
+    <x>35</x>
+    <y>330</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color red="218" green="218" blue="218" />
+    </background_color>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
+    </font>
+    <forecolor_alarm_sensitive>true</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color name="OK" red="0" green="255" blue="0" />
+    </foreground_color>
+    <format_type>1</format_type>
+    <height>18</height>
+    <horizontal_alignment>0</horizontal_alignment>
+    <name>Text Update</name>
+    <precision>0</precision>
+    <precision_from_pv>true</precision_from_pv>
+    <pv_name>$(P)$(R)DetectorState_RBV</pv_name>
+    <pv_value />
+    <rotation_angle>0.0</rotation_angle>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_units>false</show_units>
+    <text>######</text>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Text Update</widget_type>
+    <width>160</width>
+    <wrap_words>false</wrap_words>
+    <x>180</x>
+    <y>330</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color red="255" green="255" blue="255" />
+    </background_color>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
+    </font>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <horizontal_alignment>2</horizontal_alignment>
+    <name>Label</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_scrollbar>false</show_scrollbar>
+    <text>Time remaining</text>
+    <tooltip></tooltip>
+    <transparent>true</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>140</width>
+    <wrap_words>false</wrap_words>
+    <x>35</x>
+    <y>380</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color red="187" green="187" blue="187" />
+    </background_color>
+    <border_alarm_sensitive>true</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color red="10" green="0" blue="184" />
+    </foreground_color>
+    <format_type>1</format_type>
+    <height>18</height>
+    <horizontal_alignment>0</horizontal_alignment>
+    <name>Text Update</name>
+    <precision>0</precision>
+    <precision_from_pv>true</precision_from_pv>
+    <pv_name>$(P)$(R)TimeRemaining_RBV</pv_name>
+    <pv_value />
+    <rotation_angle>0.0</rotation_angle>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_units>false</show_units>
+    <text>######</text>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Text Update</widget_type>
+    <width>67</width>
+    <wrap_words>false</wrap_words>
+    <x>180</x>
+    <y>381</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.TextInput" version="2.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color red="115" green="223" blue="255" />
+    </background_color>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>3</border_style>
+    <border_width>1</border_width>
+    <confirm_message></confirm_message>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <format_type>1</format_type>
+    <height>20</height>
+    <horizontal_alignment>0</horizontal_alignment>
+    <limits_from_pv>false</limits_from_pv>
+    <maximum>Infinity</maximum>
+    <minimum>-Infinity</minimum>
+    <multiline_input>false</multiline_input>
+    <name>Text Input</name>
+    <next_focus>0</next_focus>
+    <password_input>false</password_input>
+    <precision>0</precision>
+    <precision_from_pv>true</precision_from_pv>
+    <pv_name>$(P)$(R)ArrayCounter</pv_name>
+    <pv_value />
+    <read_only>false</read_only>
+    <rotation_angle>0.0</rotation_angle>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <selector_type>0</selector_type>
+    <show_h_scroll>false</show_h_scroll>
+    <show_native_border>true</show_native_border>
+    <show_units>false</show_units>
+    <show_v_scroll>false</show_v_scroll>
+    <style>0</style>
+    <text></text>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <visible>true</visible>
+    <widget_type>Text Input</widget_type>
+    <width>60</width>
+    <x>180</x>
+    <y>405</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color red="255" green="255" blue="255" />
+    </background_color>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
+    </font>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <horizontal_alignment>2</horizontal_alignment>
+    <name>Label</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_scrollbar>false</show_scrollbar>
+    <text>Image counter</text>
+    <tooltip></tooltip>
+    <transparent>true</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>130</width>
+    <wrap_words>false</wrap_words>
+    <x>45</x>
+    <y>405</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color red="187" green="187" blue="187" />
+    </background_color>
+    <border_alarm_sensitive>true</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color red="10" green="0" blue="184" />
+    </foreground_color>
+    <format_type>1</format_type>
+    <height>18</height>
+    <horizontal_alignment>0</horizontal_alignment>
+    <name>Text Update</name>
+    <precision>0</precision>
+    <precision_from_pv>true</precision_from_pv>
+    <pv_name>$(P)$(R)ArrayCounter_RBV</pv_name>
+    <pv_value />
+    <rotation_angle>0.0</rotation_angle>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_units>false</show_units>
+    <text>######</text>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Text Update</widget_type>
+    <width>80</width>
+    <wrap_words>false</wrap_words>
+    <x>245</x>
+    <y>406</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color red="255" green="255" blue="255" />
+    </background_color>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
+    </font>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <horizontal_alignment>2</horizontal_alignment>
+    <name>Label</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_scrollbar>false</show_scrollbar>
+    <text>Image rate</text>
+    <tooltip></tooltip>
+    <transparent>true</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>100</width>
+    <wrap_words>false</wrap_words>
+    <x>75</x>
+    <y>430</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color red="187" green="187" blue="187" />
+    </background_color>
+    <border_alarm_sensitive>true</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color red="10" green="0" blue="184" />
+    </foreground_color>
+    <format_type>1</format_type>
+    <height>18</height>
+    <horizontal_alignment>0</horizontal_alignment>
+    <name>Text Update</name>
+    <precision>0</precision>
+    <precision_from_pv>true</precision_from_pv>
+    <pv_name>$(P)$(R)ArrayRate_RBV</pv_name>
+    <pv_value />
+    <rotation_angle>0.0</rotation_angle>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_units>false</show_units>
+    <text>######</text>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Text Update</widget_type>
+    <width>100</width>
+    <wrap_words>false</wrap_words>
+    <x>180</x>
+    <y>431</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color red="255" green="255" blue="255" />
+    </background_color>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
+    </font>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <horizontal_alignment>2</horizontal_alignment>
+    <name>Label</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_scrollbar>false</show_scrollbar>
+    <text>Array callbacks</text>
+    <tooltip></tooltip>
+    <transparent>true</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>150</width>
+    <wrap_words>false</wrap_words>
+    <x>5</x>
+    <y>455</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.MenuButton" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <actions_from_pv>true</actions_from_pv>
+    <alarm_pulsing>false</alarm_pulsing>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color red="115" green="223" blue="255" />
+    </background_color>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>6</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <opifont.name fontName="Sans" height="10" style="0" pixels="false">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <label></label>
+    <name>Menu Button</name>
+    <pv_name>$(P)$(R)ArrayCallbacks</pv_name>
+    <pv_value />
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_down_arrow>false</show_down_arrow>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <visible>true</visible>
+    <widget_type>Menu Button</widget_type>
+    <width>90</width>
+    <x>160</x>
+    <y>455</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color red="187" green="187" blue="187" />
+    </background_color>
+    <border_alarm_sensitive>true</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color red="10" green="0" blue="184" />
+    </foreground_color>
+    <format_type>4</format_type>
+    <height>18</height>
+    <horizontal_alignment>1</horizontal_alignment>
+    <name>Text Update</name>
+    <precision>0</precision>
+    <precision_from_pv>true</precision_from_pv>
+    <pv_name>$(P)$(R)ArrayCallbacks_RBV</pv_name>
+    <pv_value />
+    <rotation_angle>0.0</rotation_angle>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_units>false</show_units>
+    <text>######</text>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Text Update</widget_type>
+    <width>80</width>
+    <wrap_words>false</wrap_words>
+    <x>255</x>
+    <y>457</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color red="255" green="255" blue="255" />
+    </background_color>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
+    </font>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <horizontal_alignment>2</horizontal_alignment>
+    <name>Label</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_scrollbar>false</show_scrollbar>
+    <text>Status</text>
+    <tooltip></tooltip>
+    <transparent>true</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>60</width>
+    <wrap_words>false</wrap_words>
+    <x>5</x>
+    <y>355</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color red="218" green="218" blue="218" />
+    </background_color>
+    <border_alarm_sensitive>true</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color red="10" green="0" blue="184" />
+    </foreground_color>
+    <format_type>4</format_type>
+    <height>18</height>
+    <horizontal_alignment>0</horizontal_alignment>
+    <name>Text Update</name>
+    <precision>0</precision>
+    <precision_from_pv>true</precision_from_pv>
+    <pv_name>$(P)$(R)StatusMessage_RBV</pv_name>
+    <pv_value />
+    <rotation_angle>0.0</rotation_angle>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_units>false</show_units>
+    <text>######</text>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Text Update</widget_type>
+    <width>275</width>
+    <wrap_words>false</wrap_words>
+    <x>70</x>
+    <y>355</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color red="255" green="255" blue="255" />
+    </background_color>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
+    </font>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <horizontal_alignment>2</horizontal_alignment>
+    <name>Label</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_scrollbar>false</show_scrollbar>
+    <text># active plugins</text>
+    <tooltip></tooltip>
+    <transparent>true</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>160</width>
+    <wrap_words>false</wrap_words>
+    <x>15</x>
+    <y>255</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color red="187" green="187" blue="187" />
+    </background_color>
+    <border_alarm_sensitive>true</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color red="10" green="0" blue="184" />
+    </foreground_color>
+    <format_type>1</format_type>
+    <height>18</height>
+    <horizontal_alignment>2</horizontal_alignment>
+    <name>Text Update</name>
+    <precision>0</precision>
+    <precision_from_pv>true</precision_from_pv>
+    <pv_name>$(P)$(R)NumActivePlugins</pv_name>
+    <pv_value />
+    <rotation_angle>0.0</rotation_angle>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_units>false</show_units>
+    <text>######</text>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Text Update</widget_type>
+    <width>60</width>
+    <wrap_words>false</wrap_words>
+    <x>180</x>
+    <y>256</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color red="255" green="255" blue="255" />
+    </background_color>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
+    </font>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <horizontal_alignment>2</horizontal_alignment>
+    <name>Label</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_scrollbar>false</show_scrollbar>
+    <text>Trigger mode</text>
+    <tooltip></tooltip>
+    <transparent>true</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>120</width>
+    <wrap_words>false</wrap_words>
+    <x>5</x>
+    <y>180</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.MenuButton" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <actions_from_pv>true</actions_from_pv>
+    <alarm_pulsing>false</alarm_pulsing>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color red="115" green="223" blue="255" />
+    </background_color>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>6</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <opifont.name fontName="Sans" height="10" style="0" pixels="false">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <label></label>
+    <name>Menu Button</name>
+    <pv_name>$(P)$(R)TriggerMode</pv_name>
+    <pv_value />
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_down_arrow>false</show_down_arrow>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <visible>true</visible>
+    <widget_type>Menu Button</widget_type>
+    <width>120</width>
+    <x>130</x>
+    <y>180</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color red="187" green="187" blue="187" />
+    </background_color>
+    <border_alarm_sensitive>true</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color red="10" green="0" blue="184" />
+    </foreground_color>
+    <format_type>4</format_type>
+    <height>18</height>
+    <horizontal_alignment>0</horizontal_alignment>
+    <name>Text Update</name>
+    <precision>0</precision>
+    <precision_from_pv>true</precision_from_pv>
+    <pv_name>$(P)$(R)TriggerMode_RBV</pv_name>
+    <pv_value />
+    <rotation_angle>0.0</rotation_angle>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_units>false</show_units>
+    <text>######</text>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Text Update</widget_type>
+    <width>80</width>
+    <wrap_words>false</wrap_words>
+    <x>255</x>
+    <y>181</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color red="255" green="255" blue="255" />
+    </background_color>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
+    </font>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <horizontal_alignment>2</horizontal_alignment>
+    <name>Label</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_scrollbar>false</show_scrollbar>
+    <text>Wait for plugins</text>
+    <tooltip></tooltip>
+    <transparent>true</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>160</width>
+    <wrap_words>false</wrap_words>
+    <x>15</x>
+    <y>280</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.MenuButton" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <actions_from_pv>true</actions_from_pv>
+    <alarm_pulsing>false</alarm_pulsing>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color red="115" green="223" blue="255" />
+    </background_color>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>6</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <opifont.name fontName="Sans" height="10" style="0" pixels="false">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <label></label>
+    <name>Menu Button</name>
+    <pv_name>$(P)$(R)TriggerMode</pv_name>
+    <pv_value />
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_down_arrow>false</show_down_arrow>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <visible>true</visible>
+    <widget_type>Menu Button</widget_type>
+    <width>80</width>
+    <x>180</x>
+    <y>280</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color red="187" green="187" blue="187" />
+    </background_color>
+    <border_alarm_sensitive>true</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color red="10" green="0" blue="184" />
+    </foreground_color>
+    <format_type>4</format_type>
+    <height>18</height>
+    <horizontal_alignment>0</horizontal_alignment>
+    <name>Text Update</name>
+    <precision>0</precision>
+    <precision_from_pv>true</precision_from_pv>
+    <pv_name>$(P)$(R)TriggerMode_RBV</pv_name>
+    <pv_value />
+    <rotation_angle>0.0</rotation_angle>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_units>false</show_units>
+    <text>######</text>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Text Update</widget_type>
+    <width>60</width>
+    <wrap_words>false</wrap_words>
+    <x>265</x>
+    <y>281</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color red="255" green="255" blue="255" />
+    </background_color>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
+    </font>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <horizontal_alignment>2</horizontal_alignment>
+    <name>Label</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_scrollbar>false</show_scrollbar>
+    <text>Acquire busy</text>
+    <tooltip></tooltip>
+    <transparent>true</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>120</width>
+    <wrap_words>false</wrap_words>
+    <x>55</x>
+    <y>305</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color red="218" green="218" blue="218" />
+    </background_color>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
+    </font>
+    <forecolor_alarm_sensitive>true</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color name="OK" red="0" green="255" blue="0" />
+    </foreground_color>
+    <format_type>4</format_type>
+    <height>18</height>
+    <horizontal_alignment>0</horizontal_alignment>
+    <name>Text Update</name>
+    <precision>0</precision>
+    <precision_from_pv>true</precision_from_pv>
+    <pv_name>$(P)$(R)AcquireBusy</pv_name>
+    <pv_value />
+    <rotation_angle>0.0</rotation_angle>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_units>false</show_units>
+    <text>######</text>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Text Update</widget_type>
+    <width>160</width>
+    <wrap_words>false</wrap_words>
+    <x>180</x>
+    <y>306</y>
   </widget>
 </display>

--- a/ADApp/op/opi/autoconvert/ADCollect.opi
+++ b/ADApp/op/opi/autoconvert/ADCollect.opi
@@ -2211,7 +2211,7 @@ $(pv_value)</tooltip>
     <height>20</height>
     <label></label>
     <name>Menu Button</name>
-    <pv_name>$(P)$(R)TriggerMode</pv_name>
+    <pv_name>$(P)$(R)WaitForPlugins</pv_name>
     <pv_value />
     <rules />
     <scale_options>
@@ -2229,57 +2229,6 @@ $(pv_value)</tooltip>
     <width>80</width>
     <x>180</x>
     <y>280</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <alarm_pulsing>false</alarm_pulsing>
-    <auto_size>false</auto_size>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="187" green="187" blue="187" />
-    </background_color>
-    <border_alarm_sensitive>true</border_alarm_sensitive>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
-    </font>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <foreground_color>
-      <color red="10" green="0" blue="184" />
-    </foreground_color>
-    <format_type>4</format_type>
-    <height>18</height>
-    <horizontal_alignment>0</horizontal_alignment>
-    <name>Text Update</name>
-    <precision>0</precision>
-    <precision_from_pv>true</precision_from_pv>
-    <pv_name>$(P)$(R)TriggerMode_RBV</pv_name>
-    <pv_value />
-    <rotation_angle>0.0</rotation_angle>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_units>false</show_units>
-    <text>######</text>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <transparent>false</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Text Update</widget_type>
-    <width>60</width>
-    <wrap_words>false</wrap_words>
-    <x>265</x>
-    <y>281</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <actions hook="false" hook_all="false" />

--- a/ADApp/op/ui/autoconvert/ADBase.ui
+++ b/ADApp/op/ui/autoconvert/ADBase.ui
@@ -7,7 +7,7 @@
             <x>670</x>
             <y>172</y>
             <width>715</width>
-            <height>915</height>
+            <height>945</height>
         </rect>
     </property>
     <property name="styleSheet">
@@ -191,7 +191,7 @@ border-radius: 2px;
             <property name="geometry">
                 <rect>
                     <x>360</x>
-                    <y>780</y>
+                    <y>830</y>
                     <width>352</width>
                     <height>112</height>
                 </rect>
@@ -199,7 +199,7 @@ border-radius: 2px;
             <property name="geometry">
                 <rect>
                     <x>360</x>
-                    <y>780</y>
+                    <y>830</y>
                     <width>350</width>
                     <height>110</height>
                 </rect>
@@ -265,7 +265,7 @@ border-radius: 2px;
                     <x>360</x>
                     <y>205</y>
                     <width>352</width>
-                    <height>407</height>
+                    <height>482</height>
                 </rect>
             </property>
             <property name="geometry">
@@ -273,7 +273,7 @@ border-radius: 2px;
                     <x>360</x>
                     <y>205</y>
                     <width>350</width>
-                    <height>405</height>
+                    <height>480</height>
                 </rect>
             </property>
             <property name="filename">
@@ -311,17 +311,17 @@ border-radius: 2px;
             <property name="geometry">
                 <rect>
                     <x>360</x>
-                    <y>615</y>
+                    <y>690</y>
                     <width>352</width>
-                    <height>162</height>
+                    <height>137</height>
                 </rect>
             </property>
             <property name="geometry">
                 <rect>
                     <x>360</x>
-                    <y>615</y>
+                    <y>690</y>
                     <width>350</width>
-                    <height>160</height>
+                    <height>135</height>
                 </rect>
             </property>
             <property name="filename">

--- a/ADApp/op/ui/autoconvert/ADBase.ui
+++ b/ADApp/op/ui/autoconvert/ADBase.ui
@@ -7,7 +7,7 @@
             <x>670</x>
             <y>172</y>
             <width>715</width>
-            <height>935</height>
+            <height>915</height>
         </rect>
     </property>
     <property name="styleSheet">
@@ -191,7 +191,7 @@ border-radius: 2px;
             <property name="geometry">
                 <rect>
                     <x>360</x>
-                    <y>820</y>
+                    <y>780</y>
                     <width>352</width>
                     <height>112</height>
                 </rect>
@@ -199,7 +199,7 @@ border-radius: 2px;
             <property name="geometry">
                 <rect>
                     <x>360</x>
-                    <y>820</y>
+                    <y>780</y>
                     <width>350</width>
                     <height>110</height>
                 </rect>
@@ -214,16 +214,16 @@ border-radius: 2px;
         <widget class="caInclude" name="caInclude_3">
             <property name="geometry">
                 <rect>
-                    <x>360</x>
-                    <y>755</y>
+                    <x>5</x>
+                    <y>850</y>
                     <width>352</width>
                     <height>62</height>
                 </rect>
             </property>
             <property name="geometry">
                 <rect>
-                    <x>360</x>
-                    <y>755</y>
+                    <x>5</x>
+                    <y>850</y>
                     <width>350</width>
                     <height>60</height>
                 </rect>
@@ -313,7 +313,7 @@ border-radius: 2px;
                     <x>360</x>
                     <y>615</y>
                     <width>352</width>
-                    <height>137</height>
+                    <height>162</height>
                 </rect>
             </property>
             <property name="geometry">
@@ -321,7 +321,7 @@ border-radius: 2px;
                     <x>360</x>
                     <y>615</y>
                     <width>350</width>
-                    <height>135</height>
+                    <height>160</height>
                 </rect>
             </property>
             <property name="filename">

--- a/ADApp/op/ui/autoconvert/ADBuffers.ui
+++ b/ADApp/op/ui/autoconvert/ADBuffers.ui
@@ -7,7 +7,7 @@
             <x>603</x>
             <y>111</y>
             <width>350</width>
-            <height>135</height>
+            <height>160</height>
         </rect>
     </property>
     <property name="styleSheet">
@@ -185,114 +185,6 @@ border-radius: 2px;
                 </rect>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_0">
-            <property name="geometry">
-                <rect>
-                    <x>215</x>
-                    <y>81</y>
-                    <width>60</width>
-                    <height>18</height>
-                </rect>
-            </property>
-            <property name="fontScaleMode">
-                <enum>caLineEdit::WidthAndHeight</enum>
-            </property>
-            <property name="channel">
-                <string>$(P)$(R)PoolMaxMem</string>
-            </property>
-            <property name="foreground">
-                <color alpha="255">
-                    <red>10</red>
-                    <green>0</green>
-                    <blue>184</blue>
-                </color>
-            </property>
-            <property name="background">
-                <color alpha="255">
-                    <red>187</red>
-                    <green>187</green>
-                    <blue>187</blue>
-                </color>
-            </property>
-            <property name="alignment">
-                <set>Qt::AlignAbsolute|Qt::AlignRight|Qt::AlignVCenter</set>
-            </property>
-            <property name="limitsMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="limitsMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="precisionMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="minValue">
-                <double>0.0</double>
-            </property>
-            <property name="maxValue">
-                <double>1.0</double>
-            </property>
-            <property name="formatType">
-                <enum>decimal</enum>
-            </property>
-            <property name="colorMode">
-                <enum>caLineEdit::Static</enum>
-            </property>
-        </widget>
-        <widget class="caLineEdit" name="caLineEdit_1">
-            <property name="geometry">
-                <rect>
-                    <x>280</x>
-                    <y>81</y>
-                    <width>60</width>
-                    <height>18</height>
-                </rect>
-            </property>
-            <property name="fontScaleMode">
-                <enum>caLineEdit::WidthAndHeight</enum>
-            </property>
-            <property name="channel">
-                <string>$(P)$(R)PoolUsedMem</string>
-            </property>
-            <property name="foreground">
-                <color alpha="255">
-                    <red>10</red>
-                    <green>0</green>
-                    <blue>184</blue>
-                </color>
-            </property>
-            <property name="background">
-                <color alpha="255">
-                    <red>187</red>
-                    <green>187</green>
-                    <blue>187</blue>
-                </color>
-            </property>
-            <property name="alignment">
-                <set>Qt::AlignAbsolute|Qt::AlignRight|Qt::AlignVCenter</set>
-            </property>
-            <property name="limitsMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="limitsMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="precisionMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="minValue">
-                <double>0.0</double>
-            </property>
-            <property name="maxValue">
-                <double>1.0</double>
-            </property>
-            <property name="formatType">
-                <enum>decimal</enum>
-            </property>
-            <property name="colorMode">
-                <enum>caLineEdit::Static</enum>
-            </property>
-        </widget>
         <widget class="caLabel" name="caLabel_1">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
@@ -312,7 +204,7 @@ border-radius: 2px;
                 </color>
             </property>
             <property name="text">
-                <string>Buffers max/used</string>
+                <string>Buffers used</string>
             </property>
             <property name="fontScaleMode">
                 <enum>ESimpleLabel::WidthAndHeight</enum>
@@ -329,64 +221,10 @@ border-radius: 2px;
                 </rect>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_2">
+        <widget class="caLineEdit" name="caLineEdit_0">
             <property name="geometry">
                 <rect>
                     <x>215</x>
-                    <y>31</y>
-                    <width>50</width>
-                    <height>18</height>
-                </rect>
-            </property>
-            <property name="fontScaleMode">
-                <enum>caLineEdit::WidthAndHeight</enum>
-            </property>
-            <property name="channel">
-                <string>$(P)$(R)PoolMaxBuffers</string>
-            </property>
-            <property name="foreground">
-                <color alpha="255">
-                    <red>10</red>
-                    <green>0</green>
-                    <blue>184</blue>
-                </color>
-            </property>
-            <property name="background">
-                <color alpha="255">
-                    <red>187</red>
-                    <green>187</green>
-                    <blue>187</blue>
-                </color>
-            </property>
-            <property name="alignment">
-                <set>Qt::AlignAbsolute|Qt::AlignRight|Qt::AlignVCenter</set>
-            </property>
-            <property name="limitsMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="limitsMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="precisionMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="minValue">
-                <double>0.0</double>
-            </property>
-            <property name="maxValue">
-                <double>1.0</double>
-            </property>
-            <property name="formatType">
-                <enum>decimal</enum>
-            </property>
-            <property name="colorMode">
-                <enum>caLineEdit::Static</enum>
-            </property>
-        </widget>
-        <widget class="caLineEdit" name="caLineEdit_3">
-            <property name="geometry">
-                <rect>
-                    <x>270</x>
                     <y>31</y>
                     <width>50</width>
                     <height>18</height>
@@ -473,7 +311,7 @@ border-radius: 2px;
                 </rect>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_4">
+        <widget class="caLineEdit" name="caLineEdit_1">
             <property name="geometry">
                 <rect>
                     <x>215</x>
@@ -527,7 +365,7 @@ border-radius: 2px;
                 <enum>caLineEdit::Static</enum>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_5">
+        <widget class="caLineEdit" name="caLineEdit_2">
             <property name="geometry">
                 <rect>
                     <x>270</x>
@@ -581,11 +419,48 @@ border-radius: 2px;
                 <enum>caLineEdit::Static</enum>
             </property>
         </widget>
+        <widget class="caGraphics" name="caRectangle_1">
+            <property name="form">
+                <enum>caGraphics::Rectangle</enum>
+            </property>
+            <property name="geometry">
+                <rect>
+                    <x>0</x>
+                    <y>0</y>
+                    <width>350</width>
+                    <height>160</height>
+                </rect>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="0">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="lineColor">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="linestyle">
+                <enum>Solid</enum>
+            </property>
+        </widget>
         <widget class="caMenu" name="caMenu_0">
             <property name="geometry">
                 <rect>
                     <x>245</x>
-                    <y>105</y>
+                    <y>130</y>
                     <width>90</width>
                     <height>20</height>
                 </rect>
@@ -641,47 +516,118 @@ border-radius: 2px;
             <property name="geometry">
                 <rect>
                     <x>10</x>
-                    <y>105</y>
+                    <y>130</y>
                     <width>230</width>
                     <height>20</height>
                 </rect>
             </property>
         </widget>
-        <widget class="caGraphics" name="caRectangle_1">
-            <property name="form">
-                <enum>caGraphics::Rectangle</enum>
-            </property>
+        <widget class="caLineEdit" name="caLineEdit_3">
             <property name="geometry">
                 <rect>
-                    <x>0</x>
-                    <y>0</y>
-                    <width>350</width>
-                    <height>135</height>
+                    <x>215</x>
+                    <y>81</y>
+                    <width>60</width>
+                    <height>18</height>
                 </rect>
+            </property>
+            <property name="fontScaleMode">
+                <enum>caLineEdit::WidthAndHeight</enum>
+            </property>
+            <property name="channel">
+                <string>$(P)$(R)PoolMaxMem</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
-                    <red>0</red>
+                    <red>10</red>
                     <green>0</green>
-                    <blue>0</blue>
+                    <blue>184</blue>
                 </color>
             </property>
             <property name="background">
-                <color alpha="0">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                </color>
-            </property>
-            <property name="lineColor">
                 <color alpha="255">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
+                    <red>187</red>
+                    <green>187</green>
+                    <blue>187</blue>
                 </color>
             </property>
-            <property name="linestyle">
-                <enum>Solid</enum>
+            <property name="alignment">
+                <set>Qt::AlignAbsolute|Qt::AlignRight|Qt::AlignVCenter</set>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="precisionMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="minValue">
+                <double>0.0</double>
+            </property>
+            <property name="maxValue">
+                <double>1.0</double>
+            </property>
+            <property name="formatType">
+                <enum>decimal</enum>
+            </property>
+            <property name="colorMode">
+                <enum>caLineEdit::Static</enum>
+            </property>
+        </widget>
+        <widget class="caLineEdit" name="caLineEdit_4">
+            <property name="geometry">
+                <rect>
+                    <x>280</x>
+                    <y>81</y>
+                    <width>60</width>
+                    <height>18</height>
+                </rect>
+            </property>
+            <property name="fontScaleMode">
+                <enum>caLineEdit::WidthAndHeight</enum>
+            </property>
+            <property name="channel">
+                <string>$(P)$(R)PoolUsedMem</string>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>10</red>
+                    <green>0</green>
+                    <blue>184</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="255">
+                    <red>187</red>
+                    <green>187</green>
+                    <blue>187</blue>
+                </color>
+            </property>
+            <property name="alignment">
+                <set>Qt::AlignAbsolute|Qt::AlignRight|Qt::AlignVCenter</set>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="precisionMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="minValue">
+                <double>0.0</double>
+            </property>
+            <property name="maxValue">
+                <double>1.0</double>
+            </property>
+            <property name="formatType">
+                <enum>decimal</enum>
+            </property>
+            <property name="colorMode">
+                <enum>caLineEdit::Static</enum>
             </property>
         </widget>
         <widget class="caLabel" name="caLabel_4">
@@ -720,21 +666,112 @@ border-radius: 2px;
                 </rect>
             </property>
         </widget>
+        <widget class="caLineEdit" name="caLineEdit_5">
+            <property name="geometry">
+                <rect>
+                    <x>215</x>
+                    <y>106</y>
+                    <width>60</width>
+                    <height>18</height>
+                </rect>
+            </property>
+            <property name="fontScaleMode">
+                <enum>caLineEdit::WidthAndHeight</enum>
+            </property>
+            <property name="channel">
+                <string>$(P)$(R)NumActivePlugins</string>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>10</red>
+                    <green>0</green>
+                    <blue>184</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="255">
+                    <red>187</red>
+                    <green>187</green>
+                    <blue>187</blue>
+                </color>
+            </property>
+            <property name="alignment">
+                <set>Qt::AlignAbsolute|Qt::AlignRight|Qt::AlignVCenter</set>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="precisionMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="minValue">
+                <double>0.0</double>
+            </property>
+            <property name="maxValue">
+                <double>1.0</double>
+            </property>
+            <property name="formatType">
+                <enum>decimal</enum>
+            </property>
+            <property name="colorMode">
+                <enum>caLineEdit::Static</enum>
+            </property>
+        </widget>
+        <widget class="caLabel" name="caLabel_5">
+            <property name="frameShape">
+                <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="0">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="text">
+                <string># active plugins</string>
+            </property>
+            <property name="fontScaleMode">
+                <enum>ESimpleLabel::WidthAndHeight</enum>
+            </property>
+            <property name="alignment">
+                <set>Qt::AlignAbsolute|Qt::AlignRight|Qt::AlignVCenter</set>
+            </property>
+            <property name="geometry">
+                <rect>
+                    <x>10</x>
+                    <y>105</y>
+                    <width>200</width>
+                    <height>20</height>
+                </rect>
+            </property>
+        </widget>
         <zorder>caRectangle_0</zorder>
         <zorder>caFrame_0</zorder>
         <zorder>caLabel_0</zorder>
         <zorder>caLabel_1</zorder>
         <zorder>caLabel_2</zorder>
-        <zorder>caLabel_3</zorder>
         <zorder>caRectangle_1</zorder>
+        <zorder>caLabel_3</zorder>
         <zorder>caLabel_4</zorder>
+        <zorder>caLabel_5</zorder>
         <zorder>caLineEdit_0</zorder>
         <zorder>caLineEdit_1</zorder>
         <zorder>caLineEdit_2</zorder>
+        <zorder>caMenu_0</zorder>
         <zorder>caLineEdit_3</zorder>
         <zorder>caLineEdit_4</zorder>
         <zorder>caLineEdit_5</zorder>
-        <zorder>caMenu_0</zorder>
     </widget>
 </widget>
 </ui>

--- a/ADApp/op/ui/autoconvert/ADBuffers.ui
+++ b/ADApp/op/ui/autoconvert/ADBuffers.ui
@@ -7,7 +7,7 @@
             <x>603</x>
             <y>111</y>
             <width>350</width>
-            <height>160</height>
+            <height>135</height>
         </rect>
     </property>
     <property name="styleSheet">
@@ -428,7 +428,7 @@ border-radius: 2px;
                     <x>0</x>
                     <y>0</y>
                     <width>350</width>
-                    <height>160</height>
+                    <height>135</height>
                 </rect>
             </property>
             <property name="foreground">
@@ -460,7 +460,7 @@ border-radius: 2px;
             <property name="geometry">
                 <rect>
                     <x>245</x>
-                    <y>130</y>
+                    <y>105</y>
                     <width>90</width>
                     <height>20</height>
                 </rect>
@@ -516,7 +516,7 @@ border-radius: 2px;
             <property name="geometry">
                 <rect>
                     <x>10</x>
-                    <y>130</y>
+                    <y>105</y>
                     <width>230</width>
                     <height>20</height>
                 </rect>
@@ -666,96 +666,6 @@ border-radius: 2px;
                 </rect>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_5">
-            <property name="geometry">
-                <rect>
-                    <x>215</x>
-                    <y>106</y>
-                    <width>60</width>
-                    <height>18</height>
-                </rect>
-            </property>
-            <property name="fontScaleMode">
-                <enum>caLineEdit::WidthAndHeight</enum>
-            </property>
-            <property name="channel">
-                <string>$(P)$(R)NumActivePlugins</string>
-            </property>
-            <property name="foreground">
-                <color alpha="255">
-                    <red>10</red>
-                    <green>0</green>
-                    <blue>184</blue>
-                </color>
-            </property>
-            <property name="background">
-                <color alpha="255">
-                    <red>187</red>
-                    <green>187</green>
-                    <blue>187</blue>
-                </color>
-            </property>
-            <property name="alignment">
-                <set>Qt::AlignAbsolute|Qt::AlignRight|Qt::AlignVCenter</set>
-            </property>
-            <property name="limitsMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="limitsMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="precisionMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="minValue">
-                <double>0.0</double>
-            </property>
-            <property name="maxValue">
-                <double>1.0</double>
-            </property>
-            <property name="formatType">
-                <enum>decimal</enum>
-            </property>
-            <property name="colorMode">
-                <enum>caLineEdit::Static</enum>
-            </property>
-        </widget>
-        <widget class="caLabel" name="caLabel_5">
-            <property name="frameShape">
-                <enum>QFrame::NoFrame</enum>
-            </property>
-            <property name="foreground">
-                <color alpha="255">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                </color>
-            </property>
-            <property name="background">
-                <color alpha="0">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                </color>
-            </property>
-            <property name="text">
-                <string># active plugins</string>
-            </property>
-            <property name="fontScaleMode">
-                <enum>ESimpleLabel::WidthAndHeight</enum>
-            </property>
-            <property name="alignment">
-                <set>Qt::AlignAbsolute|Qt::AlignRight|Qt::AlignVCenter</set>
-            </property>
-            <property name="geometry">
-                <rect>
-                    <x>10</x>
-                    <y>105</y>
-                    <width>200</width>
-                    <height>20</height>
-                </rect>
-            </property>
-        </widget>
         <zorder>caRectangle_0</zorder>
         <zorder>caFrame_0</zorder>
         <zorder>caLabel_0</zorder>
@@ -764,14 +674,12 @@ border-radius: 2px;
         <zorder>caRectangle_1</zorder>
         <zorder>caLabel_3</zorder>
         <zorder>caLabel_4</zorder>
-        <zorder>caLabel_5</zorder>
         <zorder>caLineEdit_0</zorder>
         <zorder>caLineEdit_1</zorder>
         <zorder>caLineEdit_2</zorder>
         <zorder>caMenu_0</zorder>
         <zorder>caLineEdit_3</zorder>
         <zorder>caLineEdit_4</zorder>
-        <zorder>caLineEdit_5</zorder>
     </widget>
 </widget>
 </ui>

--- a/ADApp/op/ui/autoconvert/ADCollect.ui
+++ b/ADApp/op/ui/autoconvert/ADCollect.ui
@@ -2067,7 +2067,7 @@ border-radius: 2px;
                 </rect>
             </property>
             <property name="channel">
-                <string>$(P)$(R)TriggerMode</string>
+                <string>$(P)$(R)WaitForPlugins</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -2085,60 +2085,6 @@ border-radius: 2px;
             </property>
             <property name="colorMode">
                 <enum>caMenu::Static</enum>
-            </property>
-        </widget>
-        <widget class="caLineEdit" name="caLineEdit_14">
-            <property name="geometry">
-                <rect>
-                    <x>265</x>
-                    <y>281</y>
-                    <width>60</width>
-                    <height>18</height>
-                </rect>
-            </property>
-            <property name="fontScaleMode">
-                <enum>caLineEdit::WidthAndHeight</enum>
-            </property>
-            <property name="channel">
-                <string>$(P)$(R)TriggerMode_RBV</string>
-            </property>
-            <property name="foreground">
-                <color alpha="255">
-                    <red>10</red>
-                    <green>0</green>
-                    <blue>184</blue>
-                </color>
-            </property>
-            <property name="background">
-                <color alpha="255">
-                    <red>187</red>
-                    <green>187</green>
-                    <blue>187</blue>
-                </color>
-            </property>
-            <property name="limitsMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="limitsMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="precisionMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="minValue">
-                <double>0.0</double>
-            </property>
-            <property name="maxValue">
-                <double>1.0</double>
-            </property>
-            <property name="alignment">
-                <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
-            </property>
-            <property name="formatType">
-                <enum>string</enum>
-            </property>
-            <property name="colorMode">
-                <enum>caLineEdit::Static</enum>
             </property>
         </widget>
         <widget class="caLabel" name="caLabel_19">
@@ -2177,7 +2123,7 @@ border-radius: 2px;
                 </rect>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_15">
+        <widget class="caLineEdit" name="caLineEdit_14">
             <property name="geometry">
                 <rect>
                     <x>180</x>
@@ -2279,7 +2225,6 @@ border-radius: 2px;
         <zorder>caLineEdit_13</zorder>
         <zorder>caMenu_3</zorder>
         <zorder>caLineEdit_14</zorder>
-        <zorder>caLineEdit_15</zorder>
     </widget>
 </widget>
 </ui>

--- a/ADApp/op/ui/autoconvert/ADCollect.ui
+++ b/ADApp/op/ui/autoconvert/ADCollect.ui
@@ -4,10 +4,10 @@
 <widget class="QMainWindow" name="MainWindow">
     <property name="geometry">
         <rect>
-            <x>44</x>
-            <y>221</y>
+            <x>446</x>
+            <y>331</y>
             <width>350</width>
-            <height>405</height>
+            <height>480</height>
         </rect>
     </property>
     <property name="styleSheet">
@@ -115,7 +115,7 @@ border-radius: 2px;
                     <x>0</x>
                     <y>0</y>
                     <width>350</width>
-                    <height>405</height>
+                    <height>480</height>
                 </rect>
             </property>
             <property name="foreground">
@@ -803,126 +803,6 @@ border-radius: 2px;
             </property>
             <property name="foreground">
                 <color alpha="255">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                </color>
-            </property>
-            <property name="background">
-                <color alpha="0">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                </color>
-            </property>
-            <property name="text">
-                <string>Trigger mode</string>
-            </property>
-            <property name="fontScaleMode">
-                <enum>ESimpleLabel::WidthAndHeight</enum>
-            </property>
-            <property name="alignment">
-                <set>Qt::AlignAbsolute|Qt::AlignRight|Qt::AlignVCenter</set>
-            </property>
-            <property name="geometry">
-                <rect>
-                    <x>5</x>
-                    <y>180</y>
-                    <width>120</width>
-                    <height>20</height>
-                </rect>
-            </property>
-        </widget>
-        <widget class="caMenu" name="caMenu_0">
-            <property name="geometry">
-                <rect>
-                    <x>130</x>
-                    <y>180</y>
-                    <width>120</width>
-                    <height>20</height>
-                </rect>
-            </property>
-            <property name="channel">
-                <string>$(P)$(R)TriggerMode</string>
-            </property>
-            <property name="foreground">
-                <color alpha="255">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                </color>
-            </property>
-            <property name="background">
-                <color alpha="255">
-                    <red>115</red>
-                    <green>223</green>
-                    <blue>255</blue>
-                </color>
-            </property>
-            <property name="colorMode">
-                <enum>caMenu::Static</enum>
-            </property>
-        </widget>
-        <widget class="caLineEdit" name="caLineEdit_5">
-            <property name="geometry">
-                <rect>
-                    <x>255</x>
-                    <y>181</y>
-                    <width>80</width>
-                    <height>18</height>
-                </rect>
-            </property>
-            <property name="fontScaleMode">
-                <enum>caLineEdit::WidthAndHeight</enum>
-            </property>
-            <property name="channel">
-                <string>$(P)$(R)TriggerMode_RBV</string>
-            </property>
-            <property name="foreground">
-                <color alpha="255">
-                    <red>10</red>
-                    <green>0</green>
-                    <blue>184</blue>
-                </color>
-            </property>
-            <property name="background">
-                <color alpha="255">
-                    <red>187</red>
-                    <green>187</green>
-                    <blue>187</blue>
-                </color>
-            </property>
-            <property name="limitsMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="limitsMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="precisionMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="minValue">
-                <double>0.0</double>
-            </property>
-            <property name="maxValue">
-                <double>1.0</double>
-            </property>
-            <property name="alignment">
-                <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
-            </property>
-            <property name="formatType">
-                <enum>string</enum>
-            </property>
-            <property name="colorMode">
-                <enum>caLineEdit::Static</enum>
-            </property>
-        </widget>
-        <widget class="caLabel" name="caLabel_6">
-            <property name="frameShape">
-                <enum>QFrame::NoFrame</enum>
-            </property>
-            <property name="foreground">
-                <color alpha="255">
                     <red>40</red>
                     <green>147</green>
                     <blue>21</blue>
@@ -962,7 +842,7 @@ border-radius: 2px;
                 </rect>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_7">
+        <widget class="caLabel" name="caLabel_6">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1085,7 +965,7 @@ border-radius: 2px;
                 <enum>caMessageButton::Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_8">
+        <widget class="caLabel" name="caLabel_7">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1121,7 +1001,196 @@ border-radius: 2px;
                 </rect>
             </property>
         </widget>
+        <widget class="caGraphics" name="caRectangle_1">
+            <property name="form">
+                <enum>caGraphics::Rectangle</enum>
+            </property>
+            <property name="geometry">
+                <rect>
+                    <x>123</x>
+                    <y>2</y>
+                    <width>105</width>
+                    <height>21</height>
+                </rect>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>218</red>
+                    <green>218</green>
+                    <blue>218</blue>
+                </color>
+            </property>
+            <property name="fillstyle">
+                <enum>Filled</enum>
+            </property>
+            <property name="lineColor">
+                <color alpha="255">
+                    <red>218</red>
+                    <green>218</green>
+                    <blue>218</blue>
+                </color>
+            </property>
+            <property name="linestyle">
+                <enum>Solid</enum>
+            </property>
+        </widget>
+        <widget class="caLabel" name="caLabel_8">
+            <property name="frameShape">
+                <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>10</red>
+                    <green>0</green>
+                    <blue>184</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="0">
+                    <red>10</red>
+                    <green>0</green>
+                    <blue>184</blue>
+                </color>
+            </property>
+            <property name="text">
+                <string>Collect</string>
+            </property>
+            <property name="fontScaleMode">
+                <enum>ESimpleLabel::WidthAndHeight</enum>
+            </property>
+            <property name="alignment">
+                <set>Qt::AlignAbsolute|Qt::AlignHCenter|Qt::AlignVCenter</set>
+            </property>
+            <property name="geometry">
+                <rect>
+                    <x>140</x>
+                    <y>3</y>
+                    <width>70</width>
+                    <height>20</height>
+                </rect>
+            </property>
+        </widget>
         <widget class="caLabel" name="caLabel_9">
+            <property name="frameShape">
+                <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="0">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="text">
+                <string>Image mode</string>
+            </property>
+            <property name="fontScaleMode">
+                <enum>ESimpleLabel::WidthAndHeight</enum>
+            </property>
+            <property name="alignment">
+                <set>Qt::AlignAbsolute|Qt::AlignRight|Qt::AlignVCenter</set>
+            </property>
+            <property name="geometry">
+                <rect>
+                    <x>25</x>
+                    <y>155</y>
+                    <width>100</width>
+                    <height>20</height>
+                </rect>
+            </property>
+        </widget>
+        <widget class="caMenu" name="caMenu_0">
+            <property name="geometry">
+                <rect>
+                    <x>130</x>
+                    <y>155</y>
+                    <width>120</width>
+                    <height>20</height>
+                </rect>
+            </property>
+            <property name="channel">
+                <string>$(P)$(R)ImageMode</string>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="255">
+                    <red>115</red>
+                    <green>223</green>
+                    <blue>255</blue>
+                </color>
+            </property>
+            <property name="colorMode">
+                <enum>caMenu::Static</enum>
+            </property>
+        </widget>
+        <widget class="caLineEdit" name="caLineEdit_5">
+            <property name="geometry">
+                <rect>
+                    <x>255</x>
+                    <y>157</y>
+                    <width>80</width>
+                    <height>18</height>
+                </rect>
+            </property>
+            <property name="fontScaleMode">
+                <enum>caLineEdit::WidthAndHeight</enum>
+            </property>
+            <property name="channel">
+                <string>$(P)$(R)ImageMode_RBV</string>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>10</red>
+                    <green>0</green>
+                    <blue>184</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="255">
+                    <red>187</red>
+                    <green>187</green>
+                    <blue>187</blue>
+                </color>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="precisionMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="minValue">
+                <double>0.0</double>
+            </property>
+            <property name="maxValue">
+                <double>1.0</double>
+            </property>
+            <property name="alignment">
+                <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
+            </property>
+            <property name="formatType">
+                <enum>string</enum>
+            </property>
+            <property name="colorMode">
+                <enum>caLineEdit::Static</enum>
+            </property>
+        </widget>
+        <widget class="caLabel" name="caLabel_10">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1151,7 +1220,7 @@ border-radius: 2px;
             <property name="geometry">
                 <rect>
                     <x>35</x>
-                    <y>255</y>
+                    <y>330</y>
                     <width>140</width>
                     <height>20</height>
                 </rect>
@@ -1161,8 +1230,8 @@ border-radius: 2px;
             <property name="geometry">
                 <rect>
                     <x>180</x>
-                    <y>255</y>
-                    <width>158</width>
+                    <y>330</y>
+                    <width>160</width>
                     <height>18</height>
                 </rect>
             </property>
@@ -1211,7 +1280,7 @@ border-radius: 2px;
                 <enum>caLineEdit::Alarm_Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_10">
+        <widget class="caLabel" name="caLabel_11">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1241,7 +1310,7 @@ border-radius: 2px;
             <property name="geometry">
                 <rect>
                     <x>35</x>
-                    <y>305</y>
+                    <y>380</y>
                     <width>140</width>
                     <height>20</height>
                 </rect>
@@ -1251,7 +1320,7 @@ border-radius: 2px;
             <property name="geometry">
                 <rect>
                     <x>180</x>
-                    <y>306</y>
+                    <y>381</y>
                     <width>67</width>
                     <height>18</height>
                 </rect>
@@ -1305,7 +1374,7 @@ border-radius: 2px;
             <property name="geometry">
                 <rect>
                     <x>180</x>
-                    <y>330</y>
+                    <y>405</y>
                     <width>60</width>
                     <height>20</height>
                 </rect>
@@ -1352,7 +1421,7 @@ border-radius: 2px;
                 <enum>decimal</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_11">
+        <widget class="caLabel" name="caLabel_12">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1382,7 +1451,7 @@ border-radius: 2px;
             <property name="geometry">
                 <rect>
                     <x>45</x>
-                    <y>330</y>
+                    <y>405</y>
                     <width>130</width>
                     <height>20</height>
                 </rect>
@@ -1392,7 +1461,7 @@ border-radius: 2px;
             <property name="geometry">
                 <rect>
                     <x>245</x>
-                    <y>331</y>
+                    <y>406</y>
                     <width>80</width>
                     <height>18</height>
                 </rect>
@@ -1402,96 +1471,6 @@ border-radius: 2px;
             </property>
             <property name="channel">
                 <string>$(P)$(R)ArrayCounter_RBV</string>
-            </property>
-            <property name="foreground">
-                <color alpha="255">
-                    <red>10</red>
-                    <green>0</green>
-                    <blue>184</blue>
-                </color>
-            </property>
-            <property name="background">
-                <color alpha="255">
-                    <red>187</red>
-                    <green>187</green>
-                    <blue>187</blue>
-                </color>
-            </property>
-            <property name="limitsMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="limitsMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="precisionMode">
-                <enum>caLineEdit::Channel</enum>
-            </property>
-            <property name="minValue">
-                <double>0.0</double>
-            </property>
-            <property name="maxValue">
-                <double>1.0</double>
-            </property>
-            <property name="alignment">
-                <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
-            </property>
-            <property name="formatType">
-                <enum>decimal</enum>
-            </property>
-            <property name="colorMode">
-                <enum>caLineEdit::Static</enum>
-            </property>
-        </widget>
-        <widget class="caLabel" name="caLabel_12">
-            <property name="frameShape">
-                <enum>QFrame::NoFrame</enum>
-            </property>
-            <property name="foreground">
-                <color alpha="255">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                </color>
-            </property>
-            <property name="background">
-                <color alpha="0">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                </color>
-            </property>
-            <property name="text">
-                <string>Image rate</string>
-            </property>
-            <property name="fontScaleMode">
-                <enum>ESimpleLabel::WidthAndHeight</enum>
-            </property>
-            <property name="alignment">
-                <set>Qt::AlignAbsolute|Qt::AlignRight|Qt::AlignVCenter</set>
-            </property>
-            <property name="geometry">
-                <rect>
-                    <x>75</x>
-                    <y>355</y>
-                    <width>100</width>
-                    <height>20</height>
-                </rect>
-            </property>
-        </widget>
-        <widget class="caLineEdit" name="caLineEdit_9">
-            <property name="geometry">
-                <rect>
-                    <x>180</x>
-                    <y>356</y>
-                    <width>100</width>
-                    <height>18</height>
-                </rect>
-            </property>
-            <property name="fontScaleMode">
-                <enum>caLineEdit::WidthAndHeight</enum>
-            </property>
-            <property name="channel">
-                <string>$(P)$(R)ArrayRate_RBV</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -1551,6 +1530,96 @@ border-radius: 2px;
                 </color>
             </property>
             <property name="text">
+                <string>Image rate</string>
+            </property>
+            <property name="fontScaleMode">
+                <enum>ESimpleLabel::WidthAndHeight</enum>
+            </property>
+            <property name="alignment">
+                <set>Qt::AlignAbsolute|Qt::AlignRight|Qt::AlignVCenter</set>
+            </property>
+            <property name="geometry">
+                <rect>
+                    <x>75</x>
+                    <y>430</y>
+                    <width>100</width>
+                    <height>20</height>
+                </rect>
+            </property>
+        </widget>
+        <widget class="caLineEdit" name="caLineEdit_9">
+            <property name="geometry">
+                <rect>
+                    <x>180</x>
+                    <y>431</y>
+                    <width>100</width>
+                    <height>18</height>
+                </rect>
+            </property>
+            <property name="fontScaleMode">
+                <enum>caLineEdit::WidthAndHeight</enum>
+            </property>
+            <property name="channel">
+                <string>$(P)$(R)ArrayRate_RBV</string>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>10</red>
+                    <green>0</green>
+                    <blue>184</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="255">
+                    <red>187</red>
+                    <green>187</green>
+                    <blue>187</blue>
+                </color>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="precisionMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="minValue">
+                <double>0.0</double>
+            </property>
+            <property name="maxValue">
+                <double>1.0</double>
+            </property>
+            <property name="alignment">
+                <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
+            </property>
+            <property name="formatType">
+                <enum>decimal</enum>
+            </property>
+            <property name="colorMode">
+                <enum>caLineEdit::Static</enum>
+            </property>
+        </widget>
+        <widget class="caLabel" name="caLabel_14">
+            <property name="frameShape">
+                <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="0">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="text">
                 <string>Array callbacks</string>
             </property>
             <property name="fontScaleMode">
@@ -1562,7 +1631,7 @@ border-radius: 2px;
             <property name="geometry">
                 <rect>
                     <x>5</x>
-                    <y>380</y>
+                    <y>455</y>
                     <width>150</width>
                     <height>20</height>
                 </rect>
@@ -1572,7 +1641,7 @@ border-radius: 2px;
             <property name="geometry">
                 <rect>
                     <x>160</x>
-                    <y>380</y>
+                    <y>455</y>
                     <width>90</width>
                     <height>20</height>
                 </rect>
@@ -1602,7 +1671,7 @@ border-radius: 2px;
             <property name="geometry">
                 <rect>
                     <x>255</x>
-                    <y>382</y>
+                    <y>457</y>
                     <width>80</width>
                     <height>18</height>
                 </rect>
@@ -1652,7 +1721,7 @@ border-radius: 2px;
                 <enum>caLineEdit::Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_14">
+        <widget class="caLabel" name="caLabel_15">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1682,7 +1751,7 @@ border-radius: 2px;
             <property name="geometry">
                 <rect>
                     <x>5</x>
-                    <y>280</y>
+                    <y>355</y>
                     <width>60</width>
                     <height>20</height>
                 </rect>
@@ -1692,7 +1761,7 @@ border-radius: 2px;
             <property name="geometry">
                 <rect>
                     <x>70</x>
-                    <y>280</y>
+                    <y>355</y>
                     <width>275</width>
                     <height>18</height>
                 </rect>
@@ -1742,75 +1811,6 @@ border-radius: 2px;
                 <enum>caLineEdit::Static</enum>
             </property>
         </widget>
-        <widget class="caGraphics" name="caRectangle_1">
-            <property name="form">
-                <enum>caGraphics::Rectangle</enum>
-            </property>
-            <property name="geometry">
-                <rect>
-                    <x>123</x>
-                    <y>2</y>
-                    <width>105</width>
-                    <height>21</height>
-                </rect>
-            </property>
-            <property name="foreground">
-                <color alpha="255">
-                    <red>218</red>
-                    <green>218</green>
-                    <blue>218</blue>
-                </color>
-            </property>
-            <property name="fillstyle">
-                <enum>Filled</enum>
-            </property>
-            <property name="lineColor">
-                <color alpha="255">
-                    <red>218</red>
-                    <green>218</green>
-                    <blue>218</blue>
-                </color>
-            </property>
-            <property name="linestyle">
-                <enum>Solid</enum>
-            </property>
-        </widget>
-        <widget class="caLabel" name="caLabel_15">
-            <property name="frameShape">
-                <enum>QFrame::NoFrame</enum>
-            </property>
-            <property name="foreground">
-                <color alpha="255">
-                    <red>10</red>
-                    <green>0</green>
-                    <blue>184</blue>
-                </color>
-            </property>
-            <property name="background">
-                <color alpha="0">
-                    <red>10</red>
-                    <green>0</green>
-                    <blue>184</blue>
-                </color>
-            </property>
-            <property name="text">
-                <string>Collect</string>
-            </property>
-            <property name="fontScaleMode">
-                <enum>ESimpleLabel::WidthAndHeight</enum>
-            </property>
-            <property name="alignment">
-                <set>Qt::AlignAbsolute|Qt::AlignHCenter|Qt::AlignVCenter</set>
-            </property>
-            <property name="geometry">
-                <rect>
-                    <x>140</x>
-                    <y>3</y>
-                    <width>70</width>
-                    <height>20</height>
-                </rect>
-            </property>
-        </widget>
         <widget class="caLabel" name="caLabel_16">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
@@ -1830,7 +1830,7 @@ border-radius: 2px;
                 </color>
             </property>
             <property name="text">
-                <string>Image mode</string>
+                <string># active plugins</string>
             </property>
             <property name="fontScaleMode">
                 <enum>ESimpleLabel::WidthAndHeight</enum>
@@ -1840,9 +1840,99 @@ border-radius: 2px;
             </property>
             <property name="geometry">
                 <rect>
-                    <x>25</x>
-                    <y>155</y>
-                    <width>100</width>
+                    <x>15</x>
+                    <y>255</y>
+                    <width>160</width>
+                    <height>20</height>
+                </rect>
+            </property>
+        </widget>
+        <widget class="caLineEdit" name="caLineEdit_12">
+            <property name="geometry">
+                <rect>
+                    <x>180</x>
+                    <y>256</y>
+                    <width>60</width>
+                    <height>18</height>
+                </rect>
+            </property>
+            <property name="fontScaleMode">
+                <enum>caLineEdit::WidthAndHeight</enum>
+            </property>
+            <property name="channel">
+                <string>$(P)$(R)NumActivePlugins</string>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>10</red>
+                    <green>0</green>
+                    <blue>184</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="255">
+                    <red>187</red>
+                    <green>187</green>
+                    <blue>187</blue>
+                </color>
+            </property>
+            <property name="alignment">
+                <set>Qt::AlignAbsolute|Qt::AlignRight|Qt::AlignVCenter</set>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="precisionMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="minValue">
+                <double>0.0</double>
+            </property>
+            <property name="maxValue">
+                <double>1.0</double>
+            </property>
+            <property name="formatType">
+                <enum>decimal</enum>
+            </property>
+            <property name="colorMode">
+                <enum>caLineEdit::Static</enum>
+            </property>
+        </widget>
+        <widget class="caLabel" name="caLabel_17">
+            <property name="frameShape">
+                <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="0">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="text">
+                <string>Trigger mode</string>
+            </property>
+            <property name="fontScaleMode">
+                <enum>ESimpleLabel::WidthAndHeight</enum>
+            </property>
+            <property name="alignment">
+                <set>Qt::AlignAbsolute|Qt::AlignRight|Qt::AlignVCenter</set>
+            </property>
+            <property name="geometry">
+                <rect>
+                    <x>5</x>
+                    <y>180</y>
+                    <width>120</width>
                     <height>20</height>
                 </rect>
             </property>
@@ -1851,13 +1941,13 @@ border-radius: 2px;
             <property name="geometry">
                 <rect>
                     <x>130</x>
-                    <y>155</y>
+                    <y>180</y>
                     <width>120</width>
                     <height>20</height>
                 </rect>
             </property>
             <property name="channel">
-                <string>$(P)$(R)ImageMode</string>
+                <string>$(P)$(R)TriggerMode</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -1877,11 +1967,11 @@ border-radius: 2px;
                 <enum>caMenu::Static</enum>
             </property>
         </widget>
-        <widget class="caLineEdit" name="caLineEdit_12">
+        <widget class="caLineEdit" name="caLineEdit_13">
             <property name="geometry">
                 <rect>
                     <x>255</x>
-                    <y>157</y>
+                    <y>181</y>
                     <width>80</width>
                     <height>18</height>
                 </rect>
@@ -1890,7 +1980,7 @@ border-radius: 2px;
                 <enum>caLineEdit::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)$(R)ImageMode_RBV</string>
+                <string>$(P)$(R)TriggerMode_RBV</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -1931,6 +2021,216 @@ border-radius: 2px;
                 <enum>caLineEdit::Static</enum>
             </property>
         </widget>
+        <widget class="caLabel" name="caLabel_18">
+            <property name="frameShape">
+                <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="0">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="text">
+                <string>Wait for plugins</string>
+            </property>
+            <property name="fontScaleMode">
+                <enum>ESimpleLabel::WidthAndHeight</enum>
+            </property>
+            <property name="alignment">
+                <set>Qt::AlignAbsolute|Qt::AlignRight|Qt::AlignVCenter</set>
+            </property>
+            <property name="geometry">
+                <rect>
+                    <x>15</x>
+                    <y>280</y>
+                    <width>160</width>
+                    <height>20</height>
+                </rect>
+            </property>
+        </widget>
+        <widget class="caMenu" name="caMenu_3">
+            <property name="geometry">
+                <rect>
+                    <x>180</x>
+                    <y>280</y>
+                    <width>80</width>
+                    <height>20</height>
+                </rect>
+            </property>
+            <property name="channel">
+                <string>$(P)$(R)TriggerMode</string>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="255">
+                    <red>115</red>
+                    <green>223</green>
+                    <blue>255</blue>
+                </color>
+            </property>
+            <property name="colorMode">
+                <enum>caMenu::Static</enum>
+            </property>
+        </widget>
+        <widget class="caLineEdit" name="caLineEdit_14">
+            <property name="geometry">
+                <rect>
+                    <x>265</x>
+                    <y>281</y>
+                    <width>60</width>
+                    <height>18</height>
+                </rect>
+            </property>
+            <property name="fontScaleMode">
+                <enum>caLineEdit::WidthAndHeight</enum>
+            </property>
+            <property name="channel">
+                <string>$(P)$(R)TriggerMode_RBV</string>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>10</red>
+                    <green>0</green>
+                    <blue>184</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="255">
+                    <red>187</red>
+                    <green>187</green>
+                    <blue>187</blue>
+                </color>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="precisionMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="minValue">
+                <double>0.0</double>
+            </property>
+            <property name="maxValue">
+                <double>1.0</double>
+            </property>
+            <property name="alignment">
+                <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
+            </property>
+            <property name="formatType">
+                <enum>string</enum>
+            </property>
+            <property name="colorMode">
+                <enum>caLineEdit::Static</enum>
+            </property>
+        </widget>
+        <widget class="caLabel" name="caLabel_19">
+            <property name="frameShape">
+                <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="0">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="text">
+                <string>Acquire busy</string>
+            </property>
+            <property name="fontScaleMode">
+                <enum>ESimpleLabel::WidthAndHeight</enum>
+            </property>
+            <property name="alignment">
+                <set>Qt::AlignAbsolute|Qt::AlignRight|Qt::AlignVCenter</set>
+            </property>
+            <property name="geometry">
+                <rect>
+                    <x>55</x>
+                    <y>305</y>
+                    <width>120</width>
+                    <height>20</height>
+                </rect>
+            </property>
+        </widget>
+        <widget class="caLineEdit" name="caLineEdit_15">
+            <property name="geometry">
+                <rect>
+                    <x>180</x>
+                    <y>306</y>
+                    <width>160</width>
+                    <height>18</height>
+                </rect>
+            </property>
+            <property name="fontScaleMode">
+                <enum>caLineEdit::WidthAndHeight</enum>
+            </property>
+            <property name="channel">
+                <string>$(P)$(R)AcquireBusy</string>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>10</red>
+                    <green>0</green>
+                    <blue>184</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="255">
+                    <red>218</red>
+                    <green>218</green>
+                    <blue>218</blue>
+                </color>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="precisionMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="minValue">
+                <double>0.0</double>
+            </property>
+            <property name="maxValue">
+                <double>1.0</double>
+            </property>
+            <property name="alignment">
+                <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
+            </property>
+            <property name="formatType">
+                <enum>string</enum>
+            </property>
+            <property name="colorMode">
+                <enum>caLineEdit::Alarm_Static</enum>
+            </property>
+        </widget>
         <zorder>caRectangle_0</zorder>
         <zorder>caLabel_0</zorder>
         <zorder>caLabel_1</zorder>
@@ -1940,6 +2240,7 @@ border-radius: 2px;
         <zorder>caLabel_5</zorder>
         <zorder>caLabel_6</zorder>
         <zorder>caLabel_7</zorder>
+        <zorder>caRectangle_1</zorder>
         <zorder>caLabel_8</zorder>
         <zorder>caLabel_9</zorder>
         <zorder>caLabel_10</zorder>
@@ -1947,9 +2248,11 @@ border-radius: 2px;
         <zorder>caLabel_12</zorder>
         <zorder>caLabel_13</zorder>
         <zorder>caLabel_14</zorder>
-        <zorder>caRectangle_1</zorder>
         <zorder>caLabel_15</zorder>
         <zorder>caLabel_16</zorder>
+        <zorder>caLabel_17</zorder>
+        <zorder>caLabel_18</zorder>
+        <zorder>caLabel_19</zorder>
         <zorder>caTextEntry_0</zorder>
         <zorder>caLineEdit_0</zorder>
         <zorder>caTextEntry_1</zorder>
@@ -1959,10 +2262,10 @@ border-radius: 2px;
         <zorder>caLineEdit_3</zorder>
         <zorder>caTextEntry_3</zorder>
         <zorder>caLineEdit_4</zorder>
-        <zorder>caMenu_0</zorder>
-        <zorder>caLineEdit_5</zorder>
         <zorder>caMessageButton_0</zorder>
         <zorder>caMessageButton_1</zorder>
+        <zorder>caMenu_0</zorder>
+        <zorder>caLineEdit_5</zorder>
         <zorder>caLineEdit_6</zorder>
         <zorder>caLineEdit_7</zorder>
         <zorder>caTextEntry_4</zorder>
@@ -1971,8 +2274,12 @@ border-radius: 2px;
         <zorder>caMenu_1</zorder>
         <zorder>caLineEdit_10</zorder>
         <zorder>caLineEdit_11</zorder>
-        <zorder>caMenu_2</zorder>
         <zorder>caLineEdit_12</zorder>
+        <zorder>caMenu_2</zorder>
+        <zorder>caLineEdit_13</zorder>
+        <zorder>caMenu_3</zorder>
+        <zorder>caLineEdit_14</zorder>
+        <zorder>caLineEdit_15</zorder>
     </widget>
 </widget>
 </ui>

--- a/ADApp/pluginSrc/NDArrayRing.cpp
+++ b/ADApp/pluginSrc/NDArrayRing.cpp
@@ -52,12 +52,12 @@ NDArray *NDArrayRing::addToEnd(NDArray *pArray)
   if (noOfBuffers_ > 0) {
       writeIndex_ = (writeIndex_ + 1) % noOfBuffers_;
       if (wrapped_ == 1){
-	  retVal = buffers_[writeIndex_];
+          retVal = buffers_[writeIndex_];
       }
       buffers_[writeIndex_] = pArray;
       if (writeIndex_+1 == noOfBuffers_){
-	  // We have now wrapped
-	  wrapped_ = 1;
+          // We have now wrapped
+          wrapped_ = 1;
       }
   } else {
       // Buffer is not being used, so return the passed array to be released immediately.

--- a/ADApp/pluginSrc/NDFileHDF5Layout.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5Layout.cpp
@@ -105,7 +105,7 @@ namespace hdf5
 
   void DataSource::set_datatype(DataType_t type)
   {
-	  this->datatype = type;
+    this->datatype = type;
   }
 
   bool DataSource::is_src_constant()

--- a/ADApp/pluginSrc/NDPluginDriver.cpp
+++ b/ADApp/pluginSrc/NDPluginDriver.cpp
@@ -89,7 +89,7 @@ NDPluginDriver::NDPluginDriver(const char *portName, int queueSize, int blocking
                                int maxBuffers, size_t maxMemory, int interfaceMask, int interruptMask,
                                int asynFlags, int autoConnect, int priority, int stackSize, int maxThreads)
 
-    : asynNDArrayDriver(portName, maxAddr, false, maxMemory,
+    : asynNDArrayDriver(portName, maxAddr, maxBuffers, maxMemory,
           interfaceMask | asynInt32Mask | asynFloat64Mask | asynOctetMask | asynInt32ArrayMask | asynDrvUserMask,
           interruptMask | asynInt32Mask | asynFloat64Mask | asynOctetMask | asynInt32ArrayMask,
           asynFlags, autoConnect, priority, stackSize),
@@ -196,7 +196,6 @@ NDPluginDriver::~NDPluginDriver()
     int colorMode=NDColorModeMono, bayerPattern=NDBayerRGGB;
     //static const char *functionName="beginProcessCallbacks";
 
-    this->pNDArrayPool = pArray->pNDArrayPool;
     pAttribute = pArray->pAttributeList->find("ColorMode");
     if (pAttribute) pAttribute->getValue(NDAttrInt32, &colorMode);
     pAttribute = pArray->pAttributeList->find("BayerPattern");

--- a/ADApp/pluginSrc/NDPluginTimeSeries.cpp
+++ b/ADApp/pluginSrc/NDPluginTimeSeries.cpp
@@ -132,14 +132,14 @@ void NDPluginTimeSeries::allocateArrays()
   numTimePoints_ = numPoints;
   if (timeStamp_)  free(timeStamp_);
   if (signalData_) free (signalData_);
-  if (pTimeCircular_) pTimeCircular_->release();
+  if (pTimeCircular_) delete pTimeCircular_;
 
   timeStamp_  = (double *)calloc(numSignals_*numTimePoints_, sizeof(double));
   signalData_ = (double *)calloc(numSignals_*numTimePoints_, sizeof(double));
   nDims = 2;
   dims[0] = numTimePoints_;
   dims[1] = numSignals_;
-  pTimeCircular_ = pNDArrayPool->alloc(nDims, dims, dataType_, 0, 0);
+  pTimeCircular_ = new NDArray(nDims, dims, dataType_, 0, 0);
   createAxisArray();
   acquireReset();
 }

--- a/ADApp/pluginSrc/NDPluginTimeSeries.cpp
+++ b/ADApp/pluginSrc/NDPluginTimeSeries.cpp
@@ -132,14 +132,14 @@ void NDPluginTimeSeries::allocateArrays()
   numTimePoints_ = numPoints;
   if (timeStamp_)  free(timeStamp_);
   if (signalData_) free (signalData_);
-  if (pTimeCircular_) delete pTimeCircular_;
+  if (pTimeCircular_) pTimeCircular_->release();
 
   timeStamp_  = (double *)calloc(numSignals_*numTimePoints_, sizeof(double));
   signalData_ = (double *)calloc(numSignals_*numTimePoints_, sizeof(double));
   nDims = 2;
   dims[0] = numTimePoints_;
   dims[1] = numSignals_;
-  pTimeCircular_ = new NDArray(nDims, dims, dataType_, 0, 0);
+  pTimeCircular_ = pNDArrayPool->alloc(nDims, dims, dataType_, 0, 0);
   createAxisArray();
   acquireReset();
 }

--- a/ADApp/pluginTests/AsynPortClientContainer.cpp
+++ b/ADApp/pluginTests/AsynPortClientContainer.cpp
@@ -9,7 +9,7 @@
 
 AsynPortClientContainer::AsynPortClientContainer(const std::string& port)
 {
-	portName = port;
+    portName = port;
 }
 
 boost::shared_ptr<int32ClientMap> AsynPortClientContainer::getInt32Map(int address)
@@ -30,44 +30,44 @@ boost::shared_ptr<octetClientMap> AsynPortClientContainer::getOctetMap(int addre
 void AsynPortClientContainer::write(const std::string& paramName, int value, int address)
 {
     boost::shared_ptr<int32ClientMap> mapPtr = getInt32Map(address);
-	// Check for the client
-	if (mapPtr->count(paramName) == 0){
-		// We need to create the client as it isn't stored
+    // Check for the client
+    if (mapPtr->count(paramName) == 0){
+        // We need to create the client as it isn't stored
         (*mapPtr)[paramName] = boost::shared_ptr<asynInt32Client>(new asynInt32Client(portName.c_str(), address, paramName.c_str()));
-	}
-	if ((*mapPtr)[paramName]->write(value) != asynSuccess){
-	  throw AsynException();
-	}
+    }
+    if ((*mapPtr)[paramName]->write(value) != asynSuccess){
+        throw AsynException();
+    }
 }
 
 void AsynPortClientContainer::write(const std::string& paramName, double value, int address)
 {
     boost::shared_ptr<float64ClientMap> mapPtr = getFloat64Map(address);
-	// Check for the client
+    // Check for the client
     if (mapPtr->count(paramName) == 0){
-		// We need to create the client as it isn't stored
+        // We need to create the client as it isn't stored
         (*mapPtr)[paramName] = boost::shared_ptr<asynFloat64Client>(new asynFloat64Client(portName.c_str(), address, paramName.c_str()));
-	}
-	if ((*mapPtr)[paramName]->write(value) != asynSuccess){
-	  throw AsynException();
-	}
+    }
+    if ((*mapPtr)[paramName]->write(value) != asynSuccess){
+        throw AsynException();
+    }
 }
 
 unsigned long int AsynPortClientContainer::write(const std::string& paramName, const std::string& value, int address)
 {
     boost::shared_ptr<octetClientMap> mapPtr = getOctetMap(address);
-  size_t length = 0;
-  size_t numWritten = 0;
-	// Check for the client
-	if (mapPtr->count(paramName) == 0){
-		// We need to create the client as it isn't stored
+    size_t length = 0;
+    size_t numWritten = 0;
+    // Check for the client
+    if (mapPtr->count(paramName) == 0){
+        // We need to create the client as it isn't stored
         (*mapPtr)[paramName] = boost::shared_ptr<asynOctetClient>(new asynOctetClient(portName.c_str(), address, paramName.c_str()));
-	}
-	length = value.size();
-	if ((*mapPtr)[paramName]->write(value.c_str(), length, &numWritten) != asynSuccess){
-    throw AsynException();
-	}
-	return numWritten;
+    }
+    length = value.size();
+    if ((*mapPtr)[paramName]->write(value.c_str(), length, &numWritten) != asynSuccess){
+        throw AsynException();
+    }
+    return numWritten;
 }
 
 int AsynPortClientContainer::readInt(const std::string& paramName, int address)
@@ -76,11 +76,11 @@ int AsynPortClientContainer::readInt(const std::string& paramName, int address)
   boost::shared_ptr<int32ClientMap> mapPtr = getInt32Map(address);
   // Check for the client
   if (mapPtr->count(paramName) == 0){
-    // We need to create the client as it isn't stored
+      // We need to create the client as it isn't stored
       (*mapPtr)[paramName] = boost::shared_ptr<asynInt32Client>(new asynInt32Client(portName.c_str(), address, paramName.c_str()));
   }
   if ((*mapPtr)[paramName]->read(&value) != asynSuccess){
-    throw AsynException();
+      throw AsynException();
   }
   return value;
 }
@@ -91,11 +91,11 @@ double AsynPortClientContainer::readDouble(const std::string& paramName, int add
   boost::shared_ptr<float64ClientMap> mapPtr = getFloat64Map(address);
   // Check for the client
   if (mapPtr->count(paramName) == 0){
-    // We need to create the client as it isn't stored
+      // We need to create the client as it isn't stored
       (*mapPtr)[paramName] = boost::shared_ptr<asynFloat64Client>(new asynFloat64Client(portName.c_str(), address, paramName.c_str()));
   }
   if ((*mapPtr)[paramName]->read(&value) != asynSuccess){
-    throw AsynException();
+      throw AsynException();
   }
   return value;
 }
@@ -109,11 +109,11 @@ std::string AsynPortClientContainer::readString(const std::string& paramName, in
   boost::shared_ptr<octetClientMap> mapPtr = getOctetMap(address);
   // Check for the client
   if (mapPtr->count(paramName) == 0){
-    // We need to create the client as it isn't stored
+      // We need to create the client as it isn't stored
       (*mapPtr)[paramName] = boost::shared_ptr<asynOctetClient>(new asynOctetClient(portName.c_str(), address, paramName.c_str()));
   }
   if ((*mapPtr)[paramName]->read(value, maxlen, &nRead, &reason) != asynSuccess){
-    throw AsynException();
+      throw AsynException();
   }
   std::string svalue(value);
   return svalue;

--- a/ADApp/pluginTests/AsynPortClientContainer.h
+++ b/ADApp/pluginTests/AsynPortClientContainer.h
@@ -24,21 +24,21 @@ class AsynPortClientContainer {
 public:
     static const int max_string_parameter_len = 1024;
 
-	AsynPortClientContainer(const std::string& port);
+    AsynPortClientContainer(const std::string& port);
 
-	virtual void write(const std::string& paramName, int value, int address=0);
-	virtual void write(const std::string& paramName, double value, int address=0);
-	virtual unsigned long int write(const std::string& paramName, const std::string& value, int address=0);
-	virtual int readInt(const std::string& paramName, int address=0);
+    virtual void write(const std::string& paramName, int value, int address=0);
+    virtual void write(const std::string& paramName, double value, int address=0);
+    virtual unsigned long int write(const std::string& paramName, const std::string& value, int address=0);
+    virtual int readInt(const std::string& paramName, int address=0);
     virtual double readDouble(const std::string& paramName, int address=0);
     virtual std::string readString(const std::string& paramName, int address=0);
 
-	virtual void cleanup();
+    virtual void cleanup();
 
-	virtual ~AsynPortClientContainer();
+    virtual ~AsynPortClientContainer();
 
 protected:
-	std::string portName;
+    std::string portName;
 
 private:
     std::vector<boost::shared_ptr<int32ClientMap> > int32Maps;

--- a/ADApp/pluginTests/HDF5PluginWrapper.h
+++ b/ADApp/pluginTests/HDF5PluginWrapper.h
@@ -22,7 +22,7 @@ public:
                     int address,
                     int priority,
                     int stackSize);
-	virtual ~HDF5PluginWrapper();
+  virtual ~HDF5PluginWrapper();
 
 };
 

--- a/ADApp/pluginTests/Makefile
+++ b/ADApp/pluginTests/Makefile
@@ -39,18 +39,18 @@ ifeq ($(WITH_BOOST),YES)
   PROD_IOC_Linux += plugin-test
   PROD_IOC_Darwin += plugin-test
   plugin-test_SRCS += plugin-test.cpp
-  plugin-test_SRCS += test_NDPluginCircularBuff.cpp
-  ifeq ($(WITH_HDF5),YES)
-    plugin-test_SRCS += test_NDFileHDF5.cpp
-    plugin-test_SRCS += test_NDFileHDF5AttributeDataset.cpp
-    plugin-test_SRCS += test_NDFileHDF5ExtraDimensions.cpp
-  endif
-  plugin-test_SRCS += test_NDPosPlugin.cpp
+#  plugin-test_SRCS += test_NDPluginCircularBuff.cpp
+#  ifeq ($(WITH_HDF5),YES)
+#    plugin-test_SRCS += test_NDFileHDF5.cpp
+#    plugin-test_SRCS += test_NDFileHDF5AttributeDataset.cpp
+#    plugin-test_SRCS += test_NDFileHDF5ExtraDimensions.cpp
+#  endif
+#  plugin-test_SRCS += test_NDPosPlugin.cpp
   plugin-test_SRCS += test_NDPluginTimeSeries.cpp
-  plugin-test_SRCS += test_NDPluginFFT.cpp
-  plugin-test_SRCS += test_NDPluginAttrPlot.cpp
-  plugin-test_SRCS += test_NDPluginROI.cpp
-  plugin-test_SRCS += test_NDPluginOverlay.cpp
+#  plugin-test_SRCS += test_NDPluginFFT.cpp
+#  plugin-test_SRCS += test_NDPluginAttrPlot.cpp
+#  plugin-test_SRCS += test_NDPluginROI.cpp
+#  plugin-test_SRCS += test_NDPluginOverlay.cpp
 
   # Add tests for new plugins like this:
   #plugin-test_SRCS += test_<plugin name>.cpp

--- a/ADApp/pluginTests/Makefile
+++ b/ADApp/pluginTests/Makefile
@@ -39,18 +39,18 @@ ifeq ($(WITH_BOOST),YES)
   PROD_IOC_Linux += plugin-test
   PROD_IOC_Darwin += plugin-test
   plugin-test_SRCS += plugin-test.cpp
-#  plugin-test_SRCS += test_NDPluginCircularBuff.cpp
-#  ifeq ($(WITH_HDF5),YES)
-#    plugin-test_SRCS += test_NDFileHDF5.cpp
-#    plugin-test_SRCS += test_NDFileHDF5AttributeDataset.cpp
-#    plugin-test_SRCS += test_NDFileHDF5ExtraDimensions.cpp
-#  endif
-#  plugin-test_SRCS += test_NDPosPlugin.cpp
+  plugin-test_SRCS += test_NDPluginCircularBuff.cpp
+  ifeq ($(WITH_HDF5),YES)
+    plugin-test_SRCS += test_NDFileHDF5.cpp
+    plugin-test_SRCS += test_NDFileHDF5AttributeDataset.cpp
+    plugin-test_SRCS += test_NDFileHDF5ExtraDimensions.cpp
+  endif
+  plugin-test_SRCS += test_NDPosPlugin.cpp
   plugin-test_SRCS += test_NDPluginTimeSeries.cpp
-#  plugin-test_SRCS += test_NDPluginFFT.cpp
-#  plugin-test_SRCS += test_NDPluginAttrPlot.cpp
-#  plugin-test_SRCS += test_NDPluginROI.cpp
-#  plugin-test_SRCS += test_NDPluginOverlay.cpp
+  plugin-test_SRCS += test_NDPluginFFT.cpp
+  plugin-test_SRCS += test_NDPluginAttrPlot.cpp
+  plugin-test_SRCS += test_NDPluginROI.cpp
+  plugin-test_SRCS += test_NDPluginOverlay.cpp
 
   # Add tests for new plugins like this:
   #plugin-test_SRCS += test_<plugin name>.cpp

--- a/ADApp/pluginTests/test_NDFileHDF5.cpp
+++ b/ADApp/pluginTests/test_NDFileHDF5.cpp
@@ -69,7 +69,6 @@ struct NDFileHDF5TestFixture
   }
   ~NDFileHDF5TestFixture()
   {
-    delete arrayPool;
     hdf5.reset();
     delete dummy_driver;
   }

--- a/ADApp/pluginTests/test_NDFileHDF5.cpp
+++ b/ADApp/pluginTests/test_NDFileHDF5.cpp
@@ -31,14 +31,13 @@ static  NDArrayPool *arrayPool;
 
 struct NDFileHDF5TestFixture
 {
-  asynPortDriver* dummy_driver;
+  asynNDArrayDriver* dummy_driver;
   boost::shared_ptr<HDF5PluginWrapper> hdf5;
 
   static int testCase;
 
   NDFileHDF5TestFixture()
   {
-    arrayPool = new NDArrayPool(100, 0);
 
     // Asyn manager doesn't like it if we try to reuse the same port name for multiple drivers (even if only one is ever instantiated at once), so
     // change it slightly for each test case.
@@ -49,7 +48,8 @@ struct NDFileHDF5TestFixture
     // We need some upstream driver for our test plugin so that calls to connectToArrayPort don't fail, but we can then ignore it and send
     // arrays by calling processCallbacks directly.
     // Thus we instansiate a basic asynPortDriver object which is never used.
-    dummy_driver = new asynPortDriver(dummy_port.c_str(), 0, 1, asynGenericPointerMask, asynGenericPointerMask, 0, 0, 0, 2000000);
+    dummy_driver = new asynNDArrayDriver(dummy_port.c_str(), 1, true, 0, asynGenericPointerMask, asynGenericPointerMask, 0, 0, 0, 0);
+    arrayPool = dummy_driver->pNDArrayPool;
 
     // This is the plugin under test
     hdf5 = boost::shared_ptr<HDF5PluginWrapper>(new HDF5PluginWrapper(testport.c_str(),

--- a/ADApp/pluginTests/test_NDFileHDF5ExtraDimensions.cpp
+++ b/ADApp/pluginTests/test_NDFileHDF5ExtraDimensions.cpp
@@ -371,10 +371,9 @@ BOOST_AUTO_TEST_CASE(test_TenExtraDimensions)
 
 BOOST_AUTO_TEST_CASE(test_PluginExtraDimensions)
 {
-  std::tr1::shared_ptr<asynPortDriver> driver;
+  std::tr1::shared_ptr<asynNDArrayDriver> driver;
   std::tr1::shared_ptr<HDF5PluginWrapper> hdf5;
 
-  NDArrayPool *arrayPool = new NDArrayPool(100, 0);
 
   // Asyn manager doesn't like it if we try to reuse the same port name for multiple drivers (even if only one is ever instantiated at once), so
   // change it slightly for each test case.
@@ -384,7 +383,8 @@ BOOST_AUTO_TEST_CASE(test_PluginExtraDimensions)
 
   // We need some upstream driver for our test plugin so that calls to connectArrayPort don't fail, but we can then ignore it and send
   // arrays by calling processCallbacks directly.
-  driver = std::tr1::shared_ptr<asynPortDriver>(new asynPortDriver(simport.c_str(), 0, 1, asynGenericPointerMask, asynGenericPointerMask, 0, 0, 0, 2000000));
+  driver = std::tr1::shared_ptr<asynNDArrayDriver>(new asynNDArrayDriver(simport.c_str(), 1, true, 0, asynGenericPointerMask, asynGenericPointerMask, 0, 0, 0, 0));
+  NDArrayPool *arrayPool = driver->pNDArrayPool;
 
   // This is the plugin under test
   hdf5 = std::tr1::shared_ptr<HDF5PluginWrapper>(new HDF5PluginWrapper(testport.c_str(),

--- a/ADApp/pluginTests/test_NDPluginAttrPlot.cpp
+++ b/ADApp/pluginTests/test_NDPluginAttrPlot.cpp
@@ -131,16 +131,20 @@ struct AttrPlotPluginTestFixture
     static const int n_selected = 2;
     AttrPlotPluginWrapper* attrPlot;
     NDArrayPool * arrPool;
+    std::string dummy_port;
     std::string port;
 
     AttrPlotPluginTestFixture()
-        : arrPool(new NDArrayPool(100,0)),
-          port("TS")
+        : port("TS")
     {
 
         // Asyn manager doesn't like it if we try to reuse the same port name for multiple drivers
         // (even if only one is ever instantiated at once), so we change it slightly for each test case.
         uniqueAsynPortName(port);
+        uniqueAsynPortName(dummy_port);
+
+        asynNDArrayDriver *dummy_driver = new asynNDArrayDriver(dummy_port.c_str(), 1, true, 0, asynGenericPointerMask, asynGenericPointerMask, 0, 0, 0, 0);
+        arrPool = dummy_driver->pNDArrayPool;
 
         // This is the plugin under test
         attrPlot = new AttrPlotPluginWrapper(

--- a/ADApp/pluginTests/test_NDPluginCircularBuff.cpp
+++ b/ADApp/pluginTests/test_NDPluginCircularBuff.cpp
@@ -81,7 +81,7 @@ struct PluginFixture
         delete cbControl;
         //delete ds; // TODO: something is wrong here - if we delete ds we get a memory corruption error (in a loop!?!?)
         delete cb;
-        //delete dummy_driver;
+        delete dummy_driver;
     }
     void cbProcess(NDArray *pArray)
     {

--- a/ADApp/pluginTests/test_NDPluginOverlay.cpp
+++ b/ADApp/pluginTests/test_NDPluginOverlay.cpp
@@ -111,7 +111,7 @@ static void appendTestCase(std::vector<overlayTestCaseStr> *pOut, overlayTempCas
 
 struct OverlayPluginTestFixture
 {
-  boost::shared_ptr<asynPortDriver> driver;
+  boost::shared_ptr<asynNDArrayDriver> driver;
   boost::shared_ptr<OverlayPluginWrapper> Overlay;
   boost::shared_ptr<asynGenericPointerClient> client;
   TestingPlugin* downstream_plugin; // TODO: we don't put this in a shared_ptr and purposefully leak memory because asyn ports cannot be deleted
@@ -123,7 +123,6 @@ struct OverlayPluginTestFixture
 
   OverlayPluginTestFixture()
   {
-    arrayPool = new NDArrayPool(100, 0);
     expectedArrayCounter=0;
 
     // Asyn manager doesn't like it if we try to reuse the same port name for multiple drivers
@@ -134,11 +133,12 @@ struct OverlayPluginTestFixture
 
     // We need some upstream driver for our test plugin so that calls to connectArrayPort
     // don't fail, but we can then ignore it and send arrays by calling processCallbacks directly.
-    driver = boost::shared_ptr<asynPortDriver>(new asynPortDriver(simport.c_str(),
-                                                                     1, 1,
+    driver = boost::shared_ptr<asynNDArrayDriver>(new asynNDArrayDriver(simport.c_str(),
+                                                                     1, true, 0,
                                                                      asynGenericPointerMask,
                                                                      asynGenericPointerMask,
                                                                      0, 0, 0, 2000000));
+    arrayPool = driver->pNDArrayPool;
 
     // This is the plugin under test
     Overlay = boost::shared_ptr<OverlayPluginWrapper>(new OverlayPluginWrapper(testport.c_str(),
@@ -193,7 +193,6 @@ struct OverlayPluginTestFixture
 
   ~OverlayPluginTestFixture()
   {
-    delete arrayPool;
     client.reset();
     Overlay.reset();
     driver.reset();

--- a/ADApp/pluginTests/test_NDPluginTimeSeries.cpp
+++ b/ADApp/pluginTests/test_NDPluginTimeSeries.cpp
@@ -128,7 +128,7 @@ struct TimeSeriesPluginTestFixture
   {
     client.reset();
     ts.reset();
-    //driver.reset();
+    driver.reset();
     //delete downstream_plugin; // TODO: We can't delete a TestingPlugin because it tries to delete an asyn port which doesnt work
   }
 

--- a/ADApp/pluginTests/test_NDPluginTimeSeries.cpp
+++ b/ADApp/pluginTests/test_NDPluginTimeSeries.cpp
@@ -42,7 +42,7 @@ void TS_callback(void *userPvt, asynUser *pasynUser, void *pointer)
 struct TimeSeriesPluginTestFixture
 {
   NDArrayPool *arrayPool;
-  boost::shared_ptr<asynPortDriver> driver;
+  boost::shared_ptr<asynNDArrayDriver> driver;
   boost::shared_ptr<TimeSeriesPluginWrapper> ts;
   boost::shared_ptr<asynGenericPointerClient> client;
   TestingPlugin* downstream_plugin; // TODO: we don't put this in a shared_ptr and purposefully leak memory because asyn ports cannot be deleted
@@ -57,7 +57,6 @@ struct TimeSeriesPluginTestFixture
 
   TimeSeriesPluginTestFixture()
   {
-    arrayPool = new NDArrayPool(250, 0);
 
     // Asyn manager doesn't like it if we try to reuse the same port name for multiple drivers
     // (even if only one is ever instantiated at once), so we change it slightly for each test case.
@@ -67,11 +66,12 @@ struct TimeSeriesPluginTestFixture
 
     // We need some upstream driver for our test plugin so that calls to connectArrayPort
     // don't fail, but we can then ignore it and send arrays by calling processCallbacks directly.
-    driver = boost::shared_ptr<asynPortDriver>(new asynPortDriver(simport.c_str(),
-                                                                     1, 1,
+    driver = boost::shared_ptr<asynNDArrayDriver>(new asynNDArrayDriver(simport.c_str(),
+                                                                     1, true, 0,
                                                                      asynGenericPointerMask,
                                                                      asynGenericPointerMask,
-                                                                     0, 0, 0, 2000000));
+                                                                     0, 0, 0, 0));
+    arrayPool = driver->pNDArrayPool;
 
     // This is the plugin under test
     ts = boost::shared_ptr<TimeSeriesPluginWrapper>(new TimeSeriesPluginWrapper(testport.c_str(),
@@ -126,10 +126,9 @@ struct TimeSeriesPluginTestFixture
 
   ~TimeSeriesPluginTestFixture()
   {
-    delete arrayPool;
     client.reset();
     ts.reset();
-    driver.reset();
+    //driver.reset();
     //delete downstream_plugin; // TODO: We can't delete a TestingPlugin because it tries to delete an asyn port which doesnt work
   }
 

--- a/ADApp/pluginTests/test_NDPosPlugin.cpp
+++ b/ADApp/pluginTests/test_NDPosPlugin.cpp
@@ -44,7 +44,7 @@ static NDArrayPool *arrayPool;
 
 struct PosPluginTestFixture
 {
-  std::tr1::shared_ptr<asynPortDriver> driver;
+  std::tr1::shared_ptr<asynNDArrayDriver> driver;
   std::tr1::shared_ptr<PosPluginWrapper> pos;
   std::tr1::shared_ptr<asynGenericPointerClient> client;
 
@@ -52,7 +52,6 @@ struct PosPluginTestFixture
 
   PosPluginTestFixture()
   {
-    arrayPool = new NDArrayPool(100, 0);
 
     // Asyn manager doesn't like it if we try to reuse the same port name for multiple drivers (even if only one is ever instantiated at once), so
     // change it slightly for each test case.
@@ -62,7 +61,8 @@ struct PosPluginTestFixture
 
     // We need some upstream driver for our test plugin so that calls to connectArrayPort don't fail, but we can then ignore it and send
     // arrays by calling processCallbacks directly.
-    driver = std::tr1::shared_ptr<asynPortDriver>(new asynPortDriver(simport.c_str(), 0, 1, asynGenericPointerMask, asynGenericPointerMask, 0, 0, 0, 2000000));
+    driver = std::tr1::shared_ptr<asynNDArrayDriver>(new asynNDArrayDriver(simport.c_str(), 1, true, 0, asynGenericPointerMask, asynGenericPointerMask, 0, 0, 0, 0));
+    arrayPool = driver->pNDArrayPool;
 
     // This is the plugin under test
     pos = std::tr1::shared_ptr<PosPluginWrapper>(new PosPluginWrapper(testport.c_str(),
@@ -86,10 +86,9 @@ struct PosPluginTestFixture
 
   ~PosPluginTestFixture()
   {
-    delete arrayPool;
     client.reset();
     pos.reset();
-    driver.reset();
+    //driver.reset();
   }
 
 };

--- a/ADApp/pluginTests/test_NDPosPlugin.cpp
+++ b/ADApp/pluginTests/test_NDPosPlugin.cpp
@@ -88,7 +88,7 @@ struct PosPluginTestFixture
   {
     client.reset();
     pos.reset();
-    //driver.reset();
+    driver.reset();
   }
 
 };

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,9 +20,59 @@ files respectively, in the configure/ directory of the appropriate release of th
 Release Notes
 =============
 
-R3-3 (April XXX, 2018)
+R3-3 (June XXX, 2018)
 ======================
-### NDArray
+### NDArrayPool design changes
+* Previously each asynNDArrayDriver had its own NDArrayPool. asynNDArrayDriver is the class from which both
+  ADDriver, NDPluginDriver, and many classes in other modules such as dxp and quadEM are derived.
+  This design had the problem that it was not really possible to enforce the maxMemory limits for the
+  driver and plugin chain.  It is the sum of the memory use by the driver and all plugins that matters, 
+  not the use by each individual driver and plugin.  
+* In the new design the asynNDArray driver constructor is passed a flag indicating if the object is a driver or a plugin.
+  It only creates an NDArrayPool if it is a driver, i.e. the original source of NDArrays.
+* The NDPluginDriver base class was changed to set its pNDArrayPool pointer to the address passed to it in the 
+  NDArray.pNDArrayPool for the NDArray in the callback.  Ultimately all NDArrays are derived from the driver,
+  either directly, or via the NDArrayPool.copy() or NDArrayPool.convert() methods.  This means that plugins
+  now allocate NDArrays from the driver's NDArrayPool, not their own.
+* This means that there is now just a single NDArrayPool and the maxMemory argument to the driver constuctor now controls
+  the total amount of memory that can be allocated for the driver and all downstream plugins.
+* The maxBuffers argument to the driver is now ignored.
+  There is now no limit on the number of NDArrays, only on the total amount of memory.
+* The maxBuffers argument to the ADDriver constructor is still present so existing drivers will work with no changes. It is ignored. 
+  A second constructor will be added in the future and the old one will be deprecated.
+* The maxBuffers and maxMemory arguments to the NDPluginDriver constructor are now ignored.
+  They are still present so existing plugins will work with no changes.
+  A second constructor will be added in the future and the old one will be deprecated.
+* These changes are not quite 100% backwards compatible.
+  - Startup scripts that set a non-zero value for maxMemory in the driver may need to increase this value.
+  - Plugins that call NDArrayPool->alloc() before the first callback need to be modified.
+    There was only one plugin in ADCore that needed this change.
+### Active plugin counting and waiting for plugins to complete
+* Previously if one wanted to wait for plugins to complete before the driver indicated that acquisition was complete
+  then one needed to set CallbacksBlock=Yes for each plugin in the chain.
+  Waiting for plugins is needed in cases like the following, for example:
+  - One is doing a step scan and one of the counters for the step-scan is a PV from the statistics plugin. It is necessary to
+    wait for the statistics plugin to complete to be sure the PV value is for current NDArray and not the previous one.
+  - One is doing a scan and writing the NDArrays to a file with one of the file plugins. It is necessary to wait
+    for the file plugin to complete before changing the file name for the next point.
+  There are 2 problems with setting CallbacksBlock=Yes.
+  - It slows down the driver because the plugin is executing in the driver thread and not in its own thread.
+  - It is complicated to change all of the required plugin settings from CallbacksBlock=No to CallbacksBlock=Yes.
+* The NDPluginDriver base class now increments a NumActivePlugins counter in the driver that owns each NDArray as it is queued, 
+  and decrements the counter after the processing is done. 
+* All drivers have 3 new records:
+  - NumActivePlugins: This record indicates the total number of NDArrays that are currently processing or are queued
+    for processing by this driver.
+  - WaitForPlugins: This record determines whether AcquireBusy waits for NumActivePlugins to go to 0 before changing to 0 when acquisition completes.
+  - AcquireBusy This is a busy record that is set to 1 when Acquire changes to 1. It changes back to 0 when acquisition completes, 
+    i.e. when Acquire_RBV=0. If WaitForPlugins is Yes then it also waits for NumActivePlugins to go to 0 before changing to 0.
+* The ADCollect sub-screen now contains these 3 PVs.
+* The ADBase screen contains the ADCollect screen, so it shows these PVs.
+* Driver screens typically do not use the ADCollect sub-screen, so they need to be individually edited to contain these PVs.  
+  They are not yet all complete.
+* With this new design it should rarely be necessary to change plugins to use CallbacksBlock=Yes.
+### NDArray, NDArrayPool
+* Changes to allow the NDArray class to be inherited by derived classes.  Thanks to Sinisa Veseli for this. 
 * Added the epicsTS (EPICS time stamp) field to the report() output. 
   Previously the timeStamp field was in the report, but not the epicsTS field was not.
 ### NDPluginPva

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -54,8 +54,8 @@ R3-3 (June XXX, 2018)
   - One is doing a step scan and one of the counters for the step-scan is a PV from the statistics plugin. It is necessary to
     wait for the statistics plugin to complete to be sure the PV value is for current NDArray and not the previous one.
   - One is doing a scan and writing the NDArrays to a file with one of the file plugins. It is necessary to wait
-    for the file plugin to complete before changing the file name for the next point.  
-  There are 2 problems with setting CallbacksBlock=Yes.
+    for the file plugin to complete before changing the file name for the next point.
+* There are 2 problems with setting CallbacksBlock=Yes.
   - It slows down the driver because the plugin is executing in the driver thread and not in its own thread.
   - It is complicated to change all of the required plugin settings from CallbacksBlock=No to CallbacksBlock=Yes.
 * The NDPluginDriver base class now increments a NumActivePlugins counter in the driver that owns each NDArray as it is queued, 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -54,9 +54,8 @@ R3-3 (June XXX, 2018)
   - One is doing a step scan and one of the counters for the step-scan is a PV from the statistics plugin. It is necessary to
     wait for the statistics plugin to complete to be sure the PV value is for current NDArray and not the previous one.
   - One is doing a scan and writing the NDArrays to a file with one of the file plugins. It is necessary to wait
-    for the file plugin to complete before changing the file name for the next point.
-  
-    There are 2 problems with setting CallbacksBlock=Yes.
+    for the file plugin to complete before changing the file name for the next point.  
+  There are 2 problems with setting CallbacksBlock=Yes.
   - It slows down the driver because the plugin is executing in the driver thread and not in its own thread.
   - It is complicated to change all of the required plugin settings from CallbacksBlock=No to CallbacksBlock=Yes.
 * The NDPluginDriver base class now increments a NumActivePlugins counter in the driver that owns each NDArray as it is queued, 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -55,7 +55,8 @@ R3-3 (June XXX, 2018)
     wait for the statistics plugin to complete to be sure the PV value is for current NDArray and not the previous one.
   - One is doing a scan and writing the NDArrays to a file with one of the file plugins. It is necessary to wait
     for the file plugin to complete before changing the file name for the next point.
-  There are 2 problems with setting CallbacksBlock=Yes.
+  
+    There are 2 problems with setting CallbacksBlock=Yes.
   - It slows down the driver because the plugin is executing in the driver thread and not in its own thread.
   - It is complicated to change all of the required plugin settings from CallbacksBlock=No to CallbacksBlock=Yes.
 * The NDPluginDriver base class now increments a NumActivePlugins counter in the driver that owns each NDArray as it is queued, 


### PR DESCRIPTION
- Count number of NDArrays queued or processing in plugins. 
- Plugins no longer have their own NDArrayPool, they use the driver pNDArrayPool pointer in the NDArray passed to them.
- NDArrayPool->alloc() no longer uses maxBuffers, only maxMemory.

New records in ADBase.template:
- NumActivePlugins  The number of NDArrays processing or queued in plugins for this driver.
- WaitForPlugins This record determines whether AcquireBusy waits for NumActivePlugins to go to 0 before changing to 0 when acquisition completes.
- AcquireBusy This is a busy record that is set to 1 when Acquire changes to 1. It changes back to 0 when acquisition completes, i.e. when Acquire_RBV=0. If WaitForPlugins is Yes then it also waits for NumActivePlugins to go to 0 before changing to 0.

The Acquire record has changed from a busy record to a bo record with info(asyn:READBACK=1).  This is required to implement the logic described above.  ca_put_callback still works because Acquire has a FLNK to AcquireBusy.
