### PR TITLE
Added the creation of NDAttributes that describe how the multi-track …

### DIFF
--- a/ADApp/ADSrc/CCDMultiTrack.cpp
+++ b/ADApp/ADSrc/CCDMultiTrack.cpp
@@ -42,7 +42,8 @@ void CCDMultiTrack::storeTrackAttributes(NDAttributeList* pAttributeList)
         for (size_t TrackNum = 0; TrackNum < size(); TrackNum++)
         {
             // Add new attributes listing.
-            std::string TrackNumString = std::to_string(TrackNum + 1);
+            char Buf[10];
+            std::string TrackNumString = _itoa(TrackNum + 1, Buf, 10);
             std::string TrackStartName = ROIString + TrackNumString + "start";
             std::string TrackStartDescription = TrackString + TrackNumString + " start";
             int TrackStart = CCDMultiTrack::TrackStart(TrackNum);

--- a/ADApp/ADSrc/CCDMultiTrack.cpp
+++ b/ADApp/ADSrc/CCDMultiTrack.cpp
@@ -43,7 +43,8 @@ void CCDMultiTrack::storeTrackAttributes(NDAttributeList* pAttributeList)
         {
             // Add new attributes listing.
             char Buf[10];
-            std::string TrackNumString = _itoa(TrackNum + 1, Buf, 10);
+            snprintf(Buf, 10, "%zd", TrackNum + 1);
+            std::string TrackNumString = Buf;
             std::string TrackStartName = ROIString + TrackNumString + "start";
             std::string TrackStartDescription = TrackString + TrackNumString + " start";
             int TrackStart = CCDMultiTrack::TrackStart(TrackNum);

--- a/ADApp/ADSrc/CCDMultiTrack.h
+++ b/ADApp/ADSrc/CCDMultiTrack.h
@@ -12,6 +12,7 @@
 #define CCD_MULTI_TRACK_H
 
 #include <asynPortDriver.h>
+#include <NDAttributeList.h>
 #include <shareLib.h>
 
 class epicsShareClass CCDMultiTrack
@@ -59,10 +60,13 @@ public:
     CCDMultiTrack(asynPortDriver* asynPortDriver);
     asynStatus writeInt32Array(asynUser *pasynUser, epicsInt32 *value, size_t nElements);
 
+    void storeTrackAttributes(NDAttributeList* pAttributeList);
+
 private:
     void writeTrackStart(epicsInt32 *value, size_t nElements);
     void writeTrackEnd(epicsInt32 *value, size_t nElements);
     void writeTrackBin(epicsInt32 *value, size_t nElements);
+
 };
 
 #endif //CCD_MULTI_TRACK_H


### PR DESCRIPTION
…was configured.

I prefer to add this as a method in ADCore/CCDMultiTrack (invoked from the camera class), since the attribute storage itself is not camera-type specific.