### PR TITLE
Allow storing NDArrays with single dimension.

### DIFF
--- a/ADApp/pluginSrc/NDFileTIFF.cpp
+++ b/ADApp/pluginSrc/NDFileTIFF.cpp
@@ -176,7 +176,15 @@ asynStatus NDFileTIFF::openFile(const char *fileName, NDFileOpenMode_t openMode,
             bitsPerSample = 64;
             break;
     }
-    if (pArray->ndims == 2) {
+    if (pArray->ndims == 1) {
+        sizeX = pArray->dims[0].size;
+        sizeY = 1;
+        rowsPerStrip = sizeY;
+        samplesPerPixel = 1;
+        photoMetric = PHOTOMETRIC_MINISBLACK;
+        planarConfig = PLANARCONFIG_CONTIG;
+        this->colorMode = NDColorModeMono;
+    } else if (pArray->ndims == 2) {
         sizeX = pArray->dims[0].size;
         sizeY = pArray->dims[1].size;
         rowsPerStrip = sizeY;


### PR DESCRIPTION
The change allows saving 1D NDArray to TIFF file.

I'm working with NDArray with 1 dimension, think waveforms as data traces (i.e. ADC samples waveform). I seems one can not save a 1D NDArray to TIFF. I'm looking at this because I want to load TIFF file from processing plugin for subtracting background.

I've tested the changed code, on an IOC I'm working right now, and it allows me to save 1D array. After loading the same file from NDProcessing TIFF loading feature I can observe the background being subtracted as expected.

Would you accept such a change?

PS.
While writing this it got me thinking that maybe I could have two dimensions in my ADC waveform NDArrays, only for such purposes. Would that have any consequences on how the other plugins would behave, which now have no issues with data being 1D?