### PR TITLE
Fix acquire busy2

### DIFF
--- a/ADApp/ADSrc/ADDriver.cpp
+++ b/ADApp/ADSrc/ADDriver.cpp
@@ -55,6 +55,16 @@ void ADDriver::setShutter(int open)
 }
 
 /** Sets the value for an integer in the parameter library.
+  * Calls setIntegerParam(0, index, value) i.e. for parameter list 0.
+  * \param[in] index The parameter number
+  * \param[in] value Value to set. */
+asynStatus ADDriver::setIntegerParam(int index, int value)
+{
+    return this->setIntegerParam(0, index, value);
+}
+
+/** Sets the value for an integer in the parameter library.
+  * \param[in] list The parameter list number.  Must be < maxAddr passed to asynPortDriver::asynPortDriver.
   * \param[in] index The parameter number
   * \param[in] value Value to set. 
   * This function was added to trap the driver setting ADAcquire to 0 and
@@ -64,30 +74,30 @@ void ADDriver::setShutter(int open)
   * When ADAcquire goes to 0 it must use getQueuedArrayCount rather then NumQueuedArrays
   * from the parameter library, because NumQueuedArrays is updated in a separate thread
   * and might not have been set yet.  getQueuedArrayCount updates immediately. */
-asynStatus ADDriver::setIntegerParam(int index, int value)
+asynStatus ADDriver::setIntegerParam(int list, int index, int value)
 {
     int waitForPlugins;
 
-    getIntegerParam(ADWaitForPlugins, &waitForPlugins);
+    getIntegerParam(list, ADWaitForPlugins, &waitForPlugins);
 
     if (index == ADAcquire) {
         if (value == 0) {
             if (waitForPlugins) {
                 int count = getQueuedArrayCount();
                 if (count == 0) {
-                    asynNDArrayDriver::setIntegerParam(ADAcquireBusy, 0);
+                    asynNDArrayDriver::setIntegerParam(list, ADAcquireBusy, 0);
                 }
             } else {
-                asynNDArrayDriver::setIntegerParam(ADAcquireBusy, 0);
+                asynNDArrayDriver::setIntegerParam(list, ADAcquireBusy, 0);
             }
         } else {
-            asynNDArrayDriver::setIntegerParam(ADAcquireBusy, 1);
+            asynNDArrayDriver::setIntegerParam(list, ADAcquireBusy, 1);
         }
     }
     else if ((index == NDNumQueuedArrays) && (value == 0)) {
-        asynNDArrayDriver::setIntegerParam(ADAcquireBusy, 0);
+        asynNDArrayDriver::setIntegerParam(list, ADAcquireBusy, 0);
     }
-    return asynNDArrayDriver::setIntegerParam(index, value);
+    return asynNDArrayDriver::setIntegerParam(list, index, value);
 }
 
 

--- a/ADApp/ADSrc/ADDriver.h
+++ b/ADApp/ADSrc/ADDriver.h
@@ -148,6 +148,7 @@ public:
     /* These are the methods that we override from asynPortDriver */
     virtual asynStatus writeInt32(asynUser *pasynUser, epicsInt32 value);
     virtual asynStatus setIntegerParam(int index, int value);
+    virtual asynStatus setIntegerParam(int list, int index, int value);
 
     /* These are the methods that are new to this class */
     virtual void setShutter(int open);

--- a/ADApp/ADSrc/ADDriver.h
+++ b/ADApp/ADSrc/ADDriver.h
@@ -109,6 +109,8 @@ typedef enum
 #define ADAcquirePeriodString       "ACQ_PERIOD"            /**< (asynFloat64,  r/w) Acquisition period between images */
 #define ADStatusString              "STATUS"                /**< (asynInt32,    r/o) Acquisition status (ADStatus_t) */
 #define ADAcquireString             "ACQUIRE"               /**< (asynInt32,    r/w) Start(1) or Stop(0) acquisition */
+#define ADAcquireBusyString         "ACQUIRE_BUSY"          /**< (asynInt32,    r/w) 0 when acquire done including plugins */
+#define ADWaitForPluginsString      "WAIT_FOR_PLUGINS"      /**< (asynInt32,    r/w) Wait for plugins before AcquireBusy goes to 0 */
 
     /* Shutter parameters */
 #define ADShutterControlString      "SHUTTER_CONTROL"       /**< (asynInt32,    r/w) (ADShutterStatus_t) Open (1) or Close(0) shutter */
@@ -145,6 +147,7 @@ public:
 
     /* These are the methods that we override from asynPortDriver */
     virtual asynStatus writeInt32(asynUser *pasynUser, epicsInt32 value);
+    virtual asynStatus setIntegerParam(int index, int value);
 
     /* These are the methods that are new to this class */
     virtual void setShutter(int open);
@@ -179,6 +182,8 @@ protected:
     int ADStatus;
     int ADTriggerMode;
     int ADAcquire;
+    int ADAcquireBusy;
+    int ADWaitForPlugins;
     int ADShutterControl;
     int ADShutterControlEPICS;
     int ADShutterStatus;

--- a/ADApp/ADSrc/asynNDArrayDriver.cpp
+++ b/ADApp/ADSrc/asynNDArrayDriver.cpp
@@ -708,7 +708,6 @@ static void updateQueuedArrayCountC(void *drvPvt)
 
 void asynNDArrayDriver::updateQueuedArrayCount()
 {
-    int arrayCount;
     while (queuedArrayUpdateRun_) {
         epicsEventWait(queuedArrayEvent_);
         // Exit early
@@ -716,14 +715,19 @@ void asynNDArrayDriver::updateQueuedArrayCount()
             break;
 
         lock();
-        queuedArrayCountMutex_->lock();
-        arrayCount = queuedArrayCount_;
-        queuedArrayCountMutex_->unlock();
-        setIntegerParam(NDNumQueuedArrays, arrayCount);
+        setIntegerParam(NDNumQueuedArrays, getQueuedArrayCount());
         callParamCallbacks();
         unlock();
     }
     epicsEventSignal(queuedArrayUpdateDone_);
+}
+
+int asynNDArrayDriver::getQueuedArrayCount()
+{
+    queuedArrayCountMutex_->lock();
+    int count = queuedArrayCount_;
+    queuedArrayCountMutex_->unlock();
+    return count;
 }
 
 asynStatus asynNDArrayDriver::incrementQueuedArrayCount() 

--- a/ADApp/ADSrc/asynNDArrayDriver.h
+++ b/ADApp/ADSrc/asynNDArrayDriver.h
@@ -143,6 +143,7 @@ public:
 
     asynStatus incrementQueuedArrayCount();
     asynStatus decrementQueuedArrayCount();
+    int getQueuedArrayCount();
     void updateQueuedArrayCount();
     
     class NDArrayPool *pNDArrayPool;     /**< An NDArrayPool pointer that is initialized to pNDArrayPoolPvt_ in the constructor.

--- a/ADApp/Db/ADBase.template
+++ b/ADApp/Db/ADBase.template
@@ -459,17 +459,27 @@ record(busy, "$(P)$(R)AcquireBusy") {
    field(VAL,  "0")
 }
 
-record(calcout, "$(P)$(R)ClearAcquireBusy")
-{
-    field(INPA, "$(P)$(R)WaitForPlugins CP")
-    field(INPB, "$(P)$(R)Acquire_RBV CP")
-    field(INPC, "$(P)$(R)NumQueuedArrays CP")
-    field(CALC, "A ? B || (C > 0) : B")
+record(bi, "$(P)$(R)AcquireBusyCB") {
+   field(DTYP, "asynInt32")
+   field(INP, "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))ACQUIRE_BUSY")
+   field(ZNAM, "Done")
+   field(ZSV,  "NO_ALARM")
+   field(ONAM, "Acquiring")
+   field(OSV,  "MINOR")
+   field(SCAN, "I/O Intr")
+}
+
+record(calcout, "$(P)$(R)ClearAcquireBusy") {
+    field(INPA, "$(P)$(R)AcquireBusyCB CP")
+    field(CALC, "A")
     field(OOPT, "Transition To Zero")
     field(OUT,  "$(P)$(R)AcquireBusy PP")
 }
 
 record(bo, "$(P)$(R)WaitForPlugins") {
+   field(PINI, "YES")
+   field(DTYP, "asynInt32")
+   field(OUT, "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))WAIT_FOR_PLUGINS")
    field(ZNAM, "No")
    field(ONAM, "Yes")
    field(VAL,  "0")

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -31,6 +31,11 @@ R3-5 (February XXX, 2018)
     html in the files.
   * The new documentation is hosted at [areaDetector.github.io](https://areaDetector.github.io).
   * Many thanks to Stuart Wilkins for this major effort.
+### ADDriver, asynNDArrayDriver
+* Fixed a race condition in R3-4 with NumQueuedArrays and AcquireBusy.
+  This caused AcquireBusy to sometimes go to Done before the plugins were done processing.
+  A typical symptom was for successive points in a scan to have the same values from the statistics plugin,
+  because the detector did not wait for the plugin to post a new value before it said it was done. 
 ### NDPluginCodec
 * Added support for the lz4 and bitshuffle/lz4 codecs.  
   These are the compressors that the Eiger uses, so compressed NDArrays from ADEiger can
@@ -48,7 +53,7 @@ R3-5 (February XXX, 2018)
 * Added support for new parameters NDCodec and NDCompressedSize and new records Codec_RBV and CompressedSize_RBV.
   These contain the values of NDArray.codec and NDArray.compressedSize.
 ### NDPluginBase.template
-* Removed DTYP from )MaxArrayRate_RBV calc record which does not support DTYP.
+* Removed DTYP from the MaxArrayRate_RBV calc record which does not support DTYP.
 
 R3-4 (December 3, 2018)
 ======================


### PR DESCRIPTION
This is intended to fix #375.

Moved the logic for determining when acquisition is complete, (including plugins if WaitForPlugins is true), from the database into ADDriver.

- This is simpler to understand, and more robust.
- Added 2 new parameters, ADWaitForPlugins and ADAcquireBusy.
- Overloaded asynPortDriver::setIntegerParam() method to trap changes to ADAcquire and NumQueuedArrays.  This function detects when acquisition is "really done" and sets ADAcquireBusy=0 when it is.
- Added new asynNDArrayDriver::getQueuedArrayCount() method that returns asynNDArrayDriver::queuedArrayCount_.  This is updated immediately on plugin callbacks, unlike NumQueuedArrays in the parameter library which has a slight delay.
- When ADAcquire goes to 0 asynPortDriver::setIntegerParam() must use getQueuedArrayCount() rather then NumQueuedArrays from the parameter library, because NumQueuedArrays is updated in a separate thread and might not have been set yet.  getQueuedArrayCount updates immediately.

I have tested the following with simDetector:
  - Very fast acquisition (1000 frames/s) in Continuous and Multiple mode. I can turn it off and back on without waiting for NumQueuedArrays to go to 0 first.  This was an issue with one of my test fixes.
  - Using Single mode with the sscan record and a statistics plugin as a counter.  The plugin has BlockingCallbacks=No, and the driver has WaitForPlugins=Yes.  The simDetector ADAcquireTime is 0.0001 seconds.
  - I did 1000 point scans many times and there are no duplicate values.  I also used the time series plugin in the stats plugin to collect the same array information, and compared to the array in the sscan record.  They were always identical.


