### PR TITLE
Added CCDMulti-track as a capability for use by CCD camera types (And…

### DIFF
--- a/ADApp/ADSrc/CCDMultiTrack.cpp
+++ b/ADApp/ADSrc/CCDMultiTrack.cpp
@@ -1,0 +1,128 @@
+/**
+ * Area Detector class enabling multi-ROI driver for the Andor CCD.
+ * This class is used by CCD camera modules that permit multiple regions-of-interest.
+ *
+ * Multi-ROI is typically used for multi-track spectrocopy application.
+ *
+ * There are 3 use cases:
+ *    1 - The user sets only the track start array.
+ *        This provides a single height track at thos positions.
+ *    2 - The user sets the start and end tracks arrays.
+ *        This provides a fully-binned track between the start and end positions.
+ *    3 - The user provides start, end and binning values.
+ *        This provides (a less than fully binned) track between the start and end positions.
+ *
+ * @author Peter Heesterman
+ * @date Nov 2019
+ *
+ */
+#include <asynPortDriver.h>
+
+#include <epicsExport.h>
+#include "CCDMultiTrack.h"
+
+static const char* CCDMultiTrackStartString = "CCD_MULTI_TRACK_START";
+static const char* CCDMultiTrackEndString = "CCD_MULTI_TRACK_END";
+static const char* CCDMultiTrackBinString = "CCD_MULTI_TRACK_BIN";
+
+CCDMultiTrack::CCDMultiTrack(asynPortDriver* asynPortDriver)
+{
+    mPortDriver = asynPortDriver;
+    asynPortDriver->createParam(CCDMultiTrackStartString, asynParamInt32Array, &mCCDMultiTrackStart);
+    asynPortDriver->createParam(CCDMultiTrackEndString, asynParamInt32Array, &mCCDMultiTrackEnd);
+    asynPortDriver->createParam(CCDMultiTrackBinString, asynParamInt32Array, &mCCDMultiTrackBin);
+}
+
+void CCDMultiTrack::writeTrackStart(epicsInt32 *value, size_t nElements)
+{
+    mTrackStart.resize(nElements);
+    for (size_t TrackNum = 0; TrackNum < mTrackStart.size(); TrackNum++)
+    {
+        if (value[TrackNum] < 1)
+            throw std::string("Tracks starts must be >= 1");
+        if ((TrackNum > 0) && (value[TrackNum] <= TrackStart(TrackNum - 1)))
+            throw std::string("Tracks starts must be in ascending order");
+        /* Copy the new data */
+        mTrackStart[TrackNum] = value[TrackNum];
+    }
+    std::vector<int> TrackEnd(mTrackStart.size());
+    /* If binning is already set, this can define the track end. */
+    for (size_t TrackNum = 0; TrackNum < TrackEnd.size(); TrackNum++)
+        TrackEnd[TrackNum] = TrackStart(TrackNum) + TrackBin(TrackNum);
+    std::vector<int> TrackBin(mTrackStart.size());
+    /* If track end is already set, this can define the binning. */
+    for (size_t TrackNum = 0; TrackNum < TrackBin.size(); TrackNum++)
+        TrackBin[TrackNum] = TrackHeight(TrackNum);
+    if (mTrackEnd != TrackEnd)
+    {
+        mTrackEnd = TrackEnd;
+        mPortDriver->doCallbacksInt32Array(&(mTrackEnd[0]), mTrackEnd.size(), CCDMultiTrackEnd(), 0);
+    }
+    if (mTrackBin != TrackBin)
+    {
+        mTrackBin = TrackBin;
+        mPortDriver->doCallbacksInt32Array(&(mTrackBin[0]), mTrackBin.size(), CCDMultiTrackBin(), 0);
+    }
+}
+
+void CCDMultiTrack::writeTrackEnd(epicsInt32 *value, size_t nElements)
+{
+    mTrackEnd.resize(nElements);
+    for (size_t TrackNum = 0; TrackNum < mTrackEnd.size(); TrackNum++)
+    {
+        if (value[TrackNum] < 2)
+            throw std::string("Tracks ends must be >= 2");
+        if ((TrackNum > 0) && (value[TrackNum] <= TrackEnd(TrackNum - 1)))
+            throw std::string("Tracks ends must be in ascending order");
+        /* Copy the new data */
+        mTrackEnd[TrackNum] = value[TrackNum];
+    }
+    std::vector<int> TrackBin(mTrackEnd.size());
+    /* If track start is already set, this can define the binning */
+    for (size_t TrackNum = 0; TrackNum < TrackBin.size(); TrackNum++)
+        TrackBin[TrackNum] = TrackHeight(TrackNum);
+    if (mTrackBin != TrackBin)
+    {
+        mTrackBin = TrackBin;
+        mPortDriver->doCallbacksInt32Array(&(mTrackBin[0]), mTrackBin.size(), CCDMultiTrackBin(), 0);
+    }
+}
+
+void CCDMultiTrack::writeTrackBin(epicsInt32 *value, size_t nElements)
+{
+    mTrackBin.resize(nElements);
+    for (size_t TrackNum = 0; TrackNum < mTrackBin.size(); TrackNum++)
+    {
+        if (value[TrackNum] < 1)
+            throw std::string("The track binning must be >= 1.");
+        if (TrackHeight(TrackNum) % value[TrackNum] != 0)
+            throw std::string("Track height must be divisible by binning.");
+        /* Copy the new data */
+        mTrackBin[TrackNum] = value[TrackNum];
+    }
+}
+
+asynStatus CCDMultiTrack::writeInt32Array(asynUser *pasynUser, epicsInt32 *value, size_t nElements)
+{
+    int function = pasynUser->reason;
+    asynStatus status = asynSuccess;
+
+    if (function == CCDMultiTrackStart())
+        writeTrackStart(value, nElements);
+    else if (function == CCDMultiTrackEnd())
+        writeTrackEnd(value, nElements);
+    else if (function == CCDMultiTrackBin())
+        writeTrackBin(value, nElements);
+    else {
+        status = asynError;
+    }
+    return status;
+}
+
+int CCDMultiTrack::DataHeight() const
+{
+    int DataHeight = 0;
+    for (size_t TrackNum = 0; TrackNum < size(); TrackNum++)
+        DataHeight += CCDMultiTrack::DataHeight(TrackNum);
+    return DataHeight;
+}

--- a/ADApp/ADSrc/CCDMultiTrack.h
+++ b/ADApp/ADSrc/CCDMultiTrack.h
@@ -1,0 +1,71 @@
+/**
+ * Area Detector class enabling multi-ROI driver for the Andor CCD.
+ * This class is used by CCD camera modules that permit multiple regions-of-interest.
+ *
+ * Multi-ROI is typically used for multi-track spectrocopy application.
+ *
+ * @author Peter Heesterman
+ * @date Nov 2019
+ *
+ */
+#ifndef CCD_MULTI_TRACK_H
+#define CCD_MULTI_TRACK_H
+
+#include <asynPortDriver.h>
+#include <shareLib.h>
+
+class epicsShareClass CCDMultiTrack
+{
+    asynPortDriver* mPortDriver;
+
+    int mCCDMultiTrackStart;
+    int mCCDMultiTrackEnd;
+    int mCCDMultiTrackBin;
+
+    std::vector<int> mTrackStart;
+    std::vector<int> mTrackEnd;
+    std::vector<int> mTrackBin;
+
+public:
+    size_t size() const {
+        return mTrackStart.size();
+    }
+    int CCDMultiTrackStart() const {
+        return mCCDMultiTrackStart;
+    }
+    int CCDMultiTrackEnd() const {
+        return mCCDMultiTrackEnd;
+    }
+    int CCDMultiTrackBin() const {
+        return mCCDMultiTrackBin;
+    }
+    int TrackStart(size_t TrackNum) const {
+        return (TrackNum < mTrackStart.size()) ? mTrackStart[TrackNum] : 0;
+    };
+    int TrackEnd(size_t TrackNum) const {
+        return (TrackNum < mTrackEnd.size()) ? mTrackEnd[TrackNum] : TrackStart(TrackNum)+1;
+    }
+    int TrackHeight(size_t TrackNum) const {
+        return TrackEnd(TrackNum) - TrackStart(TrackNum);
+    }
+    int TrackBin(size_t TrackNum) const {
+        return (TrackNum < mTrackBin.size()) ? mTrackBin[TrackNum] : TrackHeight(TrackNum);
+    }
+    int DataHeight() const;
+    int DataHeight(size_t TrackNum) const {
+        return TrackHeight(TrackNum) / TrackBin(TrackNum);
+    }
+
+
+    CCDMultiTrack(asynPortDriver* asynPortDriver);
+    asynStatus writeInt32Array(asynUser *pasynUser, epicsInt32 *value, size_t nElements);
+
+private:
+    void writeTrackStart(epicsInt32 *value, size_t nElements);
+    void writeTrackEnd(epicsInt32 *value, size_t nElements);
+    void writeTrackBin(epicsInt32 *value, size_t nElements);
+
+
+};
+
+#endif //CCD_MULTI_TRACK_H

--- a/ADApp/ADSrc/Makefile
+++ b/ADApp/ADSrc/Makefile
@@ -30,6 +30,7 @@ INC += paramAttribute.h
 INC += functAttribute.h
 INC += asynNDArrayDriver.h
 INC += ADDriver.h
+INC += CCDMultiTrack.h
 
 LIBRARY_IOC = ADBase
 LIB_SRCS += NDAttribute.cpp
@@ -39,6 +40,8 @@ LIB_SRCS += NDArray.cpp
 LIB_SRCS += asynNDArrayDriver.cpp
 LIB_SRCS += ADDriver.cpp
 LIB_SRCS += paramAttribute.cpp
+LIB_SRCS += CCDMultiTrack.cpp
+
 ifeq ($(EPICS_LIBCOM_ONLY),YES)
   USR_CXXFLAGS += -DEPICS_LIBCOM_ONLY
 else

--- a/ADApp/Db/CCDMultiTrack.template
+++ b/ADApp/Db/CCDMultiTrack.template
@@ -1,0 +1,33 @@
+# Track definition for CCD multi-track defintions./
+# Each track is a rectangular ROI defined by start and end coordinates.
+# Binning may also be applied - usually (but not always) the track is fully-binned.
+# This hardware capability of a CCD is available for certain camera types:
+#   Andor, Princeton Instruments and Photometrics.
+#
+# Peter Heesterman, UKAEA
+# October 2019
+
+include "ADBase.template"
+
+record(waveform, "$(P)$(R)CCDMultiTrackStart")
+{
+    field(DTYP, "asynInt32ArrayOut")
+    field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))CCD_MULTI_TRACK_START")
+    field(FTVL, "LONG")
+    field(NELM, "50")
+}
+record(waveform, "$(P)$(R)CCDMultiTrackEnd")
+{
+    field(DTYP, "asynInt32ArrayOut")
+    field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))CCD_MULTI_TRACK_END")
+    field(FTVL, "LONG")
+    field(NELM, "50")
+}
+record(waveform, "$(P)$(R)CCDMultiTrackBin")
+{
+    field(DTYP, "asynInt32ArrayOut")
+    field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))CCD_MULTI_TRACK_BIN")
+    field(FTVL, "LONG")
+    field(NELM, "50")
+}
+

--- a/ADApp/Db/CCDMultiTrack_settings.req
+++ b/ADApp/Db/CCDMultiTrack_settings.req
@@ -1,0 +1,3 @@
+$(P)$(R)CCDMultiTrackStart
+$(P)$(R)CCDMultiTrackEnd
+$(P)$(R)CCDMultiTrackBin

--- a/ADApp/Db/Makefile
+++ b/ADApp/Db/Makefile
@@ -15,6 +15,7 @@ include $(TOP)/configure/CONFIG
 DB += NDArrayBase.template
 DB += ADBase.template
 DB += ADPrefixes.template
+DB += CCDMultiTrack.template
 
 # Plugins
 DB += NDAttribute.template

--- a/ADApp/pluginSrc/Makefile
+++ b/ADApp/pluginSrc/Makefile
@@ -10,6 +10,11 @@ DBD         += NDPluginSupport.dbd
 # Persuade travis (ubuntu 12.04) to use HDF5 API V2 (1.8 rather than default 1.6)
 USR_CXXFLAGS_Linux += -DH5_NO_DEPRECATED_SYMBOLS -DH5Gopen_vers=2
 
+ifneq ($(SHARED_LIBRARIES), YES)
+   USR_CFLAGS_WIN32 += -DLIBXML_STATIC
+   USR_CXXFLAGS_WIN32 += -DLIBXML_STATIC
+endif
+
 INC      += NDPluginDriver.h
 LIB_SRCS += NDPluginDriver.cpp
 LIB_SRCS += throttler.cpp

--- a/ADApp/pluginSrc/NDFileHDF5LayoutXML.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5LayoutXML.cpp
@@ -20,11 +20,6 @@
 #ifdef __MINGW32__
   #define xmlFree free
 #endif
-// Also a problem in Visual Studio.  The warning is:
-// warning LNK4217: locally defined symbol xmlFree imported in function "private: int __cdecl hdf5::LayoutXML::parse_root(void)" 
-#ifdef _MSC_VER
-  #define xmlFree free
-#endif
 
 namespace hdf5
 {
@@ -465,7 +460,7 @@ namespace hdf5
     //LOG4CXX_DEBUG(log, "  new_group: " << group_name );
     if (group_name == NULL) return -1;
 
-    std::string str_group_name((char*)group_name);
+    std::string str_group_name((const char*)group_name);
     xmlFree(group_name);
 
     // Initialise the tree if it has not already been done.


### PR DESCRIPTION
…or, Princeton, Photometrics) that enable this usage.

Also, addressed issue #420 relating to static builds on Windows.