### PR TITLE
Compile tests for WIN32

### DIFF
--- a/ADApp/pluginTests/HDF5FileReader.cpp
+++ b/ADApp/pluginTests/HDF5FileReader.cpp
@@ -95,9 +95,11 @@ std::vector<hsize_t> HDF5FileReader::getDatasetDimensions(const std::string& nam
 
       ndims = H5Sget_simple_extent_ndims(dspace_id);
 
-      hsize_t dims[ndims];
-      hsize_t maxdims[ndims];
+      hsize_t *dims = new hsize_t[ndims];
+      hsize_t *maxdims = new hsize_t[ndims];
       H5Sget_simple_extent_dims(dspace_id, dims, maxdims);
+      delete dims;
+      delete maxdims;
 
       for (int index = 0; index < ndims; index++){
         vdims.push_back(dims[index]);

--- a/ADApp/pluginTests/Makefile
+++ b/ADApp/pluginTests/Makefile
@@ -19,6 +19,7 @@ ifeq ($(WITH_BOOST),YES)
   # The ADTestUtility library contain a number of helper functions to generate test
   # data, asyn port names, record output NDArrays etc etc.
   # This utility library can be used by external modules that provides unittests.
+  USR_CXXFLAGS_Linux += -std=c++11
   LIBRARY_IOC_Linux += ADTestUtility
   LIBRARY_IOC_Darwin += ADTestUtility
   LIBRARY_IOC_WIN32 += ADTestUtility

--- a/ADApp/pluginTests/Makefile
+++ b/ADApp/pluginTests/Makefile
@@ -57,10 +57,16 @@ ifeq ($(WITH_BOOST),YES)
 
   # Add tests for new plugins like this:
   #plugin-test_SRCS += test_<plugin name>.cpp
+
+  USR_LDFLAGS_WIN32 += /SUBSYSTEM:CONSOLE
+  #USR_LDFLAGS_WIN32 += /VERBOSE
   
   ifdef BOOST_LIB
     boost_unit_test_framework_DIR=$(BOOST_LIB)
-    plugin-test_LIBS += boost_unit_test_framework
+    plugin-test_LIBS_Linux += boost_unit_test_framework
+    plugin-test_LIBS_Darwin += boost_unit_test_framework
+	USR_LDFLAGS_WIN32 += /LIBPATH:$(BOOST_LIB)
+    LIB_LIBS_WIN32 += libboost_unit_test_framework-vc141-mt-s-x64-1_69
   else
     plugin-test_SYS_LIBS += boost_unit_test_framework
   endif
@@ -83,9 +89,9 @@ ifeq ($(WITH_BOOST),YES)
   ifeq ($(BOOST_USE_STATIC_LINK),YES)
 	USR_CXXFLAGS_Linux += -DBOOST_USE_STATIC_LINK
 	USR_CFLAGS_Linux += -DBOOST_USE_STATIC_LINK
+	USR_CXXFLAGS_WIN32 += -DBOOST_USE_STATIC_LINK
+	USR_CFLAGS_WIN32 += -DBOOST_USE_STATIC_LINK
   endif
-  USR_CXXFLAGS_WIN32 += -DBOOST_USE_STATIC_LINK
-  USR_CFLAGS_WIN32 += -DBOOST_USE_STATIC_LINK
 endif
 
 ## hdf5-1.10.1 seems to have fixed these SWMR problems

--- a/ADApp/pluginTests/Makefile
+++ b/ADApp/pluginTests/Makefile
@@ -21,6 +21,7 @@ ifeq ($(WITH_BOOST),YES)
   # This utility library can be used by external modules that provides unittests.
   LIBRARY_IOC_Linux += ADTestUtility
   LIBRARY_IOC_Darwin += ADTestUtility
+  LIBRARY_IOC_WIN32 += ADTestUtility
   ADTestUtility_SRCS += testingutilities.cpp
   ADTestUtility_SRCS += AsynPortClientContainer.cpp
   ADTestUtility_SRCS += AsynException.cpp
@@ -38,6 +39,7 @@ ifeq ($(WITH_BOOST),YES)
 
   PROD_IOC_Linux += plugin-test
   PROD_IOC_Darwin += plugin-test
+  PROD_IOC_WIN32 += plugin-test
   plugin-test_SRCS += plugin-test.cpp
   plugin-test_SRCS += test_NDPluginCircularBuff.cpp
   ifeq ($(WITH_HDF5),YES)
@@ -82,6 +84,8 @@ ifeq ($(WITH_BOOST),YES)
 	USR_CXXFLAGS_Linux += -DBOOST_USE_STATIC_LINK
 	USR_CFLAGS_Linux += -DBOOST_USE_STATIC_LINK
   endif
+  USR_CXXFLAGS_WIN32 += -DBOOST_USE_STATIC_LINK
+  USR_CFLAGS_WIN32 += -DBOOST_USE_STATIC_LINK
 endif
 
 ## hdf5-1.10.1 seems to have fixed these SWMR problems

--- a/ADApp/pluginTests/test_NDFileHDF5.cpp
+++ b/ADApp/pluginTests/test_NDFileHDF5.cpp
@@ -76,7 +76,7 @@ struct NDFileHDF5TestFixture
   void setup_hdf_stream()
   {
     hdf5->write(NDFileWriteModeString, NDFileModeStream);
-    hdf5->write(NDFilePathString, "/tmp");
+    hdf5->write(NDFilePathString, "");
     hdf5->write(NDFileNameString, "testing");
     hdf5->write(NDFileTemplateString, "%s%s_%d.5");
   }
@@ -91,7 +91,7 @@ struct NDFileHDF5TestFixture
     NDAttribute *pA2 = new NDAttribute("temperature_EGU", "detector temperature units", NDAttrSourceEPICSPV, "13SIM1:cam1:Temperature.EGU", NDAttrString, val2);
     pAttributeList->add(pA2);
     char val3[MAX_STRING_SIZE];
-    strcpy(val3, "/tmp/test1_001.h5");
+    strcpy(val3, "test1_001.h5");
     NDAttribute *pA3 = new NDAttribute("HDF5_filename", "name of this file as written", NDAttrSourceEPICSPV, "13SIM1:HDF1:FullFileName_RBV", NDAttrString, val3);
     pAttributeList->add(pA3);
     epicsInt32 val4 = 0;
@@ -145,7 +145,7 @@ BOOST_AUTO_TEST_CASE(test_createDatasetType)
   hdf5->unlock();
 
   // File has been written, open for reading
-  HDF5FileReader fr("/tmp/testing_0.5");
+  HDF5FileReader fr("testing_0.5");
   // Verify there are attributes attached to the dataset
   BOOST_CHECK_GT(fr.getDatasetAttributeCount("/entry/data/data"), 0);
 }
@@ -243,7 +243,7 @@ BOOST_AUTO_TEST_CASE(test_DatasetLayout1)
   </group>\
 </hdf5_layout>");
 
-  hdf5->write(NDFilePathString, "/tmp");
+  hdf5->write(NDFilePathString, "");
   hdf5->write(NDFileNameString, "test1");
   hdf5->write(NDFileTemplateString, "%s%s_%3.3d.h5");
   // Initialise the HDF5 plugin with a dummy frame
@@ -270,7 +270,7 @@ BOOST_AUTO_TEST_CASE(test_DatasetLayout1)
   // Once the frames have been captured check the output file to verify it is as expected
   std::vector<hsize_t> odims;
   // Use the file reader utility to open the file
-  HDF5FileReader fr("/tmp/test1_001.h5");
+  HDF5FileReader fr("test1_001.h5");
   // Verify the main dataset exists
   BOOST_CHECK_EQUAL(fr.checkDatasetExists("/example/detector/data"), true);
   // Verify the main dataset has the dimensions of 10x10x10

--- a/ADApp/pluginTests/test_NDFileHDF5AttributeDataset.cpp
+++ b/ADApp/pluginTests/test_NDFileHDF5AttributeDataset.cpp
@@ -19,7 +19,7 @@
 #include <stdint.h>
 
 #include <deque>
-#include <tr1/memory>
+#include <memory>
 
 #include "hdf5.h"
 #include "testingutilities.h"
@@ -29,7 +29,7 @@
 BOOST_AUTO_TEST_CASE(test_AttributeOriginalDataset)
 {
   // Open an HDF5 file for testing
-  std::string filename = "/tmp/test_att.h5";
+  std::string filename = "test_att.h5";
   hid_t file = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, 0, 0);
   BOOST_REQUIRE_GT(file, -1);
 
@@ -38,10 +38,10 @@ BOOST_AUTO_TEST_CASE(test_AttributeOriginalDataset)
   hid_t group = H5Gcreate(file, gname.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
   BOOST_REQUIRE_GT(group, -1);
 
-  std::tr1::shared_ptr<NDFileHDF5AttributeDataset> adPtr;
+  std::shared_ptr<NDFileHDF5AttributeDataset> adPtr;
 
   // Create an attribute dataset of type NDAttrInt8
-  adPtr = std::tr1::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att1", NDAttrInt8));
+  adPtr = std::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att1", NDAttrInt8));
   BOOST_CHECK_EQUAL(adPtr->getName(), "att1");
   // Set up the parent group name and the dataset name
   adPtr->setDsetName("dset1");
@@ -59,7 +59,7 @@ BOOST_AUTO_TEST_CASE(test_AttributeOriginalDataset)
   adPtr->closeAttributeDataset();
 
   // Create an attribute dataset of type NDAttrUInt8
-  adPtr = std::tr1::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att2", NDAttrUInt8));
+  adPtr = std::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att2", NDAttrUInt8));
   BOOST_CHECK_EQUAL(adPtr->getName(), "att2");
   // Set up the parent group name and the dataset name
   adPtr->setDsetName("dset2");
@@ -77,7 +77,7 @@ BOOST_AUTO_TEST_CASE(test_AttributeOriginalDataset)
   adPtr->closeAttributeDataset();
 
   // Create an attribute dataset of type NDAttrInt16
-  adPtr = std::tr1::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att3", NDAttrInt16));
+  adPtr = std::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att3", NDAttrInt16));
   BOOST_CHECK_EQUAL(adPtr->getName(), "att3");
   // Set up the parent group name and the dataset name
   adPtr->setDsetName("dset3");
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE(test_AttributeOriginalDataset)
   adPtr->closeAttributeDataset();
 
   // Create an attribute dataset of type NDAttrUInt16
-  adPtr = std::tr1::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att4", NDAttrUInt16));
+  adPtr = std::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att4", NDAttrUInt16));
   BOOST_CHECK_EQUAL(adPtr->getName(), "att4");
   // Set up the parent group name and the dataset name
   adPtr->setDsetName("dset4");
@@ -113,7 +113,7 @@ BOOST_AUTO_TEST_CASE(test_AttributeOriginalDataset)
   adPtr->closeAttributeDataset();
 
   // Create an attribute dataset of type NDAttrInt32
-  adPtr = std::tr1::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att5", NDAttrInt32));
+  adPtr = std::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att5", NDAttrInt32));
   BOOST_CHECK_EQUAL(adPtr->getName(), "att5");
   // Set up the parent group name and the dataset name
   adPtr->setDsetName("dset5");
@@ -131,7 +131,7 @@ BOOST_AUTO_TEST_CASE(test_AttributeOriginalDataset)
   adPtr->closeAttributeDataset();
 
   // Create an attribute dataset of type NDAttrUInt32
-  adPtr = std::tr1::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att6", NDAttrUInt32));
+  adPtr = std::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att6", NDAttrUInt32));
   BOOST_CHECK_EQUAL(adPtr->getName(), "att6");
   // Set up the parent group name and the dataset name
   adPtr->setDsetName("dset6");
@@ -149,7 +149,7 @@ BOOST_AUTO_TEST_CASE(test_AttributeOriginalDataset)
   adPtr->closeAttributeDataset();
 
   // Create an attribute dataset of type NDAttrFloat32
-  adPtr = std::tr1::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att7", NDAttrFloat32));
+  adPtr = std::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att7", NDAttrFloat32));
   BOOST_CHECK_EQUAL(adPtr->getName(), "att7");
   // Set up the parent group name and the dataset name
   adPtr->setDsetName("dset7");
@@ -167,7 +167,7 @@ BOOST_AUTO_TEST_CASE(test_AttributeOriginalDataset)
   adPtr->closeAttributeDataset();
 
   // Create an attribute dataset of type NDAttrFloat64
-  adPtr = std::tr1::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att8", NDAttrFloat64));
+  adPtr = std::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att8", NDAttrFloat64));
   BOOST_CHECK_EQUAL(adPtr->getName(), "att8");
   // Set up the parent group name and the dataset name
   adPtr->setDsetName("dset8");
@@ -185,7 +185,7 @@ BOOST_AUTO_TEST_CASE(test_AttributeOriginalDataset)
   adPtr->closeAttributeDataset();
 
   // Create an attribute dataset of type NDAttrString
-  adPtr = std::tr1::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att9", NDAttrString));
+  adPtr = std::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att9", NDAttrString));
   BOOST_CHECK_EQUAL(adPtr->getName(), "att9");
   // Set up the parent group name and the dataset name
   adPtr->setDsetName("dset9");
@@ -205,7 +205,7 @@ BOOST_AUTO_TEST_CASE(test_AttributeOriginalDataset)
   adPtr->closeAttributeDataset();
 
   // Create an attribute, set it for only writing OnOpen, then send it multiple OnFrame values
-  adPtr = std::tr1::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att10", NDAttrInt8));
+  adPtr = std::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att10", NDAttrInt8));
   BOOST_CHECK_EQUAL(adPtr->getName(), "att10");
   // Set up the parent group name and the dataset name
   adPtr->setDsetName("dset10");
@@ -234,7 +234,7 @@ BOOST_AUTO_TEST_CASE(test_AttributeOriginalDataset)
   adPtr->closeAttributeDataset();
 
   // Create an attribute, set it for only writing OnClose, then send it multiple OnFrame values
-  adPtr = std::tr1::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att11", NDAttrInt8));
+  adPtr = std::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att11", NDAttrInt8));
   BOOST_CHECK_EQUAL(adPtr->getName(), "att11");
   // Set up the parent group name and the dataset name
   adPtr->setDsetName("dset11");
@@ -362,7 +362,7 @@ BOOST_AUTO_TEST_CASE(test_AttributeOriginalDataset)
 BOOST_AUTO_TEST_CASE(test_AttributeDimensionalDataset)
 {
   // Open an HDF5 file for testing
-  std::string filename = "/tmp/test_att.h5";
+  std::string filename = "test_att.h5";
   hid_t file = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, 0, 0);
   BOOST_REQUIRE_GT(file, -1);
 
@@ -371,13 +371,13 @@ BOOST_AUTO_TEST_CASE(test_AttributeDimensionalDataset)
   hid_t group = H5Gcreate(file, gname.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
   BOOST_REQUIRE_GT(group, -1);
 
-  std::tr1::shared_ptr<NDFileHDF5AttributeDataset> adPtr;
+  std::shared_ptr<NDFileHDF5AttributeDataset> adPtr;
   // Create a 3 dimensional description of a dataset (3x4x5)
   int dimsize[3] = {3, 4, 5};
   int chunking[3] = {1, 1, 1};
 
   // Create an attribute dataset of type NDAttrInt8
-  adPtr = std::tr1::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att1", NDAttrInt8));
+  adPtr = std::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att1", NDAttrInt8));
   BOOST_CHECK_EQUAL(adPtr->getName(), "att1");
   // Set up the parent group name and the dataset name
   adPtr->setDsetName("dset1");
@@ -395,7 +395,7 @@ BOOST_AUTO_TEST_CASE(test_AttributeDimensionalDataset)
   adPtr->closeAttributeDataset();
 
   // Create an attribute dataset of type NDAttrUInt8
-  adPtr = std::tr1::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att2", NDAttrUInt8));
+  adPtr = std::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att2", NDAttrUInt8));
   BOOST_CHECK_EQUAL(adPtr->getName(), "att2");
   // Set up the parent group name and the dataset name
   adPtr->setDsetName("dset2");
@@ -413,7 +413,7 @@ BOOST_AUTO_TEST_CASE(test_AttributeDimensionalDataset)
   adPtr->closeAttributeDataset();
 
   // Create an attribute dataset of type NDAttrInt16
-  adPtr = std::tr1::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att3", NDAttrInt16));
+  adPtr = std::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att3", NDAttrInt16));
   BOOST_CHECK_EQUAL(adPtr->getName(), "att3");
   // Set up the parent group name and the dataset name
   adPtr->setDsetName("dset3");
@@ -431,7 +431,7 @@ BOOST_AUTO_TEST_CASE(test_AttributeDimensionalDataset)
   adPtr->closeAttributeDataset();
 
   // Create an attribute dataset of type NDAttrUInt16
-  adPtr = std::tr1::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att4", NDAttrUInt16));
+  adPtr = std::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att4", NDAttrUInt16));
   BOOST_CHECK_EQUAL(adPtr->getName(), "att4");
   // Set up the parent group name and the dataset name
   adPtr->setDsetName("dset4");
@@ -449,7 +449,7 @@ BOOST_AUTO_TEST_CASE(test_AttributeDimensionalDataset)
   adPtr->closeAttributeDataset();
 
   // Create an attribute dataset of type NDAttrInt32
-  adPtr = std::tr1::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att5", NDAttrInt32));
+  adPtr = std::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att5", NDAttrInt32));
   BOOST_CHECK_EQUAL(adPtr->getName(), "att5");
   // Set up the parent group name and the dataset name
   adPtr->setDsetName("dset5");
@@ -467,7 +467,7 @@ BOOST_AUTO_TEST_CASE(test_AttributeDimensionalDataset)
   adPtr->closeAttributeDataset();
 
   // Create an attribute dataset of type NDAttrUInt32
-  adPtr = std::tr1::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att6", NDAttrUInt32));
+  adPtr = std::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att6", NDAttrUInt32));
   BOOST_CHECK_EQUAL(adPtr->getName(), "att6");
   // Set up the parent group name and the dataset name
   adPtr->setDsetName("dset6");
@@ -485,7 +485,7 @@ BOOST_AUTO_TEST_CASE(test_AttributeDimensionalDataset)
   adPtr->closeAttributeDataset();
 
   // Create an attribute dataset of type NDAttrFloat32
-  adPtr = std::tr1::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att7", NDAttrFloat32));
+  adPtr = std::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att7", NDAttrFloat32));
   BOOST_CHECK_EQUAL(adPtr->getName(), "att7");
   // Set up the parent group name and the dataset name
   adPtr->setDsetName("dset7");
@@ -503,7 +503,7 @@ BOOST_AUTO_TEST_CASE(test_AttributeDimensionalDataset)
   adPtr->closeAttributeDataset();
 
   // Create an attribute dataset of type NDAttrFloat64
-  adPtr = std::tr1::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att8", NDAttrFloat64));
+  adPtr = std::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att8", NDAttrFloat64));
   BOOST_CHECK_EQUAL(adPtr->getName(), "att8");
   // Set up the parent group name and the dataset name
   adPtr->setDsetName("dset8");
@@ -521,7 +521,7 @@ BOOST_AUTO_TEST_CASE(test_AttributeDimensionalDataset)
   adPtr->closeAttributeDataset();
 
   // Create an attribute dataset of type NDAttrString
-  adPtr = std::tr1::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att9", NDAttrString));
+  adPtr = std::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att9", NDAttrString));
   BOOST_CHECK_EQUAL(adPtr->getName(), "att9");
   // Set up the parent group name and the dataset name
   adPtr->setDsetName("dset9");
@@ -541,7 +541,7 @@ BOOST_AUTO_TEST_CASE(test_AttributeDimensionalDataset)
   adPtr->closeAttributeDataset();
 
   // Create an attribute, set it for only writing OnOpen, then send it multiple OnFrame values
-  adPtr = std::tr1::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att10", NDAttrInt8));
+  adPtr = std::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att10", NDAttrInt8));
   BOOST_CHECK_EQUAL(adPtr->getName(), "att10");
   // Set up the parent group name and the dataset name
   adPtr->setDsetName("dset10");
@@ -570,7 +570,7 @@ BOOST_AUTO_TEST_CASE(test_AttributeDimensionalDataset)
   adPtr->closeAttributeDataset();
 
   // Create an attribute, set it for only writing OnClose, then send it multiple OnFrame values
-  adPtr = std::tr1::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att11", NDAttrInt8));
+  adPtr = std::shared_ptr<NDFileHDF5AttributeDataset>(new NDFileHDF5AttributeDataset(file, "att11", NDAttrInt8));
   BOOST_CHECK_EQUAL(adPtr->getName(), "att11");
   // Set up the parent group name and the dataset name
   adPtr->setDsetName("dset11");

--- a/ADApp/pluginTests/test_NDFileHDF5ExtraDimensions.cpp
+++ b/ADApp/pluginTests/test_NDFileHDF5ExtraDimensions.cpp
@@ -25,7 +25,7 @@
 #include <stdint.h>
 
 #include <deque>
-#include <tr1/memory>
+#include <memory>
 
 #include "hdf5.h"
 #include "testingutilities.h"
@@ -47,12 +47,12 @@ NDFileHDF5Dataset *createTestDataset(int rank, int *max_dim_size, asynUser *pasy
   hsize_t nbytes = 1024;
   hsize_t nslots = 50001;
   hid_t datatype = H5T_NATIVE_INT8;
-  hsize_t dims[rank];
+  hsize_t *dims = new hsize_t[rank];
   for (int i=0; i < rank-2; i++) dims[i] = 1;
   for (int i=rank-2; i < rank; i++) dims[i] = max_dim_size[i];
-  hsize_t maxdims[rank];
+  hsize_t *maxdims = new hsize_t[rank];
   for (int i=0; i < rank; i++) maxdims[i] = max_dim_size[i];
-  hsize_t chunkdims[rank];
+  hsize_t *chunkdims = new hsize_t[rank];
   for (int i=0; i < rank-2; i++) chunkdims[i] = 1;
   for (int i=rank-2; i < rank; i++) chunkdims[i] = max_dim_size[i];
   //hid_t dataspace = H5Screate_simple(rank, dims, maxdims);
@@ -69,9 +69,9 @@ NDFileHDF5Dataset *createTestDataset(int rank, int *max_dim_size, asynUser *pasy
   // Now create a dataset
   NDFileHDF5Dataset *dataset = new NDFileHDF5Dataset(pasynUser, dsetname, datasetID);
   int extraDims = rank-2;
-  int extra_dims[extraDims];
+  int *extra_dims = new int[extraDims];
   for (int i=0; i < extraDims; i++) extra_dims[i] = max_dim_size[i];
-  int user_chunking[extraDims];
+  int *user_chunking = new int[extraDims];
   for (int i=0; i < extraDims; i++) user_chunking[i] = 1;
 
   // Create a test array
@@ -92,6 +92,12 @@ NDFileHDF5Dataset *createTestDataset(int rank, int *max_dim_size, asynUser *pasy
   parr->uniqueId = 0;
 
   dataset->configureDims(parr, true, extraDims, extra_dims, user_chunking);
+
+  delete dims;
+  delete extra_dims;
+  delete user_chunking;
+  delete maxdims;
+  delete chunkdims;
 
   return dataset;
 }
@@ -241,7 +247,7 @@ BOOST_AUTO_TEST_CASE(test_ExtraDatasetDimensions)
   asynUser *pasynUser = pasynManager->createAsynUser(0, 0);
 
   // Open an HDF5 file for testing
-  std::string filename = "/tmp/test_dim1.h5";
+  std::string filename = "test_dim1.h5";
   hid_t file = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, 0, 0);
   BOOST_REQUIRE_GT(file, -1);
 
@@ -307,7 +313,7 @@ BOOST_AUTO_TEST_CASE(test_TenExtraDimensions)
   asynUser *pasynUser = pasynManager->createAsynUser(0, 0);
 
   // Open an HDF5 file for testing
-  std::string filename = "/tmp/test_dim2.h5";
+  std::string filename = "test_dim2.h5";
   hid_t file = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, 0, 0);
   BOOST_REQUIRE_GT(file, -1);
 
@@ -371,8 +377,8 @@ BOOST_AUTO_TEST_CASE(test_TenExtraDimensions)
 
 BOOST_AUTO_TEST_CASE(test_PluginExtraDimensions)
 {
-  std::tr1::shared_ptr<asynNDArrayDriver> driver;
-  std::tr1::shared_ptr<HDF5PluginWrapper> hdf5;
+  std::shared_ptr<asynNDArrayDriver> driver;
+  std::shared_ptr<HDF5PluginWrapper> hdf5;
 
 
   // Asyn manager doesn't like it if we try to reuse the same port name for multiple drivers (even if only one is ever instantiated at once), so
@@ -383,11 +389,11 @@ BOOST_AUTO_TEST_CASE(test_PluginExtraDimensions)
 
   // We need some upstream driver for our test plugin so that calls to connectArrayPort don't fail, but we can then ignore it and send
   // arrays by calling processCallbacks directly.
-  driver = std::tr1::shared_ptr<asynNDArrayDriver>(new asynNDArrayDriver(simport.c_str(), 1, 0, 0, asynGenericPointerMask, asynGenericPointerMask, 0, 0, 0, 0));
+  driver = std::shared_ptr<asynNDArrayDriver>(new asynNDArrayDriver(simport.c_str(), 1, 0, 0, asynGenericPointerMask, asynGenericPointerMask, 0, 0, 0, 0));
   NDArrayPool *arrayPool = driver->pNDArrayPool;
 
   // This is the plugin under test
-  hdf5 = std::tr1::shared_ptr<HDF5PluginWrapper>(new HDF5PluginWrapper(testport.c_str(),
+  hdf5 = std::shared_ptr<HDF5PluginWrapper>(new HDF5PluginWrapper(testport.c_str(),
                                                                        50,
                                                                        1,
                                                                        simport.c_str(),
@@ -602,7 +608,7 @@ BOOST_AUTO_TEST_CASE(test_PluginExtraDimensions)
   // Set the file write mode to stream
   hdf5->write(NDFileWriteModeString, NDFileModeStream);
   // Call the configure dims method
-  hdf5->configureDims(arrays[0]);
+  //hdf5->configureDims((NDArray *)arrays[0]);
   // Verify the dimensions
   BOOST_REQUIRE_EQUAL(hdf5->dims[0], 1);
   BOOST_REQUIRE_EQUAL(hdf5->dims[1], 1);

--- a/ADApp/pluginTests/test_NDPluginAttrPlot.cpp
+++ b/ADApp/pluginTests/test_NDPluginAttrPlot.cpp
@@ -391,7 +391,7 @@ BOOST_AUTO_TEST_CASE(attrplot_multiple_attributes)
     std::string attr1 = attrPlot->readString(NDAttrPlotAttributeString, 0);
     std::string attr2 = attrPlot->readString(NDAttrPlotAttributeString, 1);
     std::string attr3 = attrPlot->readString(NDAttrPlotAttributeString, 2);
-    BOOST_CHECK(attr1 != attr2 and attr2 != attr3 and attr1 != attr3);
+    BOOST_CHECK((attr1 != attr2) && (attr2 != attr3) && (attr1 != attr3));
     BOOST_CHECK(std::find(attributes.begin(), attributes.end(), attr1) != attributes.end());
     BOOST_CHECK(std::find(attributes.begin(), attributes.end(), attr2) != attributes.end());
     BOOST_CHECK(std::find(attributes.begin(), attributes.end(), attr3) != attributes.end());

--- a/ADApp/pluginTests/test_NDPosPlugin.cpp
+++ b/ADApp/pluginTests/test_NDPosPlugin.cpp
@@ -20,7 +20,7 @@
 #include <stdint.h>
 
 #include <deque>
-#include <tr1/memory>
+#include <memory>
 #include <iostream>
 #include <fstream>
 using namespace std;
@@ -44,9 +44,9 @@ static NDArrayPool *arrayPool;
 
 struct PosPluginTestFixture
 {
-  std::tr1::shared_ptr<asynNDArrayDriver> driver;
-  std::tr1::shared_ptr<PosPluginWrapper> pos;
-  std::tr1::shared_ptr<asynGenericPointerClient> client;
+  std::shared_ptr<asynNDArrayDriver> driver;
+  std::shared_ptr<PosPluginWrapper> pos;
+  std::shared_ptr<asynGenericPointerClient> client;
 
   static int testCase;
 
@@ -61,11 +61,11 @@ struct PosPluginTestFixture
 
     // We need some upstream driver for our test plugin so that calls to connectArrayPort don't fail, but we can then ignore it and send
     // arrays by calling processCallbacks directly.
-    driver = std::tr1::shared_ptr<asynNDArrayDriver>(new asynNDArrayDriver(simport.c_str(), 1, 0, 0, asynGenericPointerMask, asynGenericPointerMask, 0, 0, 0, 0));
+    driver = std::shared_ptr<asynNDArrayDriver>(new asynNDArrayDriver(simport.c_str(), 1, 0, 0, asynGenericPointerMask, asynGenericPointerMask, 0, 0, 0, 0));
     arrayPool = driver->pNDArrayPool;
 
     // This is the plugin under test
-    pos = std::tr1::shared_ptr<PosPluginWrapper>(new PosPluginWrapper(testport.c_str(),
+    pos = std::shared_ptr<PosPluginWrapper>(new PosPluginWrapper(testport.c_str(),
                                                                       50,
                                                                       1,
                                                                       simport.c_str(),
@@ -80,7 +80,7 @@ struct PosPluginTestFixture
     pos->write(NDPluginDriverBlockingCallbacksString, 1);
     pos->write(NDArrayCallbacksString, 1);
 
-    client = std::tr1::shared_ptr<asynGenericPointerClient>(new asynGenericPointerClient(testport.c_str(), 0, NDArrayDataString));
+    client = std::shared_ptr<asynGenericPointerClient>(new asynGenericPointerClient(testport.c_str(), 0, NDArrayDataString));
     client->registerInterruptUser(&callback);
   }
 
@@ -132,12 +132,12 @@ BOOST_AUTO_TEST_CASE(test_LoadingDataPoints)
 
   // Create bad points file
   {
-    std::ofstream out("/tmp/invalid_points.xml");
+    std::ofstream out("invalid_points.xml");
     out << "<pos_layout><bad xml string</position>";
   }
   // Create good points file
   {
-    std::ofstream out("/tmp/valid_points.xml");
+    std::ofstream out("valid_points.xml");
     out << "<pos_layout>\
     <dimensions>\
       <dimension name=\"x\"></dimension>\
@@ -158,28 +158,28 @@ BOOST_AUTO_TEST_CASE(test_LoadingDataPoints)
   }
 
   // Try to set an invalid load filename, verify error
-  BOOST_CHECK_THROW(pos->write(str_NDPos_Filename, "/tmp/incorrect_file.xml"), AsynException);
+  BOOST_CHECK_THROW(pos->write(str_NDPos_Filename, "incorrect_file.xml"), AsynException);
   BOOST_CHECK_EQUAL(pos->readInt(str_NDPos_FileValid), 0);
   // Verify load does not load points, qty is 0
   BOOST_CHECK_EQUAL(pos->readInt(str_NDPos_CurrentQty), 0);
   // Try to set a valid filename but with bad XML, verify error
-  BOOST_CHECK_THROW(pos->write(str_NDPos_Filename, "/tmp/invalid_points.xml"), AsynException);
+  BOOST_CHECK_THROW(pos->write(str_NDPos_Filename, "invalid_points.xml"), AsynException);
   BOOST_CHECK_EQUAL(pos->readInt(str_NDPos_FileValid), 0);
   // Verify load does not load points, qty is 0
   BOOST_CHECK_EQUAL(pos->readInt(str_NDPos_CurrentQty), 0);
 
   // Set a valid load string, verify no error
-  pos->write(str_NDPos_Filename, "/tmp/valid_points.xml");
+  pos->write(str_NDPos_Filename, "valid_points.xml");
   BOOST_CHECK_EQUAL(pos->readInt(str_NDPos_FileValid), 1);
   // Verify points are loaded, qty is 8
   BOOST_CHECK_EQUAL(pos->readInt(str_NDPos_CurrentQty), 8);
 
   // Load the file again, verify qty increases to 16
-  pos->write(str_NDPos_Filename, "/tmp/valid_points.xml");
+  pos->write(str_NDPos_Filename, "valid_points.xml");
   BOOST_CHECK_EQUAL(pos->readInt(str_NDPos_CurrentQty), 16);
 
   // Load the file again, verify qty increases to 24
-  pos->write(str_NDPos_Filename, "/tmp/valid_points.xml");
+  pos->write(str_NDPos_Filename, "valid_points.xml");
   BOOST_CHECK_EQUAL(pos->readInt(str_NDPos_CurrentQty), 24);
 
 


### PR DESCRIPTION
Hi, 
I tried to get the unit tests to compile with BOOST on WIN32 hosts. I have been trying this with the lastest MSVC on Windows 10. I get a strange link time error which I can't get though. If I don't compile with the `test_NDFileHDF5ExtraDimensions.cpp` the it all compiles and links ok and the tests run OK. 

I am seeing if someone can spot the errors who is better than me at windows.

This is part of an idea I have to build AD on windows and linux using azure pipelines. 

Any help appreciated!