### PR TITLE
Improved unit tests to remove the need for define statements.

### DIFF
--- a/ADApp/pluginSrc/NDFileHDF5.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5.cpp
@@ -1993,6 +1993,79 @@ int NDFileHDF5::verifyLayoutXMLFile()
   return status;
 }
 
+/** Return the requested dimension size.
+  * \param[in] index of dimension
+  * \param[out] size of the dimension
+  */
+hsize_t NDFileHDF5::getDim(int index)
+{
+  hsize_t value = -1;
+  if (index >= 0 && index < this->rank){
+    value = this->dims[index];
+  }
+  return value;
+}
+
+/** Return the requested max dimension size.
+  * \param[in] index of dimension
+  * \param[out] size of the dimension
+  */
+hsize_t NDFileHDF5::getMaxDim(int index)
+{
+  hsize_t value = -1;
+  if (index >= 0 && index < this->rank){
+    value = this->maxdims[index];
+  }
+  return value;
+}
+
+/** Return the requested chunk dimension size.
+  * \param[in] index of dimension
+  * \param[out] size of the dimension
+  */
+hsize_t NDFileHDF5::getChunkDim(int index)
+{
+  hsize_t value = -1;
+  if (index >= 0 && index < this->rank){
+    value = this->chunkdims[index];
+  }
+  return value;
+}
+
+/** Return the requested offset size.
+  * \param[in] index of offset
+  * \param[out] size of the offset
+  */
+hsize_t NDFileHDF5::getOffset(int index)
+{
+  hsize_t value = -1;
+  if (index >= 0 && index < this->rank){
+    value = this->offset[index];
+  }
+  return value;
+}
+
+/** Return the requested virtual dimension size.
+  * \param[in] index of dimension
+  * \param[out] size of the dimension
+  */
+hsize_t NDFileHDF5::getVirtualDim(int index)
+{
+  hsize_t value = -1;
+  if (index >= 0 && index < this->nvirtual){
+    value = this->virtualdims[index];
+  }
+  return value;
+}
+
+/** Set the multi frame parameter.
+  * \param[in] boolean to set the writer frame mode
+  */
+void NDFileHDF5::setMultiFrameFile(bool multi)
+{
+  this->multiFrameFile = multi;
+}
+
 /** Constructor for NDFileHDF5; parameters are identical to those for NDPluginFile::NDPluginFile,
     and are passed directly to that base class constructor.
   * After calling the base class constructor this method sets NDPluginFile::supportsMultipleArrays=1.
@@ -2834,9 +2907,9 @@ asynStatus NDFileHDF5::configureDims(NDArray *pArray)
     this->framesize     = (hsize_t*)calloc(ndims,     sizeof(hsize_t));
     this->dims          = (hsize_t*)calloc(ndims,     sizeof(hsize_t));
     this->offset        = (hsize_t*)calloc(ndims,     sizeof(hsize_t));
-    int nvirtual = extradims;
-    if (nvirtual <= 0) nvirtual = 1;
-    this->virtualdims   = (hsize_t*)calloc(nvirtual, sizeof(hsize_t));
+    this->nvirtual = extradims;
+    if (this->nvirtual <= 0) this->nvirtual = 1;
+    this->virtualdims   = (hsize_t*)calloc(this->nvirtual, sizeof(hsize_t));
   }
 
   if (this->multiFrameFile)

--- a/ADApp/pluginSrc/NDFileHDF5.h
+++ b/ADApp/pluginSrc/NDFileHDF5.h
@@ -111,6 +111,12 @@ class epicsShareClass NDFileHDF5 : public NDPluginFile
     int fileExists(char *filename);
     int verifyLayoutXMLFile();
 
+    hsize_t getDim(int index);
+    hsize_t getMaxDim(int index);
+    hsize_t getChunkDim(int index);
+    hsize_t getOffset(int index);
+    hsize_t getVirtualDim(int index);
+
     std::map<std::string, NDFileHDF5Dataset *> detDataMap;  // Map of handles to detector datasets, indexed by name
     std::map<std::string, hid_t>               attDataMap;  // Map of handles to attribute datasets, indexed by name
     std::string                                defDsetName; // Name of the default data set
@@ -119,9 +125,7 @@ class epicsShareClass NDFileHDF5 : public NDPluginFile
     std::map<std::string, hdf5::Element *>     onCloseMap;  // Map of handles to elements with onClose ndattributes, indexed by fullname
     Codec_t                                    codec;       // Definition of codec used to compress the data.
 
-#ifndef _UNITTEST_HDF5_
   protected:
-#endif
     /* plugin parameters */
     int NDFileHDF5_nRowChunks;
     #define FIRST_NDFILE_HDF5_PARAM NDFileHDF5_nRowChunks
@@ -162,9 +166,11 @@ class epicsShareClass NDFileHDF5 : public NDPluginFile
     int NDFileHDF5_SWMRMode;
     int NDFileHDF5_SWMRRunning;
 
-#ifndef _UNITTEST_HDF5_
+    asynStatus configureDims(NDArray *pArray);
+    void calcNumFrames();
+    void setMultiFrameFile(bool multi);
+
   private:
-#endif
     /* private helper functions */
     inline bool IsPrime(int number)
     {
@@ -182,7 +188,6 @@ class epicsShareClass NDFileHDF5 : public NDPluginFile
 
     hid_t typeNd2Hdf(NDDataType_t datatype);
     asynStatus configureDatasetDims(NDArray *pArray);
-    asynStatus configureDims(NDArray *pArray);
     asynStatus configureDatasetCompression();
     asynStatus configureCompression(NDArray *pArray);
     char* getDimsReport();
@@ -193,7 +198,6 @@ class epicsShareClass NDFileHDF5 : public NDPluginFile
     asynStatus configurePerformanceDataset();
     asynStatus createPerformanceDataset();
     asynStatus writePerformanceDataset();
-    void calcNumFrames();
     unsigned int calcIstorek();
     hsize_t calcChunkCacheBytes();
     hsize_t calcChunkCacheSlots();
@@ -247,6 +251,7 @@ class epicsShareClass NDFileHDF5 : public NDPluginFile
 
     /* dimension descriptors */
     int rank;               /** < number of dimensions */
+    int nvirtual;           /** < number of extra virtual dimensions */
     hsize_t *dims;          /** < Array of current dimension sizes. This updates as various dimensions grow. */
     hsize_t *maxdims;       /** < Array of maximum dimension sizes. The value -1 is HDF5 term for infinite. */
     hsize_t *chunkdims;     /** < Array of chunk size in each dimension. Only the dimensions that indicate the frame size (width, height) can really be tweaked. All other dimensions should be set to 1. */

--- a/ADApp/pluginSrc/NDFileHDF5Dataset.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5Dataset.cpp
@@ -73,6 +73,7 @@ asynStatus NDFileHDF5Dataset::configureDims(NDArray *pArray, bool multiframe, in
   }
 
   this->rank_ = ndims;
+  this->extra_rank_ = extradims;
 
   for (j=pArray->ndims-1,i=extradims; i<this->rank_; i++,j--){
     this->maxdims_[i]    = pArray->dims[j].size;
@@ -350,4 +351,57 @@ asynStatus NDFileHDF5Dataset::flushDataset()
 
   return asynSuccess;  
 }
+
+/** Return the requested dimension size.
+  * \param[in] index of dimension
+  * \param[out] size of the dimension
+  */
+hsize_t NDFileHDF5Dataset::getDim(int index)
+{
+  hsize_t value = -1;
+  if (index >= 0 && index < this->rank_){
+    value = this->dims_[index];
+  }
+  return value;
+}
+
+/** Return the requested max dimension size.
+  * \param[in] index of dimension
+  * \param[out] size of the dimension
+  */
+hsize_t NDFileHDF5Dataset::getMaxDim(int index)
+{
+  hsize_t value = -1;
+  if (index >= 0 && index < this->rank_){
+    value = this->maxdims_[index];
+  }
+  return value;
+}
+
+/** Return the requested offset size.
+  * \param[in] index of offset
+  * \param[out] size of the offset
+  */
+hsize_t NDFileHDF5Dataset::getOffset(int index)
+{
+  hsize_t value = -1;
+  if (index >= 0 && index < this->rank_){
+    value = this->offset_[index];
+  }
+  return value;
+}
+
+/** Return the requested virtual dimension size.
+  * \param[in] index of dimension
+  * \param[out] size of the dimension
+  */
+hsize_t NDFileHDF5Dataset::getVirtualDim(int index)
+{
+  hsize_t value = -1;
+  if (index >= 0 && index < this->extra_rank_){
+    value = this->virtualdims_[index];
+  }
+  return value;
+}
+
 

--- a/ADApp/pluginSrc/NDFileHDF5Dataset.h
+++ b/ADApp/pluginSrc/NDFileHDF5Dataset.h
@@ -21,10 +21,12 @@ class NDFileHDF5Dataset
     asynStatus writeFile(NDArray *pArray, hid_t datatype, hid_t dataspace, hsize_t *framesize);
     hid_t getHandle();
     asynStatus flushDataset();
+    hsize_t getDim(int index);
+    hsize_t getMaxDim(int index);
+    hsize_t getOffset(int index);
+    hsize_t getVirtualDim(int index);
 
-#ifndef _UNITTEST_HDF5_
   private:
-#endif
 
     asynUser    *pAsynUser_;   // Pointer to the asynUser structure
     std::string name_;         // Name of this dataset
@@ -33,6 +35,7 @@ class NDFileHDF5Dataset
     int         arrayDims[ND_ARRAY_MAX_DIMS];
     bool        multiFrame_;   // Whether this is a multi frame dataset
     int         rank_;         // number of dimensions
+    int         extra_rank_;   // number of extra dimensions
     hsize_t     *dims_;        // Array of current dimension sizes. This updates as various dimensions grow.
     hsize_t     *chunkdims_;   // Array of current configured chunk dimension sizes.
     hsize_t     *maxdims_;     // Array of maximum dimension sizes. The value -1 is HDF5 term for infinite.

--- a/ADApp/pluginTests/HDF5PluginWrapper.cpp
+++ b/ADApp/pluginTests/HDF5PluginWrapper.cpp
@@ -25,6 +25,21 @@ HDF5PluginWrapper::HDF5PluginWrapper(const std::string& port,
 {
 }
 
+asynStatus HDF5PluginWrapper::testConfigureDims(NDArray *pArray)
+{
+  return this->configureDims(pArray);
+}
+
+void HDF5PluginWrapper::testCalcNumFrames()
+{
+  this->calcNumFrames();
+}
+
+void HDF5PluginWrapper::testSetMultiFrameFile(bool multi)
+{
+  this->setMultiFrameFile(multi);
+}
+
 HDF5PluginWrapper::~HDF5PluginWrapper()
 {
   cleanup();

--- a/ADApp/pluginTests/HDF5PluginWrapper.h
+++ b/ADApp/pluginTests/HDF5PluginWrapper.h
@@ -22,6 +22,10 @@ public:
                     int address,
                     int priority,
                     int stackSize);
+  asynStatus testConfigureDims(NDArray *pArray);
+  void testCalcNumFrames();
+  void testSetMultiFrameFile(bool multi);
+
   virtual ~HDF5PluginWrapper();
 
 };

--- a/ADApp/pluginTests/test_NDFileHDF5.cpp
+++ b/ADApp/pluginTests/test_NDFileHDF5.cpp
@@ -1,9 +1,4 @@
 /* Nothing here yet*/ 
-// This must be defined first to hack the relevant classes, turning all private variables and
-// methods into public for unit testing.  It's not pretty, but necessary until the classes are
-// all re-written to be more OO.
-#define _UNITTEST_HDF5_
-
 #include <stdio.h>
 
 

--- a/ADApp/pluginTests/test_NDFileHDF5ExtraDimensions.cpp
+++ b/ADApp/pluginTests/test_NDFileHDF5ExtraDimensions.cpp
@@ -4,13 +4,6 @@
  *  Created on: 10 Nov 2015
  *      Author: gnx91527
  */
-
-// This must be defined first to hack the relevant classes, turning all private variables and
-// methods into public for unit testing.  It's not pretty, but necessary until the classes are
-// all re-written to be more OO.
-#define _UNITTEST_HDF5_
-
-
 #include <stdio.h>
 
 
@@ -104,13 +97,13 @@ void testDimensions(NDFileHDF5Dataset *dataset, int ndims, int extradims, int *v
   // Test the maximum dimensions of the dataset
   for (int i=0; i < extradims; i++){
     //BOOST_TEST_MESSAGE("Verify maxdim[" << i << "] == " << values[counter]);
-    val = dataset->maxdims_[i];
+    val = dataset->getMaxDim(i);
     BOOST_REQUIRE_EQUAL(val, values[counter]);
     counter++;
   }
   for (int i=extradims; i < extradims+ndims; i++){
     //BOOST_TEST_MESSAGE("Verify maxdim[" << i << "] == " << values[counter]);
-    val = dataset->maxdims_[i];
+    val = dataset->getMaxDim(i);
     BOOST_REQUIRE_EQUAL(val, values[counter]);
     counter++;
   }
@@ -118,13 +111,13 @@ void testDimensions(NDFileHDF5Dataset *dataset, int ndims, int extradims, int *v
   // Test the current dimension sizes of the dataset
   for (int i=0; i < extradims; i++){
     //BOOST_TEST_MESSAGE("Verify current dim[" << i << "] == " << values[counter]);
-    val = dataset->dims_[i];
+    val = dataset->getDim(i);
     BOOST_REQUIRE_EQUAL(val, values[counter]);
     counter++;
   }
   for (int i=extradims; i < extradims+ndims; i++){
     //BOOST_TEST_MESSAGE("Verify current dim[" << i << "] == " << values[counter]);
-    val = dataset->dims_[i];
+    val = dataset->getDim(i);
     BOOST_REQUIRE_EQUAL(val, values[counter]);
     counter++;
   }
@@ -132,7 +125,7 @@ void testDimensions(NDFileHDF5Dataset *dataset, int ndims, int extradims, int *v
   // Test the offsets of the dataset
   for (int i=0; i < extradims+ndims; i++){
     //BOOST_TEST_MESSAGE("Verify offset[" << i << "] == " << values[counter]);
-    val = dataset->offset_[i];
+    val = dataset->getOffset(i);
     BOOST_REQUIRE_EQUAL(val, values[counter]);
     counter++;
   }
@@ -140,7 +133,7 @@ void testDimensions(NDFileHDF5Dataset *dataset, int ndims, int extradims, int *v
   // Test the virtual dimension sizes of the dataset
   for (int i=0; i < extradims; i++){
     //BOOST_TEST_MESSAGE("Verify current virtualdim[" << i << "] == " << values[counter]);
-    val = dataset->virtualdims_[i];
+    val = dataset->getVirtualDim(i);
     BOOST_REQUIRE_EQUAL(val, values[counter]);
     counter++;
   }
@@ -153,7 +146,7 @@ void testOffsets(NDFileHDF5Dataset *dataset, int ndims, int extradims, int *valu
   // Test the offsets of the dataset
   for (int i=0; i < extradims+ndims; i++){
     //BOOST_TEST_MESSAGE("Verify offset[" << i << "] == " << values[i]);
-    val = dataset->offset_[i];
+    val = dataset->getOffset(i);
     BOOST_REQUIRE_EQUAL(val, values[i]);
   }
 }
@@ -166,13 +159,13 @@ void testDims(NDFileHDF5Dataset *dataset, int ndims, int extradims, int *values)
   // Test the current dimension sizes of the dataset
   for (int i=0; i < extradims; i++){
     //BOOST_TEST_MESSAGE("Verify current dim[" << i << "] == " << values[counter]);
-    val = dataset->dims_[i];
+    val = dataset->getDim(i);
     BOOST_REQUIRE_EQUAL(val, values[counter]);
     counter++;
   }
   for (int i=extradims; i < extradims+ndims; i++){
     //BOOST_TEST_MESSAGE("Verify current dim[" << i << "] == " << values[counter]);
-    val = dataset->dims_[i];
+    val = dataset->getDim(i);
     BOOST_REQUIRE_EQUAL(val, values[counter]);
     counter++;
   }
@@ -186,13 +179,13 @@ void testMaxDims(NDFileHDF5Dataset *dataset, int ndims, int extradims, int *valu
   // Test the maximum dimensions of the dataset
   for (int i=0; i < extradims; i++){
     //BOOST_TEST_MESSAGE("Verify maxdim[" << i << "] == " << values[counter]);
-    val = dataset->maxdims_[i];
+    val = dataset->getMaxDim(i);
     BOOST_REQUIRE_EQUAL(val, values[counter]);
     counter++;
   }
   for (int i=extradims; i < extradims+ndims; i++){
     //BOOST_TEST_MESSAGE("Verify maxdim[" << i << "] == " << values[counter]);
-    val = dataset->maxdims_[i];
+    val = dataset->getMaxDim(i);
     BOOST_REQUIRE_EQUAL(val, values[counter]);
     counter++;
   }
@@ -205,7 +198,7 @@ void testVirtualDims(NDFileHDF5Dataset *dataset, int ndims, int extradims, int *
   // Test the virtual dimension sizes of the dataset
   for (int i=0; i < extradims; i++){
     //BOOST_TEST_MESSAGE("Verify current virtualdim[" << i << "] == " << values[i]);
-    val = dataset->virtualdims_[i];
+    val = dataset->getVirtualDim(i);
     BOOST_REQUIRE_EQUAL(val, values[i]);
   }
 }
@@ -416,7 +409,7 @@ BOOST_AUTO_TEST_CASE(test_PluginExtraDimensions)
   hdf5->write(str_NDFileHDF5_nExtraDims, 1);
   hdf5->write(NDFileHDF5::str_NDFileHDF5_extraDimSize[0], 4);
   hdf5->write(NDFileHDF5::str_NDFileHDF5_extraDimSize[1], 6);
-  hdf5->calcNumFrames();
+  hdf5->testCalcNumFrames();
   numCapture = hdf5->readInt(NDFileNumCaptureString);
   BOOST_REQUIRE_EQUAL(numCapture, 24);
 
@@ -426,7 +419,7 @@ BOOST_AUTO_TEST_CASE(test_PluginExtraDimensions)
   hdf5->write(NDFileHDF5::str_NDFileHDF5_extraDimSize[0], 5);
   hdf5->write(NDFileHDF5::str_NDFileHDF5_extraDimSize[1], 7);
   hdf5->write(NDFileHDF5::str_NDFileHDF5_extraDimSize[2], 9);
-  hdf5->calcNumFrames();
+  hdf5->testCalcNumFrames();
   numCapture = hdf5->readInt(NDFileNumCaptureString);
   BOOST_REQUIRE_EQUAL(numCapture, 315);
 
@@ -437,7 +430,7 @@ BOOST_AUTO_TEST_CASE(test_PluginExtraDimensions)
   hdf5->write(NDFileHDF5::str_NDFileHDF5_extraDimSize[1], 3);
   hdf5->write(NDFileHDF5::str_NDFileHDF5_extraDimSize[2], 4);
   hdf5->write(NDFileHDF5::str_NDFileHDF5_extraDimSize[3], 5);
-  hdf5->calcNumFrames();
+  hdf5->testCalcNumFrames();
   numCapture = hdf5->readInt(NDFileNumCaptureString);
   BOOST_REQUIRE_EQUAL(numCapture, 120);
 
@@ -449,7 +442,7 @@ BOOST_AUTO_TEST_CASE(test_PluginExtraDimensions)
   hdf5->write(NDFileHDF5::str_NDFileHDF5_extraDimSize[2], 6);
   hdf5->write(NDFileHDF5::str_NDFileHDF5_extraDimSize[3], 8);
   hdf5->write(NDFileHDF5::str_NDFileHDF5_extraDimSize[4], 10);
-  hdf5->calcNumFrames();
+  hdf5->testCalcNumFrames();
   numCapture = hdf5->readInt(NDFileNumCaptureString);
   BOOST_REQUIRE_EQUAL(numCapture, 3840);
 
@@ -462,7 +455,7 @@ BOOST_AUTO_TEST_CASE(test_PluginExtraDimensions)
   hdf5->write(NDFileHDF5::str_NDFileHDF5_extraDimSize[3], 5);
   hdf5->write(NDFileHDF5::str_NDFileHDF5_extraDimSize[4], 6);
   hdf5->write(NDFileHDF5::str_NDFileHDF5_extraDimSize[5], 7);
-  hdf5->calcNumFrames();
+  hdf5->testCalcNumFrames();
   numCapture = hdf5->readInt(NDFileNumCaptureString);
   BOOST_REQUIRE_EQUAL(numCapture, 5040);
 
@@ -476,7 +469,7 @@ BOOST_AUTO_TEST_CASE(test_PluginExtraDimensions)
   hdf5->write(NDFileHDF5::str_NDFileHDF5_extraDimSize[4], 6);
   hdf5->write(NDFileHDF5::str_NDFileHDF5_extraDimSize[5], 7);
   hdf5->write(NDFileHDF5::str_NDFileHDF5_extraDimSize[6], 8);
-  hdf5->calcNumFrames();
+  hdf5->testCalcNumFrames();
   numCapture = hdf5->readInt(NDFileNumCaptureString);
   BOOST_REQUIRE_EQUAL(numCapture, 40320);
 
@@ -491,7 +484,7 @@ BOOST_AUTO_TEST_CASE(test_PluginExtraDimensions)
   hdf5->write(NDFileHDF5::str_NDFileHDF5_extraDimSize[5], 7);
   hdf5->write(NDFileHDF5::str_NDFileHDF5_extraDimSize[6], 8);
   hdf5->write(NDFileHDF5::str_NDFileHDF5_extraDimSize[7], 9);
-  hdf5->calcNumFrames();
+  hdf5->testCalcNumFrames();
   numCapture = hdf5->readInt(NDFileNumCaptureString);
   BOOST_REQUIRE_EQUAL(numCapture, 362880);
 
@@ -507,7 +500,7 @@ BOOST_AUTO_TEST_CASE(test_PluginExtraDimensions)
   hdf5->write(NDFileHDF5::str_NDFileHDF5_extraDimSize[6], 8);
   hdf5->write(NDFileHDF5::str_NDFileHDF5_extraDimSize[7], 9);
   hdf5->write(NDFileHDF5::str_NDFileHDF5_extraDimSize[8], 10);
-  hdf5->calcNumFrames();
+  hdf5->testCalcNumFrames();
   numCapture = hdf5->readInt(NDFileNumCaptureString);
   BOOST_REQUIRE_EQUAL(numCapture, 3628800);
 
@@ -524,7 +517,7 @@ BOOST_AUTO_TEST_CASE(test_PluginExtraDimensions)
   hdf5->write(NDFileHDF5::str_NDFileHDF5_extraDimSize[7], 9);
   hdf5->write(NDFileHDF5::str_NDFileHDF5_extraDimSize[8], 10);
   hdf5->write(NDFileHDF5::str_NDFileHDF5_extraDimSize[9], 11);
-  hdf5->calcNumFrames();
+  hdf5->testCalcNumFrames();
   numCapture = hdf5->readInt(NDFileNumCaptureString);
   BOOST_REQUIRE_EQUAL(numCapture, 39916800);
 
@@ -533,7 +526,7 @@ BOOST_AUTO_TEST_CASE(test_PluginExtraDimensions)
   // Set 2 extra dims
   hdf5->write(str_NDFileHDF5_nExtraDims, 2);
   // Set multiframe true
-  hdf5->multiFrameFile = true;
+  hdf5->testSetMultiFrameFile(true);
   // Set extra dim sizes n=2 x=3 y=4
   hdf5->write(NDFileHDF5::str_NDFileHDF5_extraDimSize[0], 2);
   hdf5->write(NDFileHDF5::str_NDFileHDF5_extraDimSize[1], 3);
@@ -547,41 +540,41 @@ BOOST_AUTO_TEST_CASE(test_PluginExtraDimensions)
   // Set the file write mode to stream
   hdf5->write(NDFileWriteModeString, NDFileModeStream);
   // Call the configure dims method
-  hdf5->configureDims(arrays[0]);
+  hdf5->testConfigureDims(arrays[0]);
   // Verify the dimensions
-  BOOST_REQUIRE_EQUAL(hdf5->dims[0], 1);
-  BOOST_REQUIRE_EQUAL(hdf5->dims[1], 1);
-  BOOST_REQUIRE_EQUAL(hdf5->dims[2], 1);
-  BOOST_REQUIRE_EQUAL(hdf5->dims[3], 512);
-  BOOST_REQUIRE_EQUAL(hdf5->dims[4], 1024);
+  BOOST_REQUIRE_EQUAL(hdf5->getDim(0), 1);
+  BOOST_REQUIRE_EQUAL(hdf5->getDim(1), 1);
+  BOOST_REQUIRE_EQUAL(hdf5->getDim(2), 1);
+  BOOST_REQUIRE_EQUAL(hdf5->getDim(3), 512);
+  BOOST_REQUIRE_EQUAL(hdf5->getDim(4), 1024);
   // Verify the maximum dimensions
-  BOOST_REQUIRE_EQUAL(hdf5->maxdims[0], 4);
-  BOOST_REQUIRE_EQUAL(hdf5->maxdims[1], 3);
-  BOOST_REQUIRE_EQUAL(hdf5->maxdims[2], 2);
-  BOOST_REQUIRE_EQUAL(hdf5->maxdims[3], 512);
-  BOOST_REQUIRE_EQUAL(hdf5->maxdims[4], 1024);
+  BOOST_REQUIRE_EQUAL(hdf5->getMaxDim(0), 4);
+  BOOST_REQUIRE_EQUAL(hdf5->getMaxDim(1), 3);
+  BOOST_REQUIRE_EQUAL(hdf5->getMaxDim(2), 2);
+  BOOST_REQUIRE_EQUAL(hdf5->getMaxDim(3), 512);
+  BOOST_REQUIRE_EQUAL(hdf5->getMaxDim(4), 1024);
   // Verify the chunk dimensions
-  BOOST_REQUIRE_EQUAL(hdf5->chunkdims[0], 1);
-  BOOST_REQUIRE_EQUAL(hdf5->chunkdims[1], 1);
-  BOOST_REQUIRE_EQUAL(hdf5->chunkdims[2], 1);
-  BOOST_REQUIRE_EQUAL(hdf5->chunkdims[3], 512);
-  BOOST_REQUIRE_EQUAL(hdf5->chunkdims[4], 1024);
+  BOOST_REQUIRE_EQUAL(hdf5->getChunkDim(0), 1);
+  BOOST_REQUIRE_EQUAL(hdf5->getChunkDim(1), 1);
+  BOOST_REQUIRE_EQUAL(hdf5->getChunkDim(2), 1);
+  BOOST_REQUIRE_EQUAL(hdf5->getChunkDim(3), 512);
+  BOOST_REQUIRE_EQUAL(hdf5->getChunkDim(4), 1024);
   // Verify the offsets
-  BOOST_REQUIRE_EQUAL(hdf5->offset[0], 0);
-  BOOST_REQUIRE_EQUAL(hdf5->offset[1], 0);
-  BOOST_REQUIRE_EQUAL(hdf5->offset[2], 0);
-  BOOST_REQUIRE_EQUAL(hdf5->offset[3], 0);
-  BOOST_REQUIRE_EQUAL(hdf5->offset[4], 0);
+  BOOST_REQUIRE_EQUAL(hdf5->getOffset(0), 0);
+  BOOST_REQUIRE_EQUAL(hdf5->getOffset(1), 0);
+  BOOST_REQUIRE_EQUAL(hdf5->getOffset(2), 0);
+  BOOST_REQUIRE_EQUAL(hdf5->getOffset(3), 0);
+  BOOST_REQUIRE_EQUAL(hdf5->getOffset(4), 0);
   // Verify the virtual dims
-  BOOST_REQUIRE_EQUAL(hdf5->virtualdims[0], 4);
-  BOOST_REQUIRE_EQUAL(hdf5->virtualdims[1], 3);
-  BOOST_REQUIRE_EQUAL(hdf5->virtualdims[2], 2);
+  BOOST_REQUIRE_EQUAL(hdf5->getVirtualDim(0), 4);
+  BOOST_REQUIRE_EQUAL(hdf5->getVirtualDim(1), 3);
+  BOOST_REQUIRE_EQUAL(hdf5->getVirtualDim(2), 2);
 
 
   // Set 9 extra dims
   hdf5->write(str_NDFileHDF5_nExtraDims, 9);
   // Set multiframe true
-  hdf5->multiFrameFile = true;
+  hdf5->testSetMultiFrameFile(true);
   // Set extra dim sizes 1st=2 2nd=3 3rd=4 4th=5 5th=6 6th=7 7th=8 8th=9 9th=10 10th=11
   hdf5->write(NDFileHDF5::str_NDFileHDF5_extraDimSize[0], 2);
   hdf5->write(NDFileHDF5::str_NDFileHDF5_extraDimSize[1], 3);
@@ -602,70 +595,70 @@ BOOST_AUTO_TEST_CASE(test_PluginExtraDimensions)
   // Set the file write mode to stream
   hdf5->write(NDFileWriteModeString, NDFileModeStream);
   // Call the configure dims method
-  hdf5->configureDims(arrays[0]);
+  hdf5->testConfigureDims(arrays[0]);
   // Verify the dimensions
-  BOOST_REQUIRE_EQUAL(hdf5->dims[0], 1);
-  BOOST_REQUIRE_EQUAL(hdf5->dims[1], 1);
-  BOOST_REQUIRE_EQUAL(hdf5->dims[2], 1);
-  BOOST_REQUIRE_EQUAL(hdf5->dims[3], 1);
-  BOOST_REQUIRE_EQUAL(hdf5->dims[4], 1);
-  BOOST_REQUIRE_EQUAL(hdf5->dims[5], 1);
-  BOOST_REQUIRE_EQUAL(hdf5->dims[6], 1);
-  BOOST_REQUIRE_EQUAL(hdf5->dims[7], 1);
-  BOOST_REQUIRE_EQUAL(hdf5->dims[8], 1);
-  BOOST_REQUIRE_EQUAL(hdf5->dims[9], 1);
-  BOOST_REQUIRE_EQUAL(hdf5->dims[10], 512);
-  BOOST_REQUIRE_EQUAL(hdf5->dims[11], 1024);
+  BOOST_REQUIRE_EQUAL(hdf5->getDim(0), 1);
+  BOOST_REQUIRE_EQUAL(hdf5->getDim(1), 1);
+  BOOST_REQUIRE_EQUAL(hdf5->getDim(2), 1);
+  BOOST_REQUIRE_EQUAL(hdf5->getDim(3), 1);
+  BOOST_REQUIRE_EQUAL(hdf5->getDim(4), 1);
+  BOOST_REQUIRE_EQUAL(hdf5->getDim(5), 1);
+  BOOST_REQUIRE_EQUAL(hdf5->getDim(6), 1);
+  BOOST_REQUIRE_EQUAL(hdf5->getDim(7), 1);
+  BOOST_REQUIRE_EQUAL(hdf5->getDim(8), 1);
+  BOOST_REQUIRE_EQUAL(hdf5->getDim(9), 1);
+  BOOST_REQUIRE_EQUAL(hdf5->getDim(10), 512);
+  BOOST_REQUIRE_EQUAL(hdf5->getDim(11), 1024);
   // Verify the maximum dimensions
-  BOOST_REQUIRE_EQUAL(hdf5->maxdims[0],  11);
-  BOOST_REQUIRE_EQUAL(hdf5->maxdims[1],  10);
-  BOOST_REQUIRE_EQUAL(hdf5->maxdims[2],  9);
-  BOOST_REQUIRE_EQUAL(hdf5->maxdims[3],  8);
-  BOOST_REQUIRE_EQUAL(hdf5->maxdims[4],  7);
-  BOOST_REQUIRE_EQUAL(hdf5->maxdims[5],  6);
-  BOOST_REQUIRE_EQUAL(hdf5->maxdims[6],  5);
-  BOOST_REQUIRE_EQUAL(hdf5->maxdims[7],  4);
-  BOOST_REQUIRE_EQUAL(hdf5->maxdims[8],  3);
-  BOOST_REQUIRE_EQUAL(hdf5->maxdims[9],  2);
-  BOOST_REQUIRE_EQUAL(hdf5->maxdims[10], 512);
-  BOOST_REQUIRE_EQUAL(hdf5->maxdims[11], 1024);
+  BOOST_REQUIRE_EQUAL(hdf5->getMaxDim(0),  11);
+  BOOST_REQUIRE_EQUAL(hdf5->getMaxDim(1),  10);
+  BOOST_REQUIRE_EQUAL(hdf5->getMaxDim(2),  9);
+  BOOST_REQUIRE_EQUAL(hdf5->getMaxDim(3),  8);
+  BOOST_REQUIRE_EQUAL(hdf5->getMaxDim(4),  7);
+  BOOST_REQUIRE_EQUAL(hdf5->getMaxDim(5),  6);
+  BOOST_REQUIRE_EQUAL(hdf5->getMaxDim(6),  5);
+  BOOST_REQUIRE_EQUAL(hdf5->getMaxDim(7),  4);
+  BOOST_REQUIRE_EQUAL(hdf5->getMaxDim(8),  3);
+  BOOST_REQUIRE_EQUAL(hdf5->getMaxDim(9),  2);
+  BOOST_REQUIRE_EQUAL(hdf5->getMaxDim(10), 512);
+  BOOST_REQUIRE_EQUAL(hdf5->getMaxDim(11), 1024);
   // Verify the chunk dimensions
-  BOOST_REQUIRE_EQUAL(hdf5->chunkdims[0], 1);
-  BOOST_REQUIRE_EQUAL(hdf5->chunkdims[1], 1);
-  BOOST_REQUIRE_EQUAL(hdf5->chunkdims[2], 1);
-  BOOST_REQUIRE_EQUAL(hdf5->chunkdims[3], 1);
-  BOOST_REQUIRE_EQUAL(hdf5->chunkdims[4], 1);
-  BOOST_REQUIRE_EQUAL(hdf5->chunkdims[5], 1);
-  BOOST_REQUIRE_EQUAL(hdf5->chunkdims[6], 1);
-  BOOST_REQUIRE_EQUAL(hdf5->chunkdims[7], 1);
-  BOOST_REQUIRE_EQUAL(hdf5->chunkdims[8], 1);
-  BOOST_REQUIRE_EQUAL(hdf5->chunkdims[9], 1);
-  BOOST_REQUIRE_EQUAL(hdf5->chunkdims[10], 512);
-  BOOST_REQUIRE_EQUAL(hdf5->chunkdims[11], 1024);
+  BOOST_REQUIRE_EQUAL(hdf5->getChunkDim(0), 1);
+  BOOST_REQUIRE_EQUAL(hdf5->getChunkDim(1), 1);
+  BOOST_REQUIRE_EQUAL(hdf5->getChunkDim(2), 1);
+  BOOST_REQUIRE_EQUAL(hdf5->getChunkDim(3), 1);
+  BOOST_REQUIRE_EQUAL(hdf5->getChunkDim(4), 1);
+  BOOST_REQUIRE_EQUAL(hdf5->getChunkDim(5), 1);
+  BOOST_REQUIRE_EQUAL(hdf5->getChunkDim(6), 1);
+  BOOST_REQUIRE_EQUAL(hdf5->getChunkDim(7), 1);
+  BOOST_REQUIRE_EQUAL(hdf5->getChunkDim(8), 1);
+  BOOST_REQUIRE_EQUAL(hdf5->getChunkDim(9), 1);
+  BOOST_REQUIRE_EQUAL(hdf5->getChunkDim(10), 512);
+  BOOST_REQUIRE_EQUAL(hdf5->getChunkDim(11), 1024);
   // Verify the offsets
-  BOOST_REQUIRE_EQUAL(hdf5->offset[0], 0);
-  BOOST_REQUIRE_EQUAL(hdf5->offset[1], 0);
-  BOOST_REQUIRE_EQUAL(hdf5->offset[2], 0);
-  BOOST_REQUIRE_EQUAL(hdf5->offset[3], 0);
-  BOOST_REQUIRE_EQUAL(hdf5->offset[4], 0);
-  BOOST_REQUIRE_EQUAL(hdf5->offset[5], 0);
-  BOOST_REQUIRE_EQUAL(hdf5->offset[6], 0);
-  BOOST_REQUIRE_EQUAL(hdf5->offset[7], 0);
-  BOOST_REQUIRE_EQUAL(hdf5->offset[8], 0);
-  BOOST_REQUIRE_EQUAL(hdf5->offset[9], 0);
-  BOOST_REQUIRE_EQUAL(hdf5->offset[10], 0);
-  BOOST_REQUIRE_EQUAL(hdf5->offset[11], 0);
+  BOOST_REQUIRE_EQUAL(hdf5->getOffset(0), 0);
+  BOOST_REQUIRE_EQUAL(hdf5->getOffset(1), 0);
+  BOOST_REQUIRE_EQUAL(hdf5->getOffset(2), 0);
+  BOOST_REQUIRE_EQUAL(hdf5->getOffset(3), 0);
+  BOOST_REQUIRE_EQUAL(hdf5->getOffset(4), 0);
+  BOOST_REQUIRE_EQUAL(hdf5->getOffset(5), 0);
+  BOOST_REQUIRE_EQUAL(hdf5->getOffset(6), 0);
+  BOOST_REQUIRE_EQUAL(hdf5->getOffset(7), 0);
+  BOOST_REQUIRE_EQUAL(hdf5->getOffset(8), 0);
+  BOOST_REQUIRE_EQUAL(hdf5->getOffset(9), 0);
+  BOOST_REQUIRE_EQUAL(hdf5->getOffset(10), 0);
+  BOOST_REQUIRE_EQUAL(hdf5->getOffset(11), 0);
   // Verify the virtual dims
-  BOOST_REQUIRE_EQUAL(hdf5->virtualdims[0], 11);
-  BOOST_REQUIRE_EQUAL(hdf5->virtualdims[1], 10);
-  BOOST_REQUIRE_EQUAL(hdf5->virtualdims[2], 9);
-  BOOST_REQUIRE_EQUAL(hdf5->virtualdims[3], 8);
-  BOOST_REQUIRE_EQUAL(hdf5->virtualdims[4], 7);
-  BOOST_REQUIRE_EQUAL(hdf5->virtualdims[5], 6);
-  BOOST_REQUIRE_EQUAL(hdf5->virtualdims[6], 5);
-  BOOST_REQUIRE_EQUAL(hdf5->virtualdims[7], 4);
-  BOOST_REQUIRE_EQUAL(hdf5->virtualdims[8], 3);
-  BOOST_REQUIRE_EQUAL(hdf5->virtualdims[9], 2);
+  BOOST_REQUIRE_EQUAL(hdf5->getVirtualDim(0), 11);
+  BOOST_REQUIRE_EQUAL(hdf5->getVirtualDim(1), 10);
+  BOOST_REQUIRE_EQUAL(hdf5->getVirtualDim(2), 9);
+  BOOST_REQUIRE_EQUAL(hdf5->getVirtualDim(3), 8);
+  BOOST_REQUIRE_EQUAL(hdf5->getVirtualDim(4), 7);
+  BOOST_REQUIRE_EQUAL(hdf5->getVirtualDim(5), 6);
+  BOOST_REQUIRE_EQUAL(hdf5->getVirtualDim(6), 5);
+  BOOST_REQUIRE_EQUAL(hdf5->getVirtualDim(7), 4);
+  BOOST_REQUIRE_EQUAL(hdf5->getVirtualDim(8), 3);
+  BOOST_REQUIRE_EQUAL(hdf5->getVirtualDim(9), 2);
 
 }
 


### PR DESCRIPTION
Removed check for _UNITTEST_HDF5_.
Moved some private methods required for testing into protected scope.
Added testing methods in wrapper class.
Provided getters for internal dimensions.
Updated unit tests.

This PR is raised to address issues found within #381.  The defines have been removed, private methods that are required have been made protected and exposed through the test wrapper class, and getters have been created for all internal dimensions that need to be checked.