### PR TITLE
Adding opencv_video and opencv_videoio as dependancy libs for ADCompVision

### DIFF
--- a/ADApp/commonDriverMakefile
+++ b/ADApp/commonDriverMakefile
@@ -245,9 +245,9 @@ ifdef ADCOMPVISION
   PROD_LIBS     += NDPluginCV
   ifdef OPENCV_LIB
     opencv_core_DIR += $(OPENCV_LIB)
-    PROD_LIBS       += opencv_core opencv_imgproc opencv_highgui
+    PROD_LIBS       += opencv_core opencv_imgproc opencv_highgui opencv_video opencv_videoio
   else
-    PROD_SYS_LIBS   += opencv_core opencv_imgproc opencv_highgui
+    PROD_SYS_LIBS   += opencv_core opencv_imgproc opencv_highgui opencv_video opencv_videoio
   endif 
 endif
 


### PR DESCRIPTION
I have been working on the R1-2 release of ADCompVision which adds support for saving videos from areaDetector cameras (timelapses, recordings, etc.) This requires opencv_video and opencv_videoio libraries to be linked during build, so these libs have been added to the ADCompVision call in commonDriverMakefile