### PR TITLE
Fix SIZE_MAX error in NDArrayPool for GCC 4.4.7

### DIFF
--- a/ADApp/ADSrc/NDArrayPool.cpp
+++ b/ADApp/ADSrc/NDArrayPool.cpp
@@ -8,7 +8,7 @@
 
 #include <stdlib.h>
 #include <dbDefs.h>
-#include <stdint.h>
+#include <limits>
 
 #include <cantProceed.h>
 #include <epicsExport.h>
@@ -146,7 +146,7 @@ NDArray* NDArrayPool::alloc(int ndims, size_t *dims, NDDataType_t dataType, size
 
   size_t thresholdSize = dataSize + dataSize / 2;
   // sanity check for case of overflow when calculating thresholdSize
-  thresholdSize = (thresholdSize < dataSize) ? SIZE_MAX : thresholdSize;
+  thresholdSize = (thresholdSize < dataSize) ? std::numeric_limits<size_t>::max() : thresholdSize;
   if (freeArray) {
     pArray = freeArray;
     if (pArray->dataSize != dataSize) {


### PR DESCRIPTION
NDArrayPool uses SIZE_MAX, but in GCC 4.4.7 (the default compiler
on RHEL 6), SIZE_MAX is not defined by stdint.h in C++ mode unless
explicitly requested by defining __STDC_LIMIT_MACROS.  This could be
worked around by defining the __STDC_LIMIT_MACROS macro, but instead,
avoid this altogether by using std::numeric_limits.