### PR TITLE
Clean includes

### DIFF
--- a/ADApp/ADSrc/NDArray.h
+++ b/ADApp/ADSrc/NDArray.h
@@ -13,9 +13,20 @@
 #define NDArray_H
 
 #include <set>
+#include <stdio.h>
+
+#ifdef epicsExportSharedSymbols
+#   define epicsExportSharedSymbols_NDArrayH
+#   undef epicsExportSharedSymbols
+#endif
+
 #include <epicsMutex.h>
 #include <epicsTime.h>
-#include <stdio.h>
+
+#ifdef epicsExportSharedSymbols_NDArrayH
+#   define epicsExportSharedSymbols
+#   include <shareLib.h>
+#endif
 
 #include "NDAttribute.h"
 #include "NDAttributeList.h"

--- a/ADApp/ADSrc/NDAttribute.h
+++ b/ADApp/ADSrc/NDAttribute.h
@@ -14,11 +14,21 @@
 #include <stdio.h>
 #include <string.h>
 
+#ifdef epicsExportSharedSymbols
+#   define epicsExportSharedSymbols_NDAttributeH
+#   undef epicsExportSharedSymbols
+#endif
+
 #include <ellLib.h>
 #include <epicsTypes.h>
 
 /* asynDriver.h is needed only to define epicsInt64 on 3.14 */
 #include <asynDriver.h>
+
+#ifdef epicsExportSharedSymbols_NDAttributeH
+#   define epicsExportSharedSymbols
+#   include <shareLib.h>
+#endif
 
 /** Success return code  */
 #define ND_SUCCESS 0

--- a/ADApp/ADSrc/myAttributeFunctions.cpp
+++ b/ADApp/ADSrc/myAttributeFunctions.cpp
@@ -2,8 +2,8 @@
 #include <string.h>
 #include <stdlib.h>
 #include <registryFunction.h>
-#include <epicsExport.h>
 #include <epicsTime.h>
+#include <epicsExport.h>
 #include "functAttribute.h"
 
 // These functions demonstrate using user-defined attribute functions

--- a/ADApp/ntndArrayConverterSrc/ntndArrayConverter.h
+++ b/ADApp/ntndArrayConverterSrc/ntndArrayConverter.h
@@ -1,5 +1,18 @@
+#ifndef ntndArrayConverter_H
+#define ntndArrayConverter_H
+
+#ifdef epicsExportSharedSymbols
+#   define epicsExportSharedSymbols_ntndArrayConverterH
+#   undef epicsExportSharedSymbols
+#endif
+
 #include <NDArray.h>
 #include <pv/ntndarray.h>
+
+#ifdef epicsExportSharedSymbols_ntndArrayConverterH
+#   define epicsExportSharedSymbols
+#   include <shareLib.h>
+#endif
 
 typedef struct NTNDArrayInfo
 {
@@ -63,3 +76,5 @@ private:
 };
 
 typedef std::tr1::shared_ptr<NTNDArrayConverter> NTNDArrayConverterPtr;
+
+#endif

--- a/ADApp/pluginSrc/NDPluginCircularBuff.cpp
+++ b/ADApp/pluginSrc/NDPluginCircularBuff.cpp
@@ -24,7 +24,6 @@
 #include <asynDriver.h>
 
 #include <epicsExport.h>
-#include "NDArray.h"
 #include "NDPluginCircularBuff.h"
 
 static const char *driverName="NDPluginCircularBuff";

--- a/ADApp/pluginSrc/NDPluginDriver.h
+++ b/ADApp/pluginSrc/NDPluginDriver.h
@@ -2,12 +2,23 @@
 #define NDPluginDriver_H
 
 #include <set>
+
+#ifdef epicsExportSharedSymbols
+#   define epicsExportSharedSymbols_NDPluginDriverH
+#   undef epicsExportSharedSymbols
+#endif
+
 #include <epicsTypes.h>
 #include <epicsMessageQueue.h>
 #include <epicsThread.h>
 #include <epicsTime.h>
 
 #include "asynNDArrayDriver.h"
+
+#ifdef epicsExportSharedSymbols_NDPluginDriverH
+#   define epicsExportSharedSymbols
+#   include <shareLib.h>
+#endif
 
 class Throttler;
 

--- a/ADApp/pluginSrc/NDPluginROIStat.cpp
+++ b/ADApp/pluginSrc/NDPluginROIStat.cpp
@@ -25,8 +25,6 @@
 #include <asynDriver.h>
 
 #include <epicsExport.h>
-
-#include "NDArray.h"
 #include "NDPluginROIStat.h"
 
 #define MAX(A,B) (A)>(B)?(A):(B)


### PR DESCRIPTION
Somehow related to (retracted) #436, it is to address those symbols exported by ADBase and NDPlugin, but originally exported by libCom and asyn.

It is tested with windows-x64 arch.