### PR TITLE
support bitshuffle filter for hdf5 writer

### DIFF
--- a/ADApp/Db/NDFileHDF5.template
+++ b/ADApp/Db/NDFileHDF5.template
@@ -448,6 +448,8 @@ record(mbbo, "$(P)$(R)Compression")
     field(THVL, "3")
     field(FRST, "blosc")
     field(FRVL, "4")
+    field(FVST, "bitshuffle")
+    field(FVVL, "5")
     info(autosaveFields, "VAL")
 }
 
@@ -466,6 +468,8 @@ record(mbbi, "$(P)$(R)Compression_RBV")
     field(THVL, "3")
     field(FRST, "blosc")
     field(FRVL, "4")
+    field(FVST, "bitshuffle")
+    field(FVVL, "5")
 }
 
 record(longout, "$(P)$(R)NumDataBits")

--- a/ADApp/pluginSrc/NDFileHDF5.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5.cpp
@@ -41,9 +41,11 @@
 #define METADATA_NDIMS 1
 #define MAX_LAYOUT_LEN 1048576
 
-enum HDF5Compression_t {HDF5CompressNone=0, HDF5CompressNumBits, HDF5CompressSZip, HDF5CompressZlib, HDF5CompressBlosc};
+enum HDF5Compression_t {HDF5CompressNone=0, HDF5CompressNumBits, HDF5CompressSZip, HDF5CompressZlib, HDF5CompressBlosc, HDF5CompressBshuf};
 /* Filter ID officially assigned to blosc */
 #define FILTER_BLOSC 32001
+/* Filter ID officially assigned to bitshuffle */
+#define FILTER_BSHUF 32008
 
 #define DIMSREPORTSIZE 512
 #define DIMNAMESIZE 40
@@ -1764,6 +1766,9 @@ asynStatus NDFileHDF5::writeInt32(asynUser *pasynUser, epicsInt32 value)
       case HDF5CompressBlosc:
         filterId = FILTER_BLOSC;
         break;
+      case HDF5CompressBshuf:
+        filterId = FILTER_BSHUF;
+        break;
       default:
         filterId = H5Z_FILTER_NONE;
         status = asynError;
@@ -3041,6 +3046,14 @@ asynStatus NDFileHDF5::configureCompression()
           cds[5] = bloscShuffle;
           cds[6] = bloscCompressor;
           H5Pset_filter(this->cparms, FILTER_BLOSC, H5Z_FLAG_OPTIONAL, 7, cds);
+      }
+      break;
+    case HDF5CompressBshuf:
+      {
+           /* 0 to 3 (inclusive) param slots are reserved. */
+          unsigned int cds[2];
+          cds[1] = 2; /* lz4 compression */
+          H5Pset_filter(this->cparms, FILTER_BSHUF, H5Z_FLAG_OPTIONAL, 2, cds);
       }
       break;
   }


### PR DESCRIPTION
This PR, when combined with https://github.com/areaDetector/ADSupport/pull/23, adds bitshuffle+lz4 compression filter into hdf5 writer. 