### PR TITLE
ADApp/pluginSrc/NDPluginProcess.cpp: remove else clause when applying…

### DIFF
--- a/ADApp/pluginSrc/NDPluginProcess.cpp
+++ b/ADApp/pluginSrc/NDPluginProcess.cpp
@@ -173,10 +173,7 @@ void NDPluginProcess::processCallbacks(NDArray *pArray)
         }
         if (background) value -= background[i];
         if (flatField) {
-            if (flatField[i] != 0.) 
-                value *= scaleFlatField / flatField[i];
-            else
-                value = scaleFlatField;
+            if (flatField[i] != 0.) value *= scaleFlatField / flatField[i];
         }
         if (enableOffsetScale) value = (value + offset)*scale;
         if (enableHighClip && (value > highClip)) value = highClip;


### PR DESCRIPTION
… flatfield correction. This means that when an entry in the flatfield array is zero, the original value will not be modified.

This fixes #440 