### PR TITLE
Fix memory leaks

### DIFF
--- a/ADApp/pluginSrc/NDFileHDF5.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5.cpp
@@ -718,6 +718,7 @@ asynStatus NDFileHDF5::createHardLinks(hdf5::Group* root)
         asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR, "%s::%s error creating hard link from: %s to %s\n",
                   driverName, functionName, targetName.c_str(), linkName.c_str());
       }
+      delete it_hardlinks->second;
     }
 
     hdf5::Group::MapGroups_t::const_iterator it_group;

--- a/ADApp/pluginSrc/NDFileHDF5.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5.cpp
@@ -1670,6 +1670,9 @@ asynStatus NDFileHDF5::closeFile()
   this->layout.unload_xml();
 
   // Reset the default data set and clear out the maps of handles to stale datasets
+  for (it_dset = this->detDataMap.begin(); it_dset != this->detDataMap.end(); ++it_dset){
+    delete it_dset->second;
+  }
   detDataMap.clear();
   attDataMap.clear();
   defDsetName = "";
@@ -2718,7 +2721,7 @@ asynStatus NDFileHDF5::createAttributeDataset(NDArray *pArray)
 
     } else {
       if(groupDefault > -1) {
-        std::string atName = std::string(epicsStrDup(ndAttr->getName()));
+        std::string atName = std::string(ndAttr->getName());
         NDFileHDF5AttributeDataset *attDset = new NDFileHDF5AttributeDataset(this->file, atName, ndAttr->getDataType());
         if(def_group != NULL) {
           attDset->setParentGroupName(def_group->get_full_name().c_str());

--- a/ADApp/pluginSrc/NDFileHDF5AttributeDataset.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5AttributeDataset.cpp
@@ -47,6 +47,11 @@ NDFileHDF5AttributeDataset::~NDFileHDF5AttributeDataset()
   //printf("Destructor called for %s\n", name_.c_str());
   // Free the memory that was allocated for the fill value
   free(ptrFillValue_);
+  if (this->maxdims_     != NULL) free(this->maxdims_);
+  if (this->chunk_       != NULL) free(this->chunk_);
+  if (this->dims_        != NULL) free(this->dims_);
+  if (this->offset_      != NULL) free(this->offset_);
+  if (this->elementSize_ != NULL) free(this->elementSize_);
 }
 
 void NDFileHDF5AttributeDataset::setDsetName(const std::string& dsetName)

--- a/ADApp/pluginSrc/NDFileHDF5AttributeDataset.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5AttributeDataset.cpp
@@ -39,7 +39,7 @@ NDFileHDF5AttributeDataset::NDFileHDF5AttributeDataset(hid_t file, const std::st
 {
   //printf("Constructor called for %s\n", name.c_str());
   // Allocate enough memory for the fill value to accept any data type
-  ptrFillValue_ = (void*)calloc(8, sizeof(char));
+  ptrFillValue_ = (void*)calloc(MAX_ATTRIBUTE_STRING_SIZE, sizeof(char));
 }
 
 NDFileHDF5AttributeDataset::~NDFileHDF5AttributeDataset()

--- a/ADApp/pluginSrc/NDFileHDF5Dataset.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5Dataset.cpp
@@ -20,7 +20,16 @@ NDFileHDF5Dataset::NDFileHDF5Dataset(asynUser *pAsynUser, const std::string& nam
   this->offset_      = NULL;
   this->virtualdims_ = NULL;
 }
- 
+
+NDFileHDF5Dataset::~NDFileHDF5Dataset()
+{
+  if (this->chunkdims_   != NULL) free(this->chunkdims_);
+  if (this->maxdims_     != NULL) free(this->maxdims_);
+  if (this->dims_        != NULL) free(this->dims_);
+  if (this->offset_      != NULL) free(this->offset_);
+  if (this->virtualdims_ != NULL) free(this->virtualdims_);
+} 
+
 /** configureDims.
  * Setup any extra dimensions required for this dataset
  * \param[in] pArray - A pointer to an NDArray which contains dimension information.

--- a/ADApp/pluginSrc/NDFileHDF5Dataset.h
+++ b/ADApp/pluginSrc/NDFileHDF5Dataset.h
@@ -12,6 +12,7 @@ class NDFileHDF5Dataset
 {
   public:
     NDFileHDF5Dataset(asynUser *pAsynUser, const std::string& name, hid_t dataset);
+    virtual ~NDFileHDF5Dataset();
 
     asynStatus configureDims(NDArray *pArray, bool multiframe, int extradimensions, int *extra_dims, int *user_chunking);
     asynStatus extendDataSet(int extradims);

--- a/ADApp/pluginSrc/NDFileHDF5LayoutXML.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5LayoutXML.cpp
@@ -341,6 +341,7 @@ namespace hdf5
     attr_src = xmlTextReaderGetAttribute(this->xmlreader, (const xmlChar*)LayoutXML::ATTR_SOURCE.c_str());
     if (attr_src == NULL) return ret;
     str_attr_src = (char*)attr_src;
+    xmlFree(attr_src);
 
     if (str_attr_src == LayoutXML::ATTR_SRC_DETECTOR){
       out = DataSource( detector );
@@ -368,6 +369,7 @@ namespace hdf5
     attr_src = xmlTextReaderGetAttribute(this->xmlreader, (const xmlChar*)LayoutXML::ATTR_SOURCE.c_str());
     if (attr_src == NULL) return ret;
     str_attr_src = (char*)attr_src;
+    xmlFree(attr_src);
 
     std::string str_attr_val = "";
     xmlChar *attr_val = NULL;
@@ -380,11 +382,17 @@ namespace hdf5
     // Then setup the data source as a ndattribute with the name of the NDAttribute as argument value
     if (str_attr_src == LayoutXML::ATTR_SRC_NDATTR) {
       attr_val = xmlTextReaderGetAttribute(this->xmlreader, (const xmlChar*)LayoutXML::ATTR_SRC_NDATTR.c_str());
-      if (attr_val != NULL) str_attr_val = (char*)attr_val;
+      if (attr_val != NULL) {
+        str_attr_val = (char*)attr_val;
+        xmlFree(attr_val);
+      }
       out.source = DataSource( ndattribute, str_attr_val );
       // Check for a when="OnFileClose" or when="OnFileOpen" tag
       attr_when = xmlTextReaderGetAttribute(this->xmlreader, (const xmlChar*)LayoutXML::ATTR_SRC_WHEN.c_str());
-      if (attr_when != NULL) str_attr_when = (char*)attr_when;
+      if (attr_when != NULL) {
+        str_attr_when = (char*)attr_when;
+        xmlFree(attr_when);
+      }
       if (str_attr_when == "OnFileOpen"){
         out.source.set_when_to_save(OnFileOpen);
       } else if (str_attr_when == "OnFileClose"){
@@ -399,11 +407,15 @@ namespace hdf5
     // at least a int and float as well.
     else if (str_attr_src == LayoutXML::ATTR_SRC_CONST) {
       attr_val = xmlTextReaderGetAttribute(this->xmlreader, (const xmlChar*)LayoutXML::ATTR_SRC_CONST_VALUE.c_str());
-      if (attr_val != NULL) str_attr_val = (char*)attr_val;
+      if (attr_val != NULL) {
+        str_attr_val = (char*)attr_val;
+        free(attr_val);
+      }
       out.source = DataSource( constant, str_attr_val );
       attr_type = xmlTextReaderGetAttribute(this->xmlreader, (const xmlChar*)LayoutXML::ATTR_SRC_CONST_TYPE.c_str());
       if (attr_type != NULL) {
         str_attr_type = (char*)attr_type;
+        xmlFree(attr_type);
         DataType_t dtype = string;
         if (str_attr_type == "int") dtype = int32;
         else if (str_attr_type == "float") dtype = float64;
@@ -507,6 +519,7 @@ namespace hdf5
     if (dset_name == NULL) return -1;
 
     std::string str_dset_name((char*)dset_name);
+    xmlFree(dset_name);
     Group *parent = (Group *)this->ptr_curr_element;
     Dataset *dset = NULL;
     dset = parent->new_dset(str_dset_name);
@@ -519,6 +532,7 @@ namespace hdf5
     attr_def = xmlTextReaderGetAttribute(this->xmlreader, (const xmlChar*)LayoutXML::ATTR_SRC_DET_DEFAULT.c_str());
     if (attr_def != NULL){
       str_attr_def = (char*)attr_def;
+      xmlFree(attr_def);
       if (str_attr_def == "true"){
         detector_default = true;
       }
@@ -537,12 +551,14 @@ namespace hdf5
       attr_ndname = xmlTextReaderGetAttribute(this->xmlreader, (const xmlChar*)LayoutXML::ATTR_SRC_NDATTR.c_str());
       if (attr_ndname != NULL){
         str_attr_ndname = (char*)attr_ndname;
+        xmlFree(attr_ndname);
         dset->set_ndattr_name(str_attr_ndname);
         //if ndattribute, check for 'when' tag
         xmlChar *attr_when = NULL;
         attr_when = xmlTextReaderGetAttribute(this->xmlreader, (const xmlChar*)LayoutXML::ATTR_SRC_WHEN.c_str());
         if (attr_when != NULL){
           std::string str_attr_when( (char*)attr_when );
+          xmlFree(attr_when);
           When_t when_to_save = OnFrame; //Default is to save every frame
           if (str_attr_when == "OnFileOpen"){
             when_to_save = OnFileOpen;
@@ -555,10 +571,14 @@ namespace hdf5
     } else if (attrval.is_src_constant()){
       //if constant data
       c_val = xmlTextReaderGetAttribute(this->xmlreader, (const xmlChar*)LayoutXML::ATTR_SRC_CONST_VALUE.c_str());
-      if (c_val != NULL) str_val = (char*)c_val;
+      if (c_val != NULL) {
+        str_val = (char*)c_val;
+        xmlFree(c_val);
+      }
       c_type = xmlTextReaderGetAttribute(this->xmlreader, (const xmlChar*)LayoutXML::ATTR_SRC_CONST_TYPE.c_str());
       if (c_type != NULL){
         str_type = (char*)c_type;
+        xmlFree(c_type);
         DataType_t dtype = string;
         if (str_type == "int") dtype = int32;
         else if (str_type == "float") dtype = float64;
@@ -583,6 +603,7 @@ namespace hdf5
     if (ndattr_name == NULL) return -1;
 
     std::string str_ndattr_name((char*)ndattr_name);
+    xmlFree(ndattr_name);
     Attribute ndattr(str_ndattr_name);
     this->process_attribute_xml_attribute(ndattr);
 
@@ -598,12 +619,13 @@ namespace hdf5
     xmlChar *global_name = NULL;
     global_name = xmlTextReaderGetAttribute(this->xmlreader, (const xmlChar*)LayoutXML::ATTR_GLOBAL_NAME.c_str());
     if (global_name == NULL) return -1;
+    std::string str_global_name((char*)global_name);
+    xmlFree(global_name);
     xmlChar *global_value = NULL;
     global_value = xmlTextReaderGetAttribute(this->xmlreader, (const xmlChar*)LayoutXML::ATTR_GLOBAL_VALUE.c_str());
     if (global_value == NULL) return -1;
-
-    std::string str_global_name((char*)global_name);
     std::string str_global_value((char*)global_value);
+    xmlFree(global_value);
 
     this->globals[str_global_name] = str_global_value;
     return ret;
@@ -616,16 +638,17 @@ namespace hdf5
     xmlChar *hardlink_name = NULL;
     hardlink_name = xmlTextReaderGetAttribute(this->xmlreader, (const xmlChar*)LayoutXML::ATTR_ELEMENT_NAME.c_str());
     if (hardlink_name == NULL) return -1;
+    std::string str_hardlink_name((char*)hardlink_name);
+    xmlFree(hardlink_name);
     xmlChar *hardlink_target = NULL;
     hardlink_target = xmlTextReaderGetAttribute(this->xmlreader, (const xmlChar*)LayoutXML::ATTR_HARDLINK_TARGET.c_str());
     if (hardlink_target == NULL) return -1;
-
-    std::string str_hardlink_name((char*)hardlink_name);
+    const std::string str_hardlink_target((char*)hardlink_target);
+    xmlFree(hardlink_target);
     Group *parent = (Group *)this->ptr_curr_element;
     HardLink *hardlink = NULL;
     hardlink = parent->new_hardlink(str_hardlink_name);
     if (hardlink == NULL) return -1;
-    const std::string str_hardlink_target((char*)hardlink_target);
     hardlink->set_target(str_hardlink_target);
     return 0;
   }


### PR DESCRIPTION
This fixes the HDF5 leaks that I have found using valgrind.

1) The NDFileHDF5Dataset objects were being allocated with "new" into this->detDataMap, but were never being deleted.
2) epicsStrDup was being used which allocates memory that is never freed.  I don't think it was necessary to use epicsStrDup.
3) The NDFileHDF5AttrDataset destructor was not freeing memory that it explicitly allocated.
4) There was no explicit destructor for NDFileHD5Dataset.  It is needed because it needs to free memory it explicitly allocated.