### PR TITLE
fix memory leak by calling H5close() in NDFileHDF5::closeFile()

### DIFF
--- a/ADApp/pluginSrc/NDFileHDF5.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5.cpp
@@ -1658,10 +1658,20 @@ asynStatus NDFileHDF5::closeFile()
               "%s::%s Closing file not totally clean.  Attributes remaining=%d\n",
               driverName, functionName, obj_count);
   }
+  obj_count = (int)H5Fget_obj_count(this->file, H5F_OBJ_ALL);
+  if (obj_count > 0){
+    asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
+              "%s::%s Closing file not totally clean.  All remaining=%d\n",
+              driverName, functionName, obj_count);
+  }
 
   // Close the HDF file
   H5Fclose(this->file);
   this->file = 0;
+  // Flush all data to disk, close all open HDF5 objects,
+  // and clean up all memory used by the HDF5 library
+  // to avoid memory leaks
+  H5close();
 
   // At this point we can clear the SWMR active flag, whether we were running
   // in SWMR mode or not

--- a/ADApp/pluginSrc/NDFileHDF5.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5.cpp
@@ -2765,6 +2765,9 @@ asynStatus NDFileHDF5::createAttributeDataset(NDArray *pArray)
   if(def_group != NULL){
     H5Gclose(groupDefault);
   }
+  if (numCapture) {
+    free(numCapture);
+  }
 
   return asynSuccess;
 }

--- a/ADApp/pluginSrc/NDFileHDF5.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5.cpp
@@ -1659,9 +1659,9 @@ asynStatus NDFileHDF5::closeFile()
               driverName, functionName, obj_count);
   }
   obj_count = (int)H5Fget_obj_count(this->file, H5F_OBJ_ALL);
-  if (obj_count > 0){
+  if (obj_count > 1){
     asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
-              "%s::%s Closing file not totally clean.  All remaining=%d\n",
+              "%s::%s Closing file not totally clean.  Other remaining=%d\n",
               driverName, functionName, obj_count);
   }
 

--- a/ADApp/pluginSrc/NDFileHDF5.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5.cpp
@@ -2699,7 +2699,7 @@ asynStatus NDFileHDF5::createAttributeDataset(NDArray *pArray)
       // In here we need to open the dataset for writing
 
       hdf5::DataSource dsource = dset->data_source();
-      std::string atName = std::string(epicsStrDup(ndAttr->getName()));
+      std::string atName = std::string(ndAttr->getName());
       NDFileHDF5AttributeDataset *attDset = new NDFileHDF5AttributeDataset(this->file, atName, ndAttr->getDataType());
       attDset->setDsetName(dset->get_name());
       attDset->setWhenToSave(dsource.get_when_to_save());


### PR DESCRIPTION
This a change to fix memory leak in the HDF5 plugin, see #385.

Warning!

It appears that calling `H5close()` after `H5Fclose()` plugs the hole, but the core source of the the leak might still be at large!