### PR TITLE
Direct Chunk Write

### DIFF
--- a/ADApp/ADSrc/Codec.h
+++ b/ADApp/ADSrc/Codec.h
@@ -1,0 +1,56 @@
+#ifndef Codec_H
+#define Codec_H
+
+static std::string codecName[] = {
+    "",
+    "jpeg",
+    "blosc",
+    "lz4",
+    "bslz4"
+};
+
+typedef enum {
+  NDCODEC_NONE,
+  NDCODEC_JPEG,
+  NDCODEC_BLOSC,
+  NDCODEC_LZ4,
+  NDCODEC_BSLZ4
+} NDCodecCompressor_t;
+
+typedef struct Codec_t {
+  std::string name;       /**< Name of the codec used to compress the data. codecName[NDCODEC_NONE] if uncompressed. */
+  int         level;      /**< Compression level. */
+  int         shuffle;    /**< Shuffle type. */
+  int         compressor; /**< Compressor type. For codecs that support more than one compressor. */
+
+  Codec_t() {
+    clear();
+  }
+
+  void clear() {
+    name = codecName[NDCODEC_NONE];
+    level = -1;
+    shuffle = -1;
+    compressor = -1;
+  }
+
+  bool empty() {
+    return this->name == codecName[NDCODEC_NONE];
+  }
+
+  bool operator==(const Codec_t& other) {
+    if (name == other.name &&
+        level == other.level &&
+        shuffle == other.shuffle &&
+        compressor == other.compressor) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+  bool operator!=(const Codec_t& other) {
+    return ! (*this == other);
+  }
+} Codec_t;
+
+#endif //Codec_H

--- a/ADApp/ADSrc/Makefile
+++ b/ADApp/ADSrc/Makefile
@@ -22,6 +22,7 @@ INC += ADCoreVersion.h
 INC += NDAttribute.h
 INC += NDAttributeList.h
 INC += NDArray.h
+INC += Codec.h
 INC += PVAttribute.h
 INC += paramAttribute.h
 INC += functAttribute.h

--- a/ADApp/ADSrc/NDArray.h
+++ b/ADApp/ADSrc/NDArray.h
@@ -19,6 +19,7 @@
 
 #include "NDAttribute.h"
 #include "NDAttributeList.h"
+#include "Codec.h"
 
 /** The maximum number of dimensions in an NDArray */
 #define ND_ARRAY_MAX_DIMS 10
@@ -124,7 +125,7 @@ public:
                                   * The data is assumed to be stored in the order of dims[0] changing fastest, and 
                                   * dims[ndims-1] changing slowest. */
     NDAttributeList *pAttributeList;  /**< Linked list of attributes */
-    std::string codec;          /**< Name of the codec used to compress the data. Empty string if uncompressed. */
+    Codec_t codec;              /**< Definition of codec used to compress the data. */
     size_t compressedSize;      /**< Size of the compressed data. Should be equal to dataSize if pData is uncompressed. */
 };
 

--- a/ADApp/ADSrc/NDArrayPool.cpp
+++ b/ADApp/ADSrc/NDArrayPool.cpp
@@ -157,8 +157,8 @@ NDArray* NDArrayPool::alloc(int ndims, size_t *dims, NDDataType_t dataType, size
   /* Erase the attributes if that global flag is set */
   if (eraseNDAttributes) pArray->pAttributeList->clear();
   
-  /* Set the codec field to "" */
-  pArray->codec = "";
+  /* Clear codec */
+  pArray->codec.clear();
 
   /* At this point pArray exists, but pArray->pData may be NULL */
   /* If the caller passed a valid buffer use that */
@@ -246,7 +246,7 @@ NDArray* NDArrayPool::copy(NDArray *pIn, NDArray *pOut, bool copyData, bool copy
   if (copyDataType) {
     pOut->dataType = pIn->dataType;
   }
-  pOut->codec = pIn->codec;
+  pOut->codec.name = pIn->codec.name;
   pOut->compressedSize = pIn->compressedSize;
   if (copyData) {
     pIn->getInfo(&arrayInfo);
@@ -558,7 +558,7 @@ int NDArrayPool::convert(NDArray *pIn,
   /* Can't convert compressed data */
   if (!pIn->codec.empty()) {
     fprintf(stderr, "%s:%s: can't convert compressed data [%s]\n",
-            driverName, functionName, pIn->codec.c_str());
+            driverName, functionName, pIn->codec.name.c_str());
     return ND_ERROR;
   }
 

--- a/ADApp/ntndArrayConverterSrc/ntndArrayConverter.cpp
+++ b/ADApp/ntndArrayConverterSrc/ntndArrayConverter.cpp
@@ -256,7 +256,7 @@ void NTNDArrayConverter::toValue (NDArray *dest)
     memcpy(dest->pData, srcVec.data(), srcVec.size()*sizeof(arrayValType));
 
     NTNDArrayInfo_t info = getInfo();
-    dest->codec = info.codec;
+    dest->codec.name = info.codec;
     dest->dataType = info.dataType;
 
     if (!info.codec.empty())
@@ -428,7 +428,7 @@ void NTNDArrayConverter::fromValue (NDArray *src)
 
     PVStructurePtr codec(m_array->getCodec());
     codec->getSubField<PVUnion>("parameters")->set(uncompressedType);
-    codec->getSubField<PVString>("name")->put(src->codec);
+    codec->getSubField<PVString>("name")->put(src->codec.name);
 
     size_t count = src->codec.empty() ? arrayInfo.nElements : compressedSize;
 

--- a/ADApp/pluginSrc/NDFileHDF5.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5.cpp
@@ -264,6 +264,9 @@ asynStatus NDFileHDF5::openFile(const char *fileName, NDFileOpenMode_t openMode,
     return asynError;
   }
 
+  // Configure compression if required
+  this->configureDatasetCompression();
+
   if (storeAttributes == 1){
     this->createAttributeDataset(pArray);
     this->writeAttributeDataset(hdf5::OnFileOpen, 0, NULL);
@@ -1999,7 +2002,7 @@ NDFileHDF5::NDFileHDF5(const char *portName, int queueSize, int blockingCallback
   : NDPluginFile(portName, queueSize, blockingCallbacks,
                  NDArrayPort, NDArrayAddr, 1,
                  0, 0, asynGenericPointerMask, asynGenericPointerMask, 
-                 ASYN_CANBLOCK, 1, priority, stackSize, 1)
+                 ASYN_CANBLOCK, 1, priority, stackSize, 1, true)
 {
   //static const char *functionName = "NDFileHDF5";
 
@@ -2999,6 +3002,9 @@ asynStatus NDFileHDF5::configureCompression()
   getIntegerParam(NDFileHDF5_bloscCompressor, &bloscCompressor);
   getIntegerParam(NDFileHDF5_bloscCompressLevel, &bloscLevel);
   this->unlock();
+
+  // Clear the codec to (possibly) configure a new one
+  this->codec.clear();
   switch (compressionScheme)
   {
     case HDF5CompressNone:
@@ -3012,6 +3018,7 @@ asynStatus NDFileHDF5::configureCompression()
       H5Tset_precision (this->datatype, nbitPrecision);
       H5Tset_offset (this->datatype, nbitOffset);
       H5Pset_nbit (this->cparms);
+      this->codec.name = "nbit";
 
       // Finally read back the parameters we've just sent to HDF5
       nbitOffset = H5Tget_offset(this->datatype);
@@ -3026,25 +3033,54 @@ asynStatus NDFileHDF5::configureCompression()
                 "%s::%s Setting szip compression filter # pixels=%d\n",
                 driverName, functionName, szipNumPixels);
       H5Pset_szip (this->cparms, H5_SZIP_NN_OPTION_MASK, szipNumPixels);
+      this->codec.name = "szip";
       break;
     case HDF5CompressZlib:
       asynPrint(this->pasynUserSelf, ASYN_TRACE_FLOW, 
                 "%s::%s Setting zlib compression filter level=%d\n",
                 driverName, functionName, zLevel);
       H5Pset_deflate(this->cparms, zLevel);
+      this->codec.name = "zlib";
       break;
     case HDF5CompressBlosc:
-      {
-           /* 0 to 3 (inclusive) param slots are reserved. */
-          unsigned int cds[7];
-          cds[4] = bloscLevel;
-          cds[5] = bloscShuffle;
-          cds[6] = bloscCompressor;
-          H5Pset_filter(this->cparms, FILTER_BLOSC, H5Z_FLAG_OPTIONAL, 7, cds);
+      asynPrint(this->pasynUserSelf, ASYN_TRACE_FLOW,
+                "%s::%s Setting blosc compression filter level=%d, shuffle=%d, compressor=%d\n",
+                driverName, functionName, bloscLevel, bloscShuffle, bloscCompressor);
+       /* 0 to 3 (inclusive) param slots are reserved. */
+      unsigned int cds[7];
+      cds[4] = bloscLevel;
+      cds[5] = bloscShuffle;
+      cds[6] = bloscCompressor;
+      int h5status = H5Pset_filter(this->cparms, FILTER_BLOSC, H5Z_FLAG_MANDATORY, 7, cds);
+      if (h5status) {
+        asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR, "Failed to set h5 blosc filter\n");
+        break;
       }
+      this->codec.name = codecName[NDCODEC_BLOSC];
+      this->codec.level = bloscLevel;
+      this->codec.shuffle = bloscShuffle;
+      this->codec.compressor = bloscCompressor;
       break;
   }
   return status;
+}
+
+/** Configure the required compression for a dataset.
+ *
+ *  This method will call the configureCompression method for each detector dataset created.
+ *  To enable compression via the HDF5 pipeline, it is sufficient to call this method
+ *  with just a name. This will cause the chunking verification to fail so that direct chunk write
+ *  is not used. To configure the dataset to direct chunk write pre-compressed data, the full codec
+ *  definition must be provided and match the NDArrays passed in.
+ */
+asynStatus NDFileHDF5::configureDatasetCompression()
+{
+  // Iterate over the stored detector data sets and store the compression settings
+  std::map<std::string, NDFileHDF5Dataset*>::iterator it_dset;
+  for (it_dset = this->detDataMap.begin(); it_dset != this->detDataMap.end(); ++it_dset){
+    it_dset->second->configureCompression(this->codec);
+  }
+  return asynSuccess;
 }
 
 /** Translate the NDArray datatype to HDF5 datatypes 

--- a/ADApp/pluginSrc/NDFileHDF5.h
+++ b/ADApp/pluginSrc/NDFileHDF5.h
@@ -17,6 +17,7 @@
 #include "NDFileHDF5LayoutXML.h"
 #include "NDFileHDF5AttributeDataset.h"
 #include "NDFileHDF5VersionCheck.h"
+#include "Codec.h"
 
 #define MAXEXTRADIMS 10
 
@@ -116,6 +117,7 @@ class epicsShareClass NDFileHDF5 : public NDPluginFile
     std::string                                ndDsetName;  // Name of NDAttribute that specifies the destination data set
     std::map<std::string, hdf5::Element *>     onOpenMap;   // Map of handles to elements with onOpen ndattributes, indexed by fullname
     std::map<std::string, hdf5::Element *>     onCloseMap;  // Map of handles to elements with onClose ndattributes, indexed by fullname
+    Codec_t                                    codec;       // Definition of codec used to compress the data.
 
 #ifndef _UNITTEST_HDF5_
   protected:
@@ -181,6 +183,7 @@ class epicsShareClass NDFileHDF5 : public NDPluginFile
     hid_t typeNd2Hdf(NDDataType_t datatype);
     asynStatus configureDatasetDims(NDArray *pArray);
     asynStatus configureDims(NDArray *pArray);
+    asynStatus configureDatasetCompression();
     asynStatus configureCompression();
     char* getDimsReport();
     asynStatus writeStringAttribute(hid_t element, const char* attrName, const char* attrStrValue);

--- a/ADApp/pluginSrc/NDFileHDF5Dataset.h
+++ b/ADApp/pluginSrc/NDFileHDF5Dataset.h
@@ -16,6 +16,7 @@ class NDFileHDF5Dataset
     asynStatus configureDims(NDArray *pArray, bool multiframe, int extradimensions, int *extra_dims, int *user_chunking);
     asynStatus extendDataSet(int extradims);
     asynStatus extendDataSet(int extradims, hsize_t *offsets);
+    asynStatus verifyChunking(NDArray *pArray);
     asynStatus writeFile(NDArray *pArray, hid_t datatype, hid_t dataspace, hsize_t *framesize);
     hid_t getHandle();
     asynStatus flushDataset();
@@ -31,6 +32,7 @@ class NDFileHDF5Dataset
     int         arrayDims[ND_ARRAY_MAX_DIMS];
     int         rank_;         // number of dimensions
     hsize_t     *dims_;        // Array of current dimension sizes. This updates as various dimensions grow.
+    hsize_t     *chunkdims_;   // Array of current configured chunk dimension sizes.
     hsize_t     *maxdims_;     // Array of maximum dimension sizes. The value -1 is HDF5 term for infinite.
     hsize_t     *offset_;      // Array of current offset in each dimension. The frame dimensions always have
                                // 0 offset but additional dimensions may grow as new frames are added.

--- a/ADApp/pluginSrc/NDFileHDF5Dataset.h
+++ b/ADApp/pluginSrc/NDFileHDF5Dataset.h
@@ -17,6 +17,7 @@ class NDFileHDF5Dataset
     asynStatus extendDataSet(int extradims);
     asynStatus extendDataSet(int extradims, hsize_t *offsets);
     asynStatus verifyChunking(NDArray *pArray);
+    void configureCompression(Codec_t codec);
     asynStatus writeFile(NDArray *pArray, hid_t datatype, hid_t dataspace, hsize_t *framesize);
     hid_t getHandle();
     asynStatus flushDataset();
@@ -37,6 +38,7 @@ class NDFileHDF5Dataset
     hsize_t     *offset_;      // Array of current offset in each dimension. The frame dimensions always have
                                // 0 offset but additional dimensions may grow as new frames are added.
     hsize_t     *virtualdims_; // The desired sizes of the extra (virtual) dimensions: {Y, X, n}
+    Codec_t codec;             // Definition of codec used to compress the data.
     char        *ptrDimensionNames[ND_ARRAY_MAX_DIMS]; // Array of strings with human readable names for each dimension
     char        *dimsreport_;  // A string which contain a verbose report of all dimension sizes. The method getDimsReport fill in this
 };

--- a/ADApp/pluginSrc/NDPluginCodec.h
+++ b/ADApp/pluginSrc/NDPluginCodec.h
@@ -33,14 +33,6 @@ typedef enum {
 }NDCodecMode_t;
 
 typedef enum {
-    NDCODEC_NONE,
-    NDCODEC_JPEG,
-    NDCODEC_BLOSC,
-    NDCODEC_LZ4,
-    NDCODEC_BSLZ4
-}NDCodecCompressor_t;
-
-typedef enum {
     NDCODEC_BLOSC_BLOSCLZ,
     NDCODEC_BLOSC_LZ4,
     NDCODEC_BLOSC_LZ4HC,

--- a/ADApp/pluginSrc/NDPluginDriver.cpp
+++ b/ADApp/pluginSrc/NDPluginDriver.cpp
@@ -216,7 +216,7 @@ NDPluginDriver::~NDPluginDriver()
     setIntegerParam(NDDataType, pArray->dataType);
     setIntegerParam(NDColorMode, colorMode);
     setIntegerParam(NDBayerPattern, bayerPattern);
-    setStringParam(NDCodec, pArray->codec);
+    setStringParam(NDCodec, pArray->codec.name);
     setIntegerParam(NDCompressedSize, pArray->compressedSize);
     setIntegerParam(NDUniqueId, pArray->uniqueId);
     setTimeStamp(&pArray->epicsTS);
@@ -389,8 +389,8 @@ void NDPluginDriver::driverCallback(asynUser *pasynUser, void *genericPointer)
     if (!compressionAware_ && !pArray->codec.empty()) {
         getIntegerParam(NDPluginDriverDroppedArrays, &droppedArrays);
         asynPrint(pasynUser, ASYN_TRACE_ERROR,
-                    "%s::%s got compressed array, dropped array uniqueId=%d\n",
-                    driverName, functionName, pArray->uniqueId);
+                  "%s::%s got compressed array and plugin is not compression aware, dropped array uniqueId=%d\n",
+                  driverName, functionName, pArray->uniqueId);
         droppedArrays++;
         setIntegerParam(NDPluginDriverDroppedArrays, droppedArrays);
 

--- a/ADApp/pluginSrc/NDPluginFile.cpp
+++ b/ADApp/pluginSrc/NDPluginFile.cpp
@@ -922,7 +922,8 @@ asynStatus NDPluginFile::writeNDArray(asynUser *pasynUser, void *genericPointer)
 NDPluginFile::NDPluginFile(const char *portName, int queueSize, int blockingCallbacks, 
                            const char *NDArrayPort, int NDArrayAddr, int maxAddr,
                            int maxBuffers, size_t maxMemory, int interfaceMask, int interruptMask,
-                           int asynFlags, int autoConnect, int priority, int stackSize, int maxThreads)
+                           int asynFlags, int autoConnect, int priority, int stackSize, int maxThreads,
+                           bool compressionAware)
 
     /* Invoke the base class constructor.
      * We allocate 1 NDArray of unlimited size in the NDArray pool.
@@ -931,7 +932,7 @@ NDPluginFile::NDPluginFile(const char *portName, int queueSize, int blockingCall
     : NDPluginDriver(portName, queueSize, blockingCallbacks, 
                      NDArrayPort, NDArrayAddr, maxAddr, maxBuffers, maxMemory, 
                      asynGenericPointerMask, asynGenericPointerMask,
-                     asynFlags, autoConnect, priority, stackSize, maxThreads),
+                     asynFlags, autoConnect, priority, stackSize, maxThreads, compressionAware),
     pCapture(NULL), captureBufferSize(0)
 {
     //static const char *functionName = "NDPluginFile";

--- a/ADApp/pluginSrc/NDPluginFile.h
+++ b/ADApp/pluginSrc/NDPluginFile.h
@@ -30,7 +30,8 @@ public:
     NDPluginFile(const char *portName, int queueSize, int blockingCallbacks, 
                  const char *NDArrayPort, int NDArrayAddr, int maxAddr,
                  int maxBuffers, size_t maxMemory, int interfaceMask, int interruptMask,
-                 int asynFlags, int autoConnect, int priority, int stackSize, int maxThreads);
+                 int asynFlags, int autoConnect, int priority, int stackSize, int maxThreads,
+                 bool compressionAware = false);
                  
     /* These methods override those in the base class */
     virtual void processCallbacks(NDArray *pArray);


### PR DESCRIPTION
This is an initial working version of direct chunk write support. I have tested with data direct from ADSimDetector and from NDPlugin Codec. 

The logic is as follows:
- HDF5 plugin settings match the incoming NDArrays (compressed or otherwise) - Use direct chunk write
- HDF5 chunking does not match, or compression configured and array not already compressed - Use standard write
- Data is compressed but does not match the HDF5 plugin (compression settings or chunking) - Error

Outstanding Points:
- I have tested the blosc compressors, but I haven't played with the level or shuffle yet
- I think the shuffle mode enums on HDF5 and NDPluginCodec are not in the same order, so that might need changing to allow validation of the NDArrays.
- I have not done any performance testing as I don't currently have an appropriate test server with a GPFS mount.