### PR TITLE
remove H5close call, introduce specific hdf5 object H5xclose calls

### DIFF
--- a/ADApp/pluginSrc/NDFileHDF5.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5.cpp
@@ -584,6 +584,9 @@ asynStatus NDFileHDF5::storeOnOpenCloseAttribute(hdf5::Element *element, bool op
                   asynPrint(this->pasynUserSelf, ASYN_TRACE_WARNING, "%s::%s unable to create attribute: %s\n",
                             driverName, functionName, attr.get_name().c_str());
                   H5Sclose(hdfattrdataspace);
+                  // HK test
+                  H5Tclose(hdfdatatype);
+                  // HK test
                 } else {
                   herr_t hdfstatus = H5Awrite(hdfattr, hdfdatatype, datavalue);
                   if (hdfstatus < 0) {
@@ -592,6 +595,9 @@ asynStatus NDFileHDF5::storeOnOpenCloseAttribute(hdf5::Element *element, bool op
                   }
                   H5Aclose(hdfattr);
                   H5Sclose(hdfattrdataspace);
+                  // HK test
+                  H5Tclose(hdfdatatype);
+                  // HK test
                 }
               } else if(dataType == NDAttrString){
                 // This is a string attribute
@@ -655,6 +661,7 @@ asynStatus NDFileHDF5::createTree(hdf5::Group* root, hid_t h5handle)
       hid_t new_dset = this->createDataset(new_group, it_dsets->second);
       if (new_dset <= 0) {
         hdf5::Dataset *dset = it_dsets->second;
+        // HK I can see messages: Failed to create dataset: timestamp. Continuing to next.
         asynPrint(this->pasynUserSelf, ASYN_TRACE_WARNING,
                   "%s::%s Failed to create dataset: %s. Continuing to next.\n",
                   driverName, functionName, dset->get_name().c_str());
@@ -878,6 +885,9 @@ hid_t NDFileHDF5::writeH5dsetInt32(hid_t element, const std::string &name, const
       asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR, "%s::%s unable to create dataset: %s\n",
                 driverName, functionName, name.c_str());
       H5Sclose(hdfdataspace);
+      // HK test
+      H5Tclose(hdfdatatype);
+      // HK test
       return -1;
     }
     epicsInt32 ival;
@@ -888,6 +898,9 @@ hid_t NDFileHDF5::writeH5dsetInt32(hid_t element, const std::string &name, const
                 driverName, functionName, name.c_str());
       H5Dclose(hdfdset);
       H5Sclose(hdfdataspace);
+      // HK test
+      H5Tclose(hdfdatatype);
+      // HK test
       return -1;
     }
   } else {
@@ -901,6 +914,9 @@ hid_t NDFileHDF5::writeH5dsetInt32(hid_t element, const std::string &name, const
     for (int index = 0; index < (int)vect.size(); index++){
       ivalues[index] = vect[index];
     }
+    // HK test
+    H5Sclose(hdfdataspace);
+    // HK test
     hdfdataspace = H5Screate(H5S_SIMPLE);
     H5Sset_extent_simple(hdfdataspace, 1, dims, NULL);
     hdfdset = H5Dcreate2(element, name.c_str(), hdfdatatype, hdfdataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
@@ -909,6 +925,9 @@ hid_t NDFileHDF5::writeH5dsetInt32(hid_t element, const std::string &name, const
       asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR, "%s::%s unable to create dataset: %s\n",
                 driverName, functionName, name.c_str());
       H5Sclose(hdfdataspace);
+      // HK test
+      H5Tclose(hdfdatatype);
+      // HK test
       return -1;
     }
     hdfstatus = H5Dwrite(hdfdset, hdfdatatype, H5S_ALL, H5S_ALL, H5P_DEFAULT, ivalues);
@@ -918,11 +937,17 @@ hid_t NDFileHDF5::writeH5dsetInt32(hid_t element, const std::string &name, const
                 driverName, functionName, name.c_str());
       H5Dclose (hdfdset);
       H5Sclose(hdfdataspace);
+      // HK test
+      H5Tclose(hdfdatatype);
+      // HK test
       return -1;
     }
   }
   //H5Dclose (hdfdset);
   H5Sclose(hdfdataspace);
+  // HK test
+  H5Tclose(hdfdatatype);
+  // HK test
   return hdfdset;
 
 }
@@ -959,6 +984,9 @@ hid_t NDFileHDF5::writeH5dsetFloat64(hid_t element, const std::string &name, con
       asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR, "%s::%s unable to create dataset: %s\n",
                 driverName, functionName, name.c_str());
       H5Sclose(hdfdataspace);
+      // HK test
+      H5Tclose(hdfdatatype);
+      // HK test
       return -1;
     }
     double fval;
@@ -969,6 +997,9 @@ hid_t NDFileHDF5::writeH5dsetFloat64(hid_t element, const std::string &name, con
                 driverName, functionName, name.c_str());
       H5Dclose (hdfdset);
       H5Sclose(hdfdataspace);
+      // HK test
+      H5Tclose(hdfdatatype);
+      // HK test
       return -1;
     }
   } else {
@@ -982,6 +1013,9 @@ hid_t NDFileHDF5::writeH5dsetFloat64(hid_t element, const std::string &name, con
     for (int index = 0; index < (int)vect.size(); index++){
       fvalues[index] = vect[index];
     }
+    // HK test
+    H5Sclose(hdfdataspace);
+    // HK test
     hdfdataspace = H5Screate(H5S_SIMPLE);
     H5Sset_extent_simple(hdfdataspace, 1, dims, NULL);
     hdfdset = H5Dcreate2(element, name.c_str(), hdfdatatype, hdfdataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
@@ -990,6 +1024,9 @@ hid_t NDFileHDF5::writeH5dsetFloat64(hid_t element, const std::string &name, con
       asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR, "%s::%s unable to create dataset: %s\n",
                 driverName, functionName, name.c_str());
       H5Sclose(hdfdataspace);
+      // HK test
+      H5Tclose(hdfdatatype);
+      // HK test
       return -1;
     }
     hdfstatus = H5Dwrite(hdfdset, hdfdatatype, H5S_ALL, H5S_ALL, H5P_DEFAULT, fvalues);
@@ -999,11 +1036,17 @@ hid_t NDFileHDF5::writeH5dsetFloat64(hid_t element, const std::string &name, con
                 driverName, functionName, name.c_str());
       H5Dclose(hdfdset);
       H5Sclose(hdfdataspace);
+      // HK test
+      H5Tclose(hdfdatatype);
+      // HK test
       return -1;
     }
   }
   //H5Dclose (hdfdset);
   H5Sclose(hdfdataspace);
+  // HK test
+  H5Tclose(hdfdatatype);
+  // HK test
   return hdfdset;
 
 }
@@ -1056,6 +1099,9 @@ void NDFileHDF5::writeH5attrStr(hid_t element, const std::string &attr_name, con
     asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR, "%s::%s unable to create attribute: %s\n",
               driverName, functionName, attr_name.c_str());
     H5Sclose(hdfattrdataspace);
+    // HK OK
+    H5Tclose(hdfdatatype);
+    // HK OK
     return;
   }
 
@@ -1065,10 +1111,16 @@ void NDFileHDF5::writeH5attrStr(hid_t element, const std::string &attr_name, con
               driverName, functionName, attr_name.c_str());
     H5Aclose (hdfattr);
     H5Sclose(hdfattrdataspace);
+    // HK OK
+    H5Tclose(hdfdatatype);
+    // HK OK
     return;
   }
   H5Aclose (hdfattr);
   H5Sclose(hdfattrdataspace);
+  // HK OK
+  H5Tclose(hdfdatatype);
+  // HK OK
   return;
 }
 
@@ -1130,6 +1182,9 @@ void NDFileHDF5::writeH5attrInt32(hid_t element, const std::string &attr_name, c
     for (int index = 0; index < (int)vect.size(); index++){
       ivalues[index] = vect[index];
     }
+    // HK OK
+    H5Sclose(hdfattrdataspace);
+    // HK OK
     hdfattrdataspace = H5Screate(H5S_SIMPLE);
     H5Sset_extent_simple(hdfattrdataspace, 1, dims, NULL);
     hdfattr = H5Acreate2(element, attr_name.c_str(), hdfdatatype, hdfattrdataspace, H5P_DEFAULT, H5P_DEFAULT);
@@ -1152,6 +1207,9 @@ void NDFileHDF5::writeH5attrInt32(hid_t element, const std::string &attr_name, c
   }
   H5Aclose (hdfattr);
   H5Sclose(hdfattrdataspace);
+  // HK OK
+  H5Tclose(hdfdatatype);
+  // HK OK
   return;
 }
 
@@ -1213,6 +1271,9 @@ void NDFileHDF5::writeH5attrFloat64(hid_t element, const std::string &attr_name,
     for (int index = 0; index < (int)vect.size(); index++){
       fvalues[index] = vect[index];
     }
+    // HK OK
+    H5Sclose(hdfattrdataspace);
+    // HK OK
     hdfattrdataspace = H5Screate(H5S_SIMPLE);
     H5Sset_extent_simple(hdfattrdataspace, 1, dims, NULL);
     hdfattr = H5Acreate2(element, attr_name.c_str(), hdfdatatype, hdfattrdataspace, H5P_DEFAULT, H5P_DEFAULT);
@@ -1235,6 +1296,9 @@ void NDFileHDF5::writeH5attrFloat64(hid_t element, const std::string &attr_name,
   }
   H5Aclose (hdfattr);
   H5Sclose(hdfattrdataspace);
+  // HK OK
+  H5Tclose(hdfdatatype);
+  // HK OK
   return;
 }
 
@@ -1301,6 +1365,10 @@ hid_t NDFileHDF5::createDatasetDetector(hid_t group, hdf5::Dataset *dset)
             driverName, functionName, dsetname);
   dataset = H5Dcreate2(group, dsetname, this->datatype, this->dataspace,
                        H5P_DEFAULT, this->cparms, dset_access_plist);
+  
+  // HK OK
+  H5Pclose(dset_access_plist);
+  // HK OK
 
   // Store the dataset into the detector dataset map
   this->detDataMap[dset->get_full_name()] = new NDFileHDF5Dataset(this->pasynUserSelf, dset->get_name(), dataset);
@@ -1522,6 +1590,8 @@ asynStatus NDFileHDF5::writeFile(NDArray *pArray)
     }
     if (status != asynSuccess){
       flushLock.unlock();
+      // HK is this a memory leak?
+      // compared to a couple of lines above where more is closed???
       return status;
     }
   }
@@ -1551,6 +1621,8 @@ asynStatus NDFileHDF5::writeFile(NDArray *pArray)
   }
 
   if (status != asynSuccess){
+    // HK is this a memory leak?
+    // compared to a couple of lines above where more is closed???
     hdfstatus = H5Fclose(this->file);
     if (hdfstatus){
       asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
@@ -1625,8 +1697,16 @@ asynStatus NDFileHDF5::closeFile()
   H5Tclose(this->datatype);
 
   asynPrint(this->pasynUserSelf, ASYN_TRACE_FLOW, 
+            "%s::%s closing HDF dataspace %ld\n", 
+            driverName, functionName, (long int)this->datatype);
+
+  //HK OK
+  H5Sclose(this->dataspace);
+
+  asynPrint(this->pasynUserSelf, ASYN_TRACE_FLOW, 
             "%s::%s closing groups\n", 
             driverName, functionName);
+  //HK OK
 
   // Iterate over the stored detector data sets and close them
   std::map<std::string, NDFileHDF5Dataset *>::iterator it_dset;
@@ -1668,10 +1748,6 @@ asynStatus NDFileHDF5::closeFile()
   // Close the HDF file
   H5Fclose(this->file);
   this->file = 0;
-  // Flush all data to disk, close all open HDF5 objects,
-  // and clean up all memory used by the HDF5 library
-  // to avoid memory leaks
-  H5close();
 
   // At this point we can clear the SWMR active flag, whether we were running
   // in SWMR mode or not
@@ -2561,12 +2637,18 @@ asynStatus NDFileHDF5::createPerformanceDataset()
     if (!H5Iis_valid(this->perf_dataset_id)) {
         asynPrint(this->pasynUserSelf, ASYN_TRACE_WARNING, "NDFileHDF5::writePerformanceDataset: unable to create \'timestamp\' dataset.");
         H5Sclose(dataspace_id);
+        // HK OK
+        H5Pclose(hdfcparm);
+        // HK OK
         if(perf_group != NULL){
           H5Gclose(group_performance);
         }
         return asynError;
     }
     H5Sclose(dataspace_id);
+    // HK OK
+    H5Pclose(hdfcparm);
+    // HK OK
     if(perf_group != NULL){
       H5Gclose(group_performance);
     }
@@ -2940,6 +3022,9 @@ asynStatus NDFileHDF5::writeStringAttribute(hid_t element, const char * attrName
     H5Awrite(hdfattr, hdfdatatype, attrStrValue);
     H5Aclose(hdfattr);
     H5Sclose(hdfattrdataspace);
+    // HK OK
+    H5Tclose(hdfdatatype);
+    // HK OK
   }
   return status;
 }
@@ -3679,8 +3764,16 @@ asynStatus NDFileHDF5::createNewFile(const char *fileName)
               "%s::%s Unable to create HDF5 file: %s\n", 
               driverName, functionName, fileName);
     this->file = 0;
+    //HK OK
+    H5Pclose(create_plist);
+    H5Pclose(access_plist);
+    //HK OK
     return asynError;
   }
+  //HK OK
+  H5Pclose(create_plist);
+  H5Pclose(access_plist);
+  //HK OK
   return asynSuccess;
 }
 

--- a/ADApp/pluginSrc/NDFileHDF5AttributeDataset.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5AttributeDataset.cpp
@@ -219,6 +219,11 @@ asynStatus NDFileHDF5AttributeDataset::closeAttributeDataset()
   H5Sclose(memspace_);
   H5Sclose(dataspace_);
   H5Pclose(cparm_);
+  // HK test
+  if (type_ == NDAttrString) {
+    H5Tclose(datatype_);
+  }
+  // HK test
   return asynSuccess;
 }
 

--- a/ADApp/pluginSrc/NDFileHDF5Dataset.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5Dataset.cpp
@@ -267,6 +267,9 @@ asynStatus NDFileHDF5Dataset::writeFile(NDArray *pArray, hid_t datatype, hid_t d
     asynPrint(this->pAsynUser_, ASYN_TRACE_ERROR, 
               "%s::%s ERROR Unable to select hyperslab\n", 
               fileName, functionName);
+    // HK test
+    H5Sclose(fspace);
+    // HK test
     return asynError;
   }
 
@@ -297,6 +300,9 @@ asynStatus NDFileHDF5Dataset::writeFile(NDArray *pArray, hid_t datatype, hid_t d
       asynPrint(this->pAsynUser_, ASYN_TRACE_ERROR,
                 "%s::%s ERROR Unable to write pre-compressed data - mismatched chunk definition\n",
                 fileName, functionName);
+      // HK test
+      H5Sclose(fspace);
+      // HK test
       return asynError;
     }
     asynPrint(this->pAsynUser_, ASYN_TRACE_FLOW,
@@ -309,6 +315,9 @@ asynStatus NDFileHDF5Dataset::writeFile(NDArray *pArray, hid_t datatype, hid_t d
     asynPrint(this->pAsynUser_, ASYN_TRACE_ERROR, 
               "%s::%s ERROR Unable to write data to hyperslab\n", 
               fileName, functionName);
+    // HK test
+    H5Sclose(fspace);
+    // HK test
     return asynError;
   }
 

--- a/ADApp/pluginSrc/NDFileHDF5Layout.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5Layout.cpp
@@ -311,6 +311,9 @@ namespace hdf5
   {
     for_each(this->datasets.begin(), this->datasets.end(), _delete_obj<Dataset>);
     for_each(this->groups.begin(), this->groups.end(), _delete_obj<Group>);
+    // HK verify should this be done? Causes segfault..
+    // for_each(this->hardlinks.begin(), this->hardlinks.end(), _delete_obj<HardLink>);
+    // HK verify should this be done?
   }
 
   Group& Group::operator=(const Group& src)
@@ -372,7 +375,12 @@ namespace hdf5
     std::pair<std::map<std::string, Group*>::iterator,bool> ret;
     ret = this->groups.insert(std::pair<std::string, Group*>(name, grp));
     // Check for successful insertion.
-    if (ret.second == false) return NULL;
+    if (ret.second == false) {
+      // HK test
+      delete grp;
+      // HK test
+      return NULL;
+    }
     return grp;
   }
 
@@ -402,7 +410,12 @@ namespace hdf5
     std::pair<std::map<std::string, HardLink*>::iterator,bool> ret;
     ret = this->hardlinks.insert(std::pair<std::string, HardLink*>(name, hardlink));
     // Check for successful insertion.
-    if (ret.second == false) return NULL;
+    if (ret.second == false) {
+      // HK test
+      delete hardlink;
+      // HK test
+      return NULL;
+    }
     return hardlink;
   }
 

--- a/ADApp/pluginSrc/NDFileHDF5LayoutXML.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5LayoutXML.cpp
@@ -408,7 +408,9 @@ namespace hdf5
       attr_val = xmlTextReaderGetAttribute(this->xmlreader, (const xmlChar*)LayoutXML::ATTR_SRC_CONST_VALUE.c_str());
       if (attr_val != NULL) {
         str_attr_val = (char*)attr_val;
-        free(attr_val);
+        // HK test
+        xmlFree(attr_val);
+        // HK test
       }
       out.source = DataSource( constant, str_attr_val );
       attr_type = xmlTextReaderGetAttribute(this->xmlreader, (const xmlChar*)LayoutXML::ATTR_SRC_CONST_TYPE.c_str());


### PR DESCRIPTION
The initial fix for memory leaks that added a call to H5close() was not proper. It caused IOC crashes if two HDF5 plugin instances were used (https://github.com/areaDetector/ADCore/pull/390#issuecomment-479606488).

This set of changes removes the call to H5close() and adds localized resource freeing that should result in no memory leaks.

I added comments to the code paths that I've seen taken (`// HK OK`). Some other cases I did not test or verify (i.e. error branches) and for those the comment reads `// HK test`.

Someone needs to go over my changes and verify the correctness.