### PR TITLE
DOC: add missing maxThreads argument to NDROIConfigure

### DIFF
--- a/documentation/NDPluginROI.html
+++ b/documentation/NDPluginROI.html
@@ -672,7 +672,7 @@
   <pre>NDROIConfigure(const char *portName, int queueSize, int blockingCallbacks,
                const char *NDArrayPort, int NDArrayAddr,
                int maxBuffers, size_t maxMemory,
-               int priority, int stackSize)
+               int priority, int stackSize, int maxThreads)
   </pre>
   <p>
     For details on the meaning of the parameters to this function refer to the detailed


### PR DESCRIPTION
Noticed that issue while tried to configure the `maxThreads` parameter for detectors at the NSLS-II SMI beamline. The corresponding source code is: https://github.com/areaDetector/ADCore/blob/7fc9b3f1d5f7f81bfd11c552380d4af069b189ac/ADApp/pluginSrc/NDPluginROI.cpp#L367-L370.

I suspect similar update should be done for NDPluginStats.html, and some other files (leaving it up to the developers).