### PR TITLE
Suggestions for NDCircularBuff

### DIFF
--- a/ADApp/Db/NDCircularBuff.template
+++ b/ADApp/Db/NDCircularBuff.template
@@ -198,3 +198,22 @@ record(longin, "$(P)$(R)ActualTriggerCount_RBV") {
   field(INP, "@asyn($(PORT) 0)CIRC_BUFF_ACTUAL_TRIGGER_COUNT")
 }
 
+# # Configuration behaviour of flush
+record(bo, "$(P)$(R)FlushOnSoftTrg") {
+  field(DTYP, "asynInt32")
+  field(OUT, "@asyn($(PORT) 0)CIRC_BUFF_FLUSH_ON_SOFTTRIGGER")
+  field(ZNAM, "On new image")
+  field(ONAM, "Immediately")
+  field(VAL,  "0")
+  field(PINI, "1")
+}
+
+# # How flush is configured
+record(bi, "$(P)$(R)FlushOnSoftTrg_RBV") {
+  field(SCAN, "I/O Intr")
+  field(DTYP, "asynInt32")
+  field(INP, "@asyn($(PORT) 0)CIRC_BUFF_FLUSH_ON_SOFTTRIGGER")
+  field(ZNAM, "On new image")
+  field(ONAM, "Immediately")
+}
+

--- a/ADApp/pluginSrc/NDArrayRing.cpp
+++ b/ADApp/pluginSrc/NDArrayRing.cpp
@@ -35,6 +35,7 @@ NDArrayRing::NDArrayRing(int noOfBuffers)
 NDArrayRing::~NDArrayRing()
 {
   clear();
+  delete[] buffers_;
 }
 
 int NDArrayRing::size()
@@ -98,14 +99,15 @@ bool NDArrayRing::hasNext()
 void NDArrayRing::clear()
 {
   writeIndex_ = -1;
+  readIndex_  = -1;
   wrapped_ = 0;
   if (buffers_){
     for (int index = 0; index < noOfBuffers_; index++){
       if (buffers_[index]){
         buffers_[index]->release();
+        buffers_[index] = NULL;
       }
     }
-    delete[] buffers_;
   }
 }
 

--- a/ADApp/pluginSrc/NDFileTIFF.cpp
+++ b/ADApp/pluginSrc/NDFileTIFF.cpp
@@ -447,6 +447,14 @@ asynStatus NDFileTIFF::readFile(NDArray **pArray)
     TIFFGetField(this->tiff, TIFFTAG_ROWSPERSTRIP,     &rowsPerStrip);   
     numStrips= TIFFNumberOfStrips(this->tiff);
 
+    if (0 == sampleFormat)
+    {
+        asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
+            "%s::%s Sample format is not defined! Default UINT is used.\n",
+            driverName, __FUNCTION__);
+    	sampleFormat = SAMPLEFORMAT_UINT;
+    }
+
     if      ((bitsPerSample == 8)  && (sampleFormat == SAMPLEFORMAT_INT))     dataType = NDInt8;
     else if ((bitsPerSample == 8)  && (sampleFormat == SAMPLEFORMAT_UINT))    dataType = NDUInt8;
     else if ((bitsPerSample == 16) && (sampleFormat == SAMPLEFORMAT_INT))     dataType = NDInt16;
@@ -461,9 +469,11 @@ asynStatus NDFileTIFF::readFile(NDArray **pArray)
             driverName, functionName, bitsPerSample, sampleFormat);
         return asynError;    
     }
-    if ((photoMetric == PHOTOMETRIC_MINISBLACK) && 
-        (planarConfig == PLANARCONFIG_CONTIG)   &&
-        (samplesPerPixel == 1)) {
+
+    if ((planarConfig == PLANARCONFIG_CONTIG)
+        && (samplesPerPixel == 1)
+		&& (photoMetric == PHOTOMETRIC_MINISBLACK))
+    {
         ndims = 2;
         dims[0] = sizeX;
         dims[1] = sizeY;
@@ -489,7 +499,7 @@ asynStatus NDFileTIFF::readFile(NDArray **pArray)
     }
     else {
         asynPrint(pasynUserSelf, ASYN_TRACE_ERROR, 
-            "%s::%s unsupport photoMetric=%dm planarConfig=%d, and samplesPerPixel=%d\n", 
+            "%s::%s unsupport photoMetric=%d, planarConfig=%d, and samplesPerPixel=%d\n",
             driverName, functionName, photoMetric, planarConfig, samplesPerPixel);
         return asynError;    
     }

--- a/ADApp/pluginSrc/NDFileTIFF.cpp
+++ b/ADApp/pluginSrc/NDFileTIFF.cpp
@@ -470,10 +470,9 @@ asynStatus NDFileTIFF::readFile(NDArray **pArray)
         return asynError;    
     }
 
-    if ((planarConfig == PLANARCONFIG_CONTIG)
-        && (samplesPerPixel == 1)
-		&& (photoMetric == PHOTOMETRIC_MINISBLACK))
-    {
+    if ((photoMetric == PHOTOMETRIC_MINISBLACK)  &&
+           (planarConfig == PLANARCONFIG_CONTIG) &&
+           (samplesPerPixel == 1)) {
         ndims = 2;
         dims[0] = sizeX;
         dims[1] = sizeY;

--- a/ADApp/pluginSrc/NDFileTIFF.cpp
+++ b/ADApp/pluginSrc/NDFileTIFF.cpp
@@ -471,8 +471,8 @@ asynStatus NDFileTIFF::readFile(NDArray **pArray)
     }
 
     if ((photoMetric == PHOTOMETRIC_MINISBLACK)  &&
-           (planarConfig == PLANARCONFIG_CONTIG) &&
-           (samplesPerPixel == 1)) {
+        (planarConfig == PLANARCONFIG_CONTIG) &&
+        (samplesPerPixel == 1)) {
         ndims = 2;
         dims[0] = sizeX;
         dims[1] = sizeY;

--- a/ADApp/pluginSrc/NDPluginCircularBuff.cpp
+++ b/ADApp/pluginSrc/NDPluginCircularBuff.cpp
@@ -148,7 +148,6 @@ void NDPluginCircularBuff::processCallbacks(NDArray *pArray)
 
         // Have we detected a trigger event yet?
         if (!triggered){
-
           // No trigger so add the NDArray to the pre-trigger ring
           pOldArray_ = preBuffer_->addToEnd(pArrayCpy);
           // If we overwrote an existing array in the ring, release it here
@@ -161,9 +160,7 @@ void NDPluginCircularBuff::processCallbacks(NDArray *pArray)
           if (preBuffer_->size() == preCount){
             setStringParam(NDCircBuffStatus, "Buffer Wrapping");
           }
-
         } else {
-
           // Trigger detected
           // Start making frames available if trigger has occured
           setStringParam(NDCircBuffStatus, "Flushing");

--- a/ADApp/pluginSrc/NDPluginCircularBuff.cpp
+++ b/ADApp/pluginSrc/NDPluginCircularBuff.cpp
@@ -292,9 +292,6 @@ asynStatus NDPluginCircularBuff::writeInt32(asynUser *pasynUser, epicsInt32 valu
           // Set the parameter in the parameter library.
           status = (asynStatus) setIntegerParam(function, value);
         }
-    }  else if (function == NDCircBuffFlushOnSoftTrig) {
-        // Set the parameter in the parameter library.
-        status = (asynStatus) setIntegerParam(function, value);
     } else {
         // Set the parameter in the parameter library.
         status = (asynStatus) setIntegerParam(function, value);

--- a/ADApp/pluginSrc/NDPluginCircularBuff.h
+++ b/ADApp/pluginSrc/NDPluginCircularBuff.h
@@ -63,6 +63,8 @@ protected:
     int NDCircBuffSoftTrigger;
     int NDCircBuffTriggered;
 
+    void flushPreBuffer();
+
 private:
 
     asynStatus calculateTrigger(NDArray *pArray, int *trig);

--- a/ADApp/pluginSrc/NDPluginCircularBuff.h
+++ b/ADApp/pluginSrc/NDPluginCircularBuff.h
@@ -24,6 +24,7 @@
 #define NDCircBuffPostCountString           "CIRC_BUFF_POST_COUNT"            /* (asynInt32,        r/o) Number of the current post count image */
 #define NDCircBuffSoftTriggerString         "CIRC_BUFF_SOFT_TRIGGER"          /* (asynInt32,        r/w) Force a soft trigger */
 #define NDCircBuffTriggeredString           "CIRC_BUFF_TRIGGERED"             /* (asynInt32,        r/o) Have we had a trigger event */
+#define NDCircBuffFlushOnSoftTrigString     "CIRC_BUFF_FLUSH_ON_SOFTTRIGGER"  /* (asynInt32,        r/w) Flush buffer immediatelly when software trigger obtained */
 
 
 /** Performs a scope like capture.  Records a quantity
@@ -62,6 +63,7 @@ protected:
     int NDCircBuffPostCount;
     int NDCircBuffSoftTrigger;
     int NDCircBuffTriggered;
+    int NDCircBuffFlushOnSoftTrig;
 
     void flushPreBuffer();
 

--- a/documentation/NDPluginCircularBuff.html
+++ b/documentation/NDPluginCircularBuff.html
@@ -376,6 +376,28 @@
         <td>
           bi</td>
       </tr>
+      <tr>
+        <td>
+          NDCircBuffFlushOnSoftTrig</td>
+        <td>
+          asynInt32</td>
+        <td>
+          r/o</td>
+        <td>
+          Defines behaviour of the flush functionlity. Possible values are:
+		  <ul>
+			<li><b>On new image</b> - flushes on new image. <b>(DEFAULT)</b></li>
+			<li><b>Immediately</b>  - flushes immediately on software trigger.</li>
+		  </ul>
+		  </td>
+        <td>
+          CIRC_BUFF_FLUSH_ON_SOFTTRIGGER</td>
+        <td>
+          $(P)$(R)FlushOnSoftTrg
+		  $(P)$(R)FlushOnSoftTrg_RBV</td>
+        <td>
+          bi</td>
+      </tr>
     </tbody>
   </table>
   <p>


### PR DESCRIPTION
Hi Mark,

Here I am again suggesting same fixes. :)

1.  Fixing ND circular buffer so it flushes pre-trigger buffer immediately on software trigger. It is because in my case there might not be a sequential image after the trigger.
I added a PV which allows to regulate when buffer is flushed ($(P)$(R)FlushOnSoftTrg). By default the behavior is the same as before. If the parameter is set to 1=Immediately, pre buffer is flushed immediately on Software trigger arrival.

2. Fixing NDArrayRing. Currently buffer holder is deleted on clear request. That makes reuse of the NDArrayRing impossible if you need to clear NDArrayRing in between.

 3. Small change in TIFF plugin which allows to read TIFFs generated in Photoshop or other editor which doesn't saves explicitly parameters with default value.
    sampleFormat = SAMPLEFORMAT_UINT;

Thank you,
Slava Isaev

Project Leader
Cosylab d.d.