### PR TITLE
Fix problem with not closing constant datasets

### DIFF
--- a/ADApp/pluginSrc/NDFileHDF5.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5.cpp
@@ -1067,6 +1067,10 @@ hid_t NDFileHDF5::createDataset(hid_t group, hdf5::Dataset *dset)
   }
   else if(dset->data_source().is_src_constant()) {
       retcode = this->writeHdfConstDataset(group,  dset);
+      if (retcode != -1) {
+          // Store the dataset into the constant dataset map
+          this->constDsetMap[dset->get_full_name()] = retcode;
+      }
   }
   else {
     retcode = -1;
@@ -1699,8 +1703,8 @@ asynStatus NDFileHDF5::closeFile()
     H5Dclose(it_dset->second->getHandle());
   }
   std::map<std::string, hid_t>::iterator it_hid;
-  // Iterate over the stored attribute data sets and close them
-  for (it_hid = this->attDataMap.begin(); it_hid != this->attDataMap.end(); ++it_hid){
+  // Iterate over the stored constant data sets and close them
+  for (it_hid = this->constDsetMap.begin(); it_hid != this->constDsetMap.end(); ++it_hid){
     H5Dclose(it_hid->second);
   }
 
@@ -1746,7 +1750,7 @@ asynStatus NDFileHDF5::closeFile()
     delete it_dset->second;
   }
   detDataMap.clear();
-  attDataMap.clear();
+  constDsetMap.clear();
   defDsetName = "";
 
   epicsTimeGetCurrent(&now);

--- a/ADApp/pluginSrc/NDFileHDF5.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5.cpp
@@ -869,7 +869,6 @@ hid_t NDFileHDF5::writeH5dsetStr(hid_t element, const std::string &name, const s
     return -1;
   }
 
-  //H5Dclose (hdfdset);
   H5Tclose(hdfdatatype);
   H5Sclose(hdfdataspace);
 
@@ -956,7 +955,6 @@ hid_t NDFileHDF5::writeH5dsetInt32(hid_t element, const std::string &name, const
       return -1;
     }
   }
-  //H5Dclose (hdfdset);
   H5Sclose(hdfdataspace);
   H5Tclose(hdfdatatype);
   return hdfdset;
@@ -1043,7 +1041,6 @@ hid_t NDFileHDF5::writeH5dsetFloat64(hid_t element, const std::string &name, con
       return -1;
     }
   }
-  //H5Dclose (hdfdset);
   H5Sclose(hdfdataspace);
   H5Tclose(hdfdatatype);
   return hdfdset;

--- a/ADApp/pluginSrc/NDFileHDF5.h
+++ b/ADApp/pluginSrc/NDFileHDF5.h
@@ -122,7 +122,7 @@ class epicsShareClass NDFileHDF5 : public NDPluginFile
     hsize_t getVirtualDim(int index);
 
     std::map<std::string, NDFileHDF5Dataset *> detDataMap;  // Map of handles to detector datasets, indexed by name
-    std::map<std::string, hid_t>               attDataMap;  // Map of handles to attribute datasets, indexed by name
+    std::map<std::string, hid_t>               constDsetMap;  // Map of handles to constant datasets, indexed by name
     std::string                                defDsetName; // Name of the default data set
     std::string                                ndDsetName;  // Name of NDAttribute that specifies the destination data set
     std::map<std::string, hdf5::Element *>     onOpenMap;   // Map of handles to elements with onOpen ndattributes, indexed by fullname

--- a/XML_schema/hdf5_xml_layout_schema.xsd
+++ b/XML_schema/hdf5_xml_layout_schema.xsd
@@ -32,7 +32,6 @@
         <xs:restriction base="xs:string">
           <xs:enumeration value="OnFileOpen" />
           <xs:enumeration value="OnFileClose" />
-          <xs:enumeration value="OnFileWrite" />
         </xs:restriction>
       </xs:simpleType>
     </xs:attribute>
@@ -52,6 +51,15 @@
     <xs:attribute name="value" type="xs:string" use="optional" default="" />
     <xs:attribute name="ndattribute" type="xs:string" use="optional" default="" />
     <xs:attribute name="det_default" type="xs:boolean" use="optional" default="false" />
+    <xs:attribute name="when" use="optional">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="OnFileOpen" />
+          <xs:enumeration value="OnFileClose" />
+          <xs:enumeration value="OnFileWrite" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
   </xs:complexType>
 
   <!-- The hardlink element -->

--- a/docs/ADCore/NDFileHDF5.rst
+++ b/docs/ADCore/NDFileHDF5.rst
@@ -90,8 +90,8 @@ of the same names.
     - Enum string: "constant", "ndattribute"
   * - when
     - optional
-    - Event when the attribute data is updated
-    - Enum string: "OnFileOpen", "OnFileClose", "OnFileWrite"
+    - Event when the attribute data is written
+    - Enum string: "OnFileOpen" (default), "OnFileClose"
   * - value
     - Required only if source="constant"
     - The constant value to give the attribute
@@ -135,6 +135,10 @@ of the same names.
     - yes
     - Definition of where the dataset gets its data values from
     - string enum: "detector", "ndattribute", "constant"
+  * - when
+    - optional
+    - Event when the dataset data is written
+    - Enum string: "OnFileOpen", "OnFileClose", "OnFileWrite" (default)
   * - value
     - Required only if source="constant"
     - Constant value to write directly into the HDF5 dataset


### PR DESCRIPTION
This fixes #433.

I discovered that attDataMap was actually not being used.  Rather this list was used instead:
```
 std::list<NDFileHDF5AttributeDataset*> attrList;
```
I renamed attDataMap to constDsetMap.  It contains all the hid_t for each of the constant datasets.  All of these datasets are now closed in CloseFile().

This eliminates the error messages.
