### PR TITLE
Travis: run unittest through valgrind

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,10 @@ before_install:
 install:
 - make
 script:
-- "./bin/linux-x86_64/plugin-test --log_level=test_suite"
+- "valgrind --leak-check=yes --log-file=valgrind_output.txt ./bin/linux-x86_64/plugin-test --log_level=test_suite"
 after_success:
 - sh ci/coverage.sh
 - coveralls-lcov --source-encoding=ISO-8859-1 ci/coverage.info
+- tail --lines 15 valgrind_output.txt
 notifications:
   slack: epicsareadetector:xf0ac8PfwqcSqi2gE0tUcUkP

--- a/ci/install-packages.sh
+++ b/ci/install-packages.sh
@@ -101,6 +101,7 @@ if [[ $XML2_EXTERNAL == "YES" ]]; then
   sudo apt-get install libxml2-dev
 fi
 
+sudo apt-get install valgrind
 # TO DO: Install ZLIB, SZIP, JPEG, NEXUS, NETCDF if we want to use package versions
 
 # Installing latest version of code coverage tool lcov (because the ubuntu package is very old)


### PR DESCRIPTION
Running unittest on Travis CI through valgrind for automatic memory checks.

This is a bit of a crude attempt to get memory/leak checks into the CI - consider this PR a discussion point for now.

Initial attempt does:
* Runs the unittest through valgrind, outputting report to a local text file.
* Prints (with tail) the last few lines of the valgrind report (i.e. the summary)

This obviously isn't the same as running an IOC - but is it good enough to get an idea if a new change (i.e. a PR) leaks?

Is the valgrind report useful in its current state? Should we do more to parse the resulting report? Add any other options to the valgrind command to show other details?
