### PR TITLE
Allow AD Plugin Framework to Use Objects Derived from NDArray Class

### DIFF
--- a/ADApp/ADSrc/NDArray.h
+++ b/ADApp/ADSrc/NDArray.h
@@ -133,7 +133,6 @@ public:
   */
 class epicsShareClass NDArrayPool {
 public:
-    NDArrayPool  (int maxBuffers, size_t maxMemory);
     NDArrayPool  (class asynNDArrayDriver *pDriver, size_t maxMemory);
     virtual ~NDArrayPool() {}
     NDArray*     alloc     (int ndims, size_t *dims, NDDataType_t dataType, size_t dataSize, void *pData);

--- a/ADApp/ADSrc/NDArray.h
+++ b/ADApp/ADSrc/NDArray.h
@@ -91,11 +91,12 @@ class epicsShareClass NDArray {
 public:
     /* Methods */
     NDArray();
-    ~NDArray();
+    virtual ~NDArray();
     int          initDimension   (NDDimension_t *pDimension, size_t size);
     int          getInfo         (NDArrayInfo_t *pInfo);
     int          reserve();
     int          release();
+    int          getReferenceCount() const {return referenceCount;}
     int          report(FILE *fp, int details);
     friend class NDArrayPool;
     
@@ -131,6 +132,7 @@ public:
 class epicsShareClass NDArrayPool {
 public:
     NDArrayPool  (int maxBuffers, size_t maxMemory);
+    virtual ~NDArrayPool() {}
     NDArray*     alloc     (int ndims, size_t *dims, NDDataType_t dataType, size_t dataSize, void *pData);
     NDArray*     copy      (NDArray *pIn, NDArray *pOut, int copyData);
 
@@ -149,6 +151,11 @@ public:
     size_t       maxMemory  ();
     size_t       memorySize ();
     int          numFree    ();
+protected:
+    virtual NDArray* createArray();
+    virtual void onAllocateArray(NDArray *pArray);
+    virtual void onReserveArray(NDArray *pArray);
+    virtual void onReleaseArray(NDArray *pArray);
 private:
     ELLLIST      freeList_;      /**< Linked list of free NDArray objects that form the pool */
     epicsMutexId listLock_;      /**< Mutex to protect the free list */
@@ -157,6 +164,7 @@ private:
     size_t       maxMemory_;     /**< Maximum bytes of memory this object is allowed to allocate; -1=unlimited */
     size_t       memorySize_;    /**< Number of bytes of memory this object has currently allocated */
     int          numFree_;       /**< Number of NDArray objects in the free list */
+    size_t ellNodeOffset;
 };
 
 #endif

--- a/ADApp/ADSrc/NDArray.h
+++ b/ADApp/ADSrc/NDArray.h
@@ -164,7 +164,7 @@ private:
     size_t       maxMemory_;     /**< Maximum bytes of memory this object is allowed to allocate; -1=unlimited */
     size_t       memorySize_;    /**< Number of bytes of memory this object has currently allocated */
     int          numFree_;       /**< Number of NDArray objects in the free list */
-    size_t ellNodeOffset;
+    size_t       ellNodeOffset;  /**< Difference between the list node and NDArray object that belongs to that node; this offset is non-zero only if this pool manages objects derived from NDArray class */
     class asynNDArrayDriver *pDriver_; /**< The asynNDArrayDriver that created this object */
 };
 

--- a/ADApp/ADSrc/NDArray.h
+++ b/ADApp/ADSrc/NDArray.h
@@ -152,11 +152,16 @@ public:
     size_t       getMaxMemory  ();
     size_t       getMemorySize ();
     int          getNumFree    ();
+
 protected:
+    /** The following methods should be implemented by a pool class
+      * that manages objects derived from the NDArray class.
+      */
     virtual NDArray* createArray();
     virtual void onAllocateArray(NDArray *pArray);
     virtual void onReserveArray(NDArray *pArray);
     virtual void onReleaseArray(NDArray *pArray);
+
 private:
     ELLLIST      freeList_;      /**< Linked list of free NDArray objects that form the pool */
     epicsMutexId listLock_;      /**< Mutex to protect the free list */

--- a/ADApp/ADSrc/NDArrayPool.cpp
+++ b/ADApp/ADSrc/NDArrayPool.cpp
@@ -114,7 +114,7 @@ NDArray* NDArrayPool::alloc(int ndims, size_t *dims, NDDataType_t dataType, size
     numBuffers_++;
     pArray = this->createArray();
     if (numBuffers_ <= 1) {
-        /* Calculate offset for the first allocated buffer. This will be non-zero only of the pool manages objects that derive from NDArray class */
+        /* Calculate offset for the first allocated buffer. This will be non-zero only if the pool manages objects that derive from NDArray class */
         ellNodeOffset = (char*)(&(pArray->node)) - (char*)pArray;
     }
     ellAdd(&freeList_, &pArray->node);


### PR DESCRIPTION
These changes allow AD drivers and plugins to use any class that derives from NDArray. Modifications are fully backwards compatible with existing code and plugins.