### PR TITLE
re-order header inclusion to have correct exports

### DIFF
--- a/ADApp/pluginSrc/NDFileHDF5.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5.cpp
@@ -34,6 +34,7 @@
 #include <osiSock.h>
 
 #include <asynDriver.h>
+#include "NDPluginFile.h"
 
 #include <epicsExport.h>
 #include "NDFileHDF5.h"

--- a/ADApp/pluginSrc/NDFileHDF5.h
+++ b/ADApp/pluginSrc/NDFileHDF5.h
@@ -9,9 +9,7 @@
 
 #include <list>
 #include <hdf5.h>
-#include <asynDriver.h>
-#include <NDPluginFile.h>
-#include <NDArray.h>
+#include "NDPluginFile.h"
 #include "NDFileHDF5Layout.h"
 #include "NDFileHDF5Dataset.h"
 #include "NDFileHDF5LayoutXML.h"

--- a/ADApp/pluginSrc/NDFileJPEG.cpp
+++ b/ADApp/pluginSrc/NDFileJPEG.cpp
@@ -17,9 +17,9 @@
 #include <iocsh.h>
 
 #include <asynDriver.h>
+#include "NDPluginFile.h"
 
 #include <epicsExport.h>
-#include "NDPluginFile.h"
 #include "NDFileJPEG.h"
 
 

--- a/ADApp/pluginSrc/NDFileMagick.cpp
+++ b/ADApp/pluginSrc/NDFileMagick.cpp
@@ -17,9 +17,9 @@
 #include <iocsh.h>
 
 #include <asynDriver.h>
+#include "NDPluginFile.h"
 
 #include <epicsExport.h>
-#include "NDPluginFile.h"
 #include "NDFileMagick.h"
 
 static const char *driverName = "NDFileMagick";

--- a/ADApp/pluginSrc/NDFileNetCDF.cpp
+++ b/ADApp/pluginSrc/NDFileNetCDF.cpp
@@ -18,9 +18,9 @@
 #include <iocsh.h>
 
 #include <asynDriver.h>
+#include "NDPluginFile.h"
 
 #include <epicsExport.h>
-#include "NDPluginFile.h"
 #include "NDFileNetCDF.h"
 
 #define MAX_ATTRIBUTE_STRING_SIZE 256

--- a/ADApp/pluginSrc/NDFileNexus.cpp
+++ b/ADApp/pluginSrc/NDFileNexus.cpp
@@ -22,9 +22,9 @@
 #include <string.h>
 
 #include <asynDriver.h>
+#include "NDPluginFile.h"
 
 #include <epicsExport.h>
-#include "NDPluginFile.h"
 #include "NDFileNexus.h"
 
 static const char *driverName="NDFileNexus";

--- a/ADApp/pluginSrc/NDFileNull.cpp
+++ b/ADApp/pluginSrc/NDFileNull.cpp
@@ -18,6 +18,7 @@
 #include <iocsh.h>
 
 #include <asynDriver.h>
+#include "NDPluginFile.h"
 
 #include <epicsExport.h>
 #include "NDFileNull.h"

--- a/ADApp/pluginSrc/NDFileTIFF.cpp
+++ b/ADApp/pluginSrc/NDFileTIFF.cpp
@@ -31,10 +31,9 @@
 #include <iocsh.h>
 
 #include <asynDriver.h>
+#include "NDPluginFile.h"
 
 #include <epicsExport.h>
-#include "NDPluginFile.h"
-#include "tiffio.h"
 #include "NDFileTIFF.h"
 
 #define STRING_BUFFER_SIZE 2048

--- a/ADApp/pluginSrc/NDPluginAttrPlot.cpp
+++ b/ADApp/pluginSrc/NDPluginAttrPlot.cpp
@@ -8,6 +8,8 @@
 #include <epicsMath.h>
 #include <epicsThread.h>
 
+#include "NDPluginDriver.h"
+
 #include <epicsExport.h>
 #include "NDPluginAttrPlot.h"
 #include "CircularBuffer.h"

--- a/ADApp/pluginSrc/NDPluginAttribute.cpp
+++ b/ADApp/pluginSrc/NDPluginAttribute.cpp
@@ -21,9 +21,9 @@
 #include <iocsh.h>
 
 #include <asynDriver.h>
+#include "NDPluginDriver.h"
 
 #include <epicsExport.h>
-#include "NDPluginDriver.h"
 #include "NDPluginAttribute.h"
 
 const epicsInt32 NDPluginAttribute::MAX_ATTR_NAME_      = 256;

--- a/ADApp/pluginSrc/NDPluginCircularBuff.cpp
+++ b/ADApp/pluginSrc/NDPluginCircularBuff.cpp
@@ -22,9 +22,9 @@
 #include <postfix.h>
 
 #include <asynDriver.h>
+#include "NDPluginDriver.h"
 
 #include <epicsExport.h>
-#include "NDArray.h"
 #include "NDPluginCircularBuff.h"
 
 static const char *driverName="NDPluginCircularBuff";

--- a/ADApp/pluginSrc/NDPluginCodec.cpp
+++ b/ADApp/pluginSrc/NDPluginCodec.cpp
@@ -51,6 +51,7 @@
 #include <iocsh.h>
 
 #include <asynDriver.h>
+#include "NDPluginDriver.h"
 
 #include <epicsExport.h>
 #include "Codec.h"

--- a/ADApp/pluginSrc/NDPluginColorConvert.cpp
+++ b/ADApp/pluginSrc/NDPluginColorConvert.cpp
@@ -21,9 +21,9 @@
 #include <iocsh.h>
 
 #include <asynDriver.h>
+#include "NDPluginDriver.h"
 
 #include <epicsExport.h>
-#include "NDPluginDriver.h"
 #include "colorMaps.h"
 #include "NDPluginColorConvert.h"
 

--- a/ADApp/pluginSrc/NDPluginDriver.cpp
+++ b/ADApp/pluginSrc/NDPluginDriver.cpp
@@ -21,6 +21,7 @@
 #include <cantProceed.h>
 
 #include <asynDriver.h>
+#include "asynNDArrayDriver.h"
 
 #include <epicsExport.h>
 #include "NDPluginDriver.h"

--- a/ADApp/pluginSrc/NDPluginFFT.cpp
+++ b/ADApp/pluginSrc/NDPluginFFT.cpp
@@ -22,9 +22,9 @@
 #include <asynDriver.h>
 
 #include <NDArray.h>
+#include "NDPluginDriver.h"
 
 #include <epicsExport.h>
-
 #include "NDPluginFFT.h"
 #include "fft.h"
 

--- a/ADApp/pluginSrc/NDPluginFile.cpp
+++ b/ADApp/pluginSrc/NDPluginFile.cpp
@@ -21,9 +21,9 @@
 #include <epicsString.h>
 
 #include <asynDriver.h>
+#include "NDPluginDriver.h"
 
 #include <epicsExport.h>
-#include <NDPluginDriver.h>
 #include "NDPluginFile.h"
 
 

--- a/ADApp/pluginSrc/NDPluginGather.cpp
+++ b/ADApp/pluginSrc/NDPluginGather.cpp
@@ -17,9 +17,9 @@
 #include <iocsh.h>
 
 #include <asynDriver.h>
+#include "NDPluginDriver.h"
 
 #include <epicsExport.h>
-#include "NDPluginDriver.h"
 #include "NDPluginGather.h"
 
 static const char *driverName="NDPluginGather";

--- a/ADApp/pluginSrc/NDPluginOverlay.cpp
+++ b/ADApp/pluginSrc/NDPluginOverlay.cpp
@@ -22,9 +22,9 @@
 #include <iocsh.h>
 
 #include <asynDriver.h>
+#include "NDPluginDriver.h"
 
 #include <epicsExport.h>
-#include "NDPluginDriver.h"
 #include "NDPluginOverlayTextFont.h"
 #include "NDPluginOverlay.h"
 

--- a/ADApp/pluginSrc/NDPluginProcess.cpp
+++ b/ADApp/pluginSrc/NDPluginProcess.cpp
@@ -20,9 +20,9 @@
 #include <iocsh.h>
 
 #include <asynDriver.h>
+#include "NDPluginDriver.h"
 
 #include <epicsExport.h>
-#include "NDPluginDriver.h"
 #include "NDPluginProcess.h"
 
 static const char *driverName="NDPluginProcess";

--- a/ADApp/pluginSrc/NDPluginPva.cpp
+++ b/ADApp/pluginSrc/NDPluginPva.cpp
@@ -8,13 +8,13 @@
 #include <ntndArrayConverter.h>
 
 #include <asynDriver.h>
+#include "NDPluginDriver.h"
 
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
 
 #include <epicsExport.h>
-#include "NDPluginDriver.h"
 #include "NDPluginPva.h"
 
 static const char *driverName="NDPluginPva";

--- a/ADApp/pluginSrc/NDPluginROI.cpp
+++ b/ADApp/pluginSrc/NDPluginROI.cpp
@@ -20,9 +20,9 @@
 #include <iocsh.h>
 
 #include <asynDriver.h>
+#include "NDPluginDriver.h"
 
 #include <epicsExport.h>
-#include "NDPluginDriver.h"
 #include "NDPluginROI.h"
 
 //static const char *driverName="NDPluginROI";

--- a/ADApp/pluginSrc/NDPluginROIStat.cpp
+++ b/ADApp/pluginSrc/NDPluginROIStat.cpp
@@ -23,10 +23,9 @@
 #include <iocsh.h>
 
 #include <asynDriver.h>
+#include "NDPluginDriver.h"
 
 #include <epicsExport.h>
-
-#include "NDArray.h"
 #include "NDPluginROIStat.h"
 
 #define MAX(A,B) (A)>(B)?(A):(B)

--- a/ADApp/pluginSrc/NDPluginScatter.cpp
+++ b/ADApp/pluginSrc/NDPluginScatter.cpp
@@ -16,9 +16,9 @@
 #include <iocsh.h>
 
 #include <asynDriver.h>
+#include "NDPluginDriver.h"
 
 #include <epicsExport.h>
-#include "NDPluginDriver.h"
 #include "NDPluginScatter.h"
 
 static const char *driverName="NDPluginScatter";

--- a/ADApp/pluginSrc/NDPluginStats.cpp
+++ b/ADApp/pluginSrc/NDPluginStats.cpp
@@ -20,9 +20,9 @@
 #include <iocsh.h>
 
 #include <asynDriver.h>
+#include "NDPluginDriver.h"
 
 #include <epicsExport.h>
-#include "NDPluginDriver.h"
 #include "NDPluginStats.h"
 
 #define MAX(A,B) (A)>(B)?(A):(B)

--- a/ADApp/pluginSrc/NDPluginStdArrays.cpp
+++ b/ADApp/pluginSrc/NDPluginStdArrays.cpp
@@ -21,9 +21,9 @@
 #include <iocsh.h>
 
 #include <asynDriver.h>
+#include "NDPluginDriver.h"
 
 #include <epicsExport.h>
-#include "NDPluginDriver.h"
 #include "NDPluginStdArrays.h"
 
 static const char *driverName="NDPluginStdArrays";

--- a/ADApp/pluginSrc/NDPluginTimeSeries.cpp
+++ b/ADApp/pluginSrc/NDPluginTimeSeries.cpp
@@ -22,9 +22,9 @@
 #include <asynDriver.h>
 
 #include <NDArray.h>
+#include "NDPluginDriver.h"
 
 #include <epicsExport.h>
-
 #include "NDPluginTimeSeries.h"
 
 #define DEFAULT_NUM_TSPOINTS 2048

--- a/ADApp/pluginSrc/NDPluginTransform.cpp
+++ b/ADApp/pluginSrc/NDPluginTransform.cpp
@@ -24,9 +24,9 @@
 #include <iocsh.h>
 
 #include <asynDriver.h>
+#include "NDPluginDriver.h"
 
 #include <epicsExport.h>
-#include "NDPluginDriver.h"
 #include "NDPluginTransform.h"
 
 /* Enums to describe the types of transformations */

--- a/ADApp/pluginSrc/NDPluginTransform.h
+++ b/ADApp/pluginSrc/NDPluginTransform.h
@@ -1,9 +1,6 @@
 #ifndef NDPluginTransform_H
 #define NDPluginTransform_H
 
-#include <epicsTypes.h>
-#include <asynStandardInterfaces.h>
-
 #include "NDPluginDriver.h"
 
 /** Map parameter enums to strings that will be used to set up EPICS databases

--- a/ADApp/pluginSrc/NDPosPlugin.cpp
+++ b/ADApp/pluginSrc/NDPosPlugin.cpp
@@ -19,9 +19,9 @@
 
 #include <asynDriver.h>
 
-#include <epicsExport.h>
 #include "NDPluginDriver.h"
 
+#include <epicsExport.h>
 #include "NDPosPlugin.h"
 #include "NDPosPluginFileReader.h"
 


### PR DESCRIPTION
the principle is to only include class header after
epicsExport.h.

parent class header is included once more before
epicsExport.h, so the linkage gets correct.