### PR TITLE
Set scan rate

### DIFF
--- a/ADApp/Db/ADBase.template
+++ b/ADApp/Db/ADBase.template
@@ -181,7 +181,7 @@ record(ai, "$(P)$(R)AcquireTime_RBV")
    field(DTYP, "asynFloat64")
    field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))ACQ_TIME")
    field(PREC, "3")
-   field(SCAN, "I/O Intr")
+   field(SCAN, "$(SCANRATE=I/O Intr)")
 }
 
 record(ao, "$(P)$(R)AcquirePeriod")
@@ -199,7 +199,7 @@ record(ai, "$(P)$(R)AcquirePeriod_RBV")
    field(DTYP, "asynFloat64")
    field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))ACQ_PERIOD")
    field(PREC, "3")
-   field(SCAN, "I/O Intr")
+   field(SCAN, "$(SCANRATE=I/O Intr)")
 }
 
 record(ai, "$(P)$(R)TimeRemaining_RBV")
@@ -370,7 +370,7 @@ record(longin, "$(P)$(R)NumImagesCounter_RBV")
 {
    field(DTYP, "asynInt32")
    field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))NIMAGES_COUNTER")
-   field(SCAN, "I/O Intr")
+   field(SCAN, "$(SCANRATE=I/O Intr)")
 }
 
 ###################################################################

--- a/ADApp/Db/ADBase.template
+++ b/ADApp/Db/ADBase.template
@@ -4,6 +4,10 @@
 # Mark Rivers
 # March 9, 2008
 
+#  Using SCANRATE:The ImageJ EPICS_AD_Viewer plugin monitors ArrayCounter_RBV to decide 
+#  when there is a new image to display. That means that it will not display faster than
+#  the SCANRATE you select.
+
 include "NDArrayBase.template"
 
 record(longin, "$(P)$(R)MaxSizeX_RBV")

--- a/ADApp/Db/ADBase.template
+++ b/ADApp/Db/ADBase.template
@@ -181,7 +181,7 @@ record(ai, "$(P)$(R)AcquireTime_RBV")
    field(DTYP, "asynFloat64")
    field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))ACQ_TIME")
    field(PREC, "3")
-   field(SCAN, "$(SCANRATE=I/O Intr)")
+   field(SCAN, "I/O Intr")
 }
 
 record(ao, "$(P)$(R)AcquirePeriod")
@@ -199,7 +199,7 @@ record(ai, "$(P)$(R)AcquirePeriod_RBV")
    field(DTYP, "asynFloat64")
    field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))ACQ_PERIOD")
    field(PREC, "3")
-   field(SCAN, "$(SCANRATE=I/O Intr)")
+   field(SCAN, "I/O Intr")
 }
 
 record(ai, "$(P)$(R)TimeRemaining_RBV")

--- a/ADApp/Db/NDArrayBase.template
+++ b/ADApp/Db/NDArrayBase.template
@@ -687,7 +687,7 @@ record(longin, "$(P)$(R)UniqueId_RBV")
 {
     field(DTYP, "asynInt32")
     field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))UNIQUE_ID")
-    field(SCAN, "I/O Intr")
+    field(SCAN, "$(SCANRATE=I/O Intr)")
 }
 
 record(ai, "$(P)$(R)TimeStamp_RBV")
@@ -695,7 +695,7 @@ record(ai, "$(P)$(R)TimeStamp_RBV")
     field(DTYP, "asynFloat64")
     field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))TIME_STAMP")
     field(PREC, "3")
-    field(SCAN, "I/O Intr")
+    field(SCAN, "$(SCANRATE=I/O Intr)")
 }
 
 record(longin, "$(P)$(R)EpicsTSSec_RBV")
@@ -726,7 +726,7 @@ record(longin, "$(P)$(R)ArrayCounter_RBV")
 {
     field(DTYP, "asynInt32")
     field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))ARRAY_COUNTER")
-    field(SCAN, "I/O Intr")
+    field(SCAN, "$(SCANRATE=I/O Intr)")
 }
 
 # Updated rate calculation to use a smoothing factor w/ guard against negative values
@@ -877,5 +877,5 @@ record(longin, "$(P)$(R)NumQueuedArrays")
 {
    field(DTYP, "asynInt32")
    field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))NUM_QUEUED_ARRAYS")
-   field(SCAN, "I/O Intr")
+   field(SCAN, "$(SCANRATE=I/O Intr)")
 }

--- a/ADApp/Db/NDFile.template
+++ b/ADApp/Db/NDFile.template
@@ -299,7 +299,7 @@ record(longin, "$(P)$(R)NumCaptured_RBV")
 {
     field(DTYP, "asynInt32")
     field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))NUM_CAPTURED")
-    field(SCAN, "I/O Intr")
+    field(SCAN, "$(SCANRATE=I/O Intr)")
 }
 
 # Delete driver file flag

--- a/ADApp/Db/NDPluginBase.template
+++ b/ADApp/Db/NDPluginBase.template
@@ -258,7 +258,7 @@ record(longin, "$(P)$(R)QueueFree")
     field(LSV,  "MINOR")
     field(LOLO, "0")
     field(HYST, "1")
-    field(SCAN, "I/O Intr")
+    field(SCAN, "$(SCANRATE=I/O Intr)")
 }
 
 # Display the fill level on the plugins input queue

--- a/ADApp/Db/NDPosPlugin.template
+++ b/ADApp/Db/NDPosPlugin.template
@@ -3,6 +3,7 @@
 #% macro, PORT, Asyn Port name
 #% macro, ADDR, Asyn Port address
 #% macro, TIMEOUT, Asyn timeout
+#% macro, SCANRATE, Chosen Scan Rate for cpu intensive PVs
 
 # This associates the template with an edm screen
 # % gui, $(PORT), edmtab, NDPosPlugin.edl, P=$(P),R=$(R)
@@ -89,7 +90,7 @@ record(longin, "$(P)$(R)Qty_RBV")
 {
     field(DTYP, "asynInt32")
     field(INP,  "@asyn($(PORT),0)NDPos_CurrentQty")
-    field(SCAN, "I/O Intr")
+    field(SCAN, "$(SCANRATE=I/O Intr)")
 }
 
 record(longin, "$(P)$(R)Index_RBV")
@@ -103,7 +104,7 @@ record(stringin, "$(P)$(R)Position_RBV")
 {
     field(DTYP, "asynOctetRead")
     field(INP,  "@asyn($(PORT),0)NDPos_CurrentPos")
-    field(SCAN, "I/O Intr")
+    field(SCAN, "$(SCANRATE=I/O Intr)")
 }
 
 record(longout, "$(P)$(R)Missing")
@@ -138,7 +139,7 @@ record(longin, "$(P)$(R)ExpectedID_RBV")
 {
     field(DTYP, "asynInt32")
     field(INP,  "@asyn($(PORT),0)NDPos_ExpectedID")
-    field(SCAN, "I/O Intr")
+    field(SCAN, "$(SCANRATE=I/O Intr)")
 }
 
 record(stringout, "$(P)$(R)IDName")

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -21,9 +21,10 @@ files respectively, in the configure/ directory of the appropriate release of th
 
 ### SCANRATE macro
   * A new macro has been added to NDPosPlugin.template, NDPluginBase.template, NDFile.tamplate, NDArrayBase.template and 
-    ADBase.template. This can be used to control the SCAN value of multiple PVs, which were found to be intensive on the 
-    CPU when set to I/O Intr for a detector running at faster than 1 KHz. The performance could be improved by setting 
-    the SCAN value to update less frequently.
+    ADBase.template. This can be used to control the SCAN value of status PVs which update on every frame such as 
+    ArrayCounter_RBV, TimeStamp_RBV, UniqueId_RBV among others. These were found to be intensive on the CPU when set to 
+    I/O Intr for a detector running at faster than 1 KHz. The performance could be improved by setting the SCAN value 
+    to update less frequently.
   * The default value of the macro has been set to I/O Intr so that it will not affect any applications that do not 
     require the SCAN rate throttled. 
   * The ImageJ EPICS_AD_Viewer plugin monitors ArrayCounter_RBV to decide when there is a new image to display. That 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,6 +19,18 @@ the EXAMPLE_RELEASE_PATHS.local, EXAMPLE_RELEASE_LIBS.local, and EXAMPLE_RELEASE
 files respectively, in the configure/ directory of the appropriate release of the 
 [top-level areaDetector](https://github.com/areaDetector/areaDetector) repository.
 
+### SCANRATE macro
+  * A new macro has been added to NDPosPlugin.template, NDPluginBase.template, NDFile.tamplate, NDArrayBase.template and 
+    ADBase.template. This can be used to control the SCAN value of multiple PVs, which were found to be intensive on the 
+    CPU when set to I/O Intr for a detector running at faster than 1 KHz. The performance could be improved by setting 
+    the SCAN value to update less frequently.
+  * The default value of the macro has been set to I/O Intr so that it will not affect any applications that do not 
+    require the SCAN rate throttled. 
+  * The ImageJ EPICS_AD_Viewer plugin monitors ArrayCounter_RBV to decide when there is a new image to display. That 
+    means that it will not display faster than the SCANRATE you select.
+  * By making the records periodically scanned they will be reading even when the detector is stopped, which is a bit 
+    more overhead than SCAN=I/O Intr.
+
 ## __R3-9 (December XXX, 2019)__
 
 ### CCDMultiTrack


### PR DESCRIPTION
After finding a high CPU rate when running a detector at 10KHz, it was found that changing the SCAN value for certain PVs would lower the CPU rate considerably. We have then added a macro for these PVs, so they could be easily changed, with a default value of "I/O Intr" so these changes would have no effect on others.

Refs #416  