### PR TITLE
Fix race condition on asynNDArrayDriver's destructor. Fix #353

### DIFF
--- a/ADApp/ADSrc/asynNDArrayDriver.h
+++ b/ADApp/ADSrc/asynNDArrayDriver.h
@@ -210,6 +210,9 @@ private:
     epicsEventId queuedArrayEvent_;
     int queuedArrayCount_;
     
+    bool queuedArrayUpdateRun_;
+    epicsEventId queuedArrayUpdateDone_;
+
     friend class NDArrayPool;
 
 };


### PR DESCRIPTION
This PR hopefully fixes #353. I have been running the tests [non-stop](https://stackoverflow.com/questions/6545763/how-can-i-rerun-a-program-with-gdb-until-a-segmentation-fault-occurs) for a few minutes now and no crashes were observed anymore.