### PR TITLE
Improve disconnect

### DIFF
--- a/ADApp/ADSrc/ADDriver.cpp
+++ b/ADApp/ADSrc/ADDriver.cpp
@@ -54,6 +54,24 @@ void ADDriver::setShutter(int open)
     }
 }
 
+/** Connects driver to device;
+  * This method uses the class variable deviceIsConnected to determine whether to call
+  * the base class method, which in turn calls pasynManager::exceptionConnect().
+  * \param[in] pasynUser The pasynUser structure which contains information about the port and address */
+asynStatus ADDriver::connect(asynUser *pasynUser)
+{
+    static const char *functionName = "connect";
+
+    if (this->deviceIsConnected) {
+        return asynNDArrayDriver::connect(pasynUser);
+    }
+    asynPrint(pasynUserSelf, ASYN_TRACE_WARNING,
+        "%s::%s warning attempt to connect but deviceIsConnected is false\n",
+        driverName, functionName);
+    return asynSuccess;
+}
+
+
 /** Sets an int32 parameter.
   * \param[in] pasynUser asynUser structure that contains the function code in pasynUser->reason.
   * \param[in] value The value for this parameter
@@ -110,7 +128,8 @@ ADDriver::ADDriver(const char *portName, int maxAddr, int numParams, int maxBuff
     : asynNDArrayDriver(portName, maxAddr, maxBuffers, maxMemory,
           interfaceMask | asynInt32Mask | asynFloat64Mask | asynOctetMask | asynGenericPointerMask | asynDrvUserMask,
           interruptMask | asynInt32Mask | asynFloat64Mask | asynOctetMask | asynGenericPointerMask,
-          asynFlags, autoConnect, priority, stackSize)
+          asynFlags, autoConnect, priority, stackSize),
+    deviceIsConnected(true)
 
 {
     //char *functionName = "ADDriver";

--- a/ADApp/ADSrc/ADDriver.cpp
+++ b/ADApp/ADSrc/ADDriver.cpp
@@ -55,18 +55,23 @@ void ADDriver::setShutter(int open)
 }
 
 /** Connects driver to device;
-  * This method uses the class variable deviceIsConnected to determine whether to call
-  * the base class method, which in turn calls pasynManager::exceptionConnect().
+  * This method is called when the driver's pasynCommon->connect() function is called.
+  * It uses the class variable deviceIsReachable to determine whether to call
+  * asynPortDriver::connect(), which in turn calls pasynManager::exceptionConnect()
+  * to signal that the driver is connected to the underlying hardware.
+  * Derived classes can override this method if they need to handle connect() calls in a more
+  * complex way.  For example, with a network camera that can be temporarily unreachable
+  * the driver could attempt to connect to the camera each time that connect() is called.
   * \param[in] pasynUser The pasynUser structure which contains information about the port and address */
 asynStatus ADDriver::connect(asynUser *pasynUser)
 {
     static const char *functionName = "connect";
 
-    if (this->deviceIsConnected) {
-        return asynNDArrayDriver::connect(pasynUser);
+    if (this->deviceIsReachable) {
+        return asynPortDriver::connect(pasynUser);
     }
     asynPrint(pasynUserSelf, ASYN_TRACE_WARNING,
-        "%s::%s warning attempt to connect but deviceIsConnected is false\n",
+        "%s::%s warning attempt to connect but deviceIsReachable is false\n",
         driverName, functionName);
     return asynSuccess;
 }
@@ -129,7 +134,7 @@ ADDriver::ADDriver(const char *portName, int maxAddr, int numParams, int maxBuff
           interfaceMask | asynInt32Mask | asynFloat64Mask | asynOctetMask | asynGenericPointerMask | asynDrvUserMask,
           interruptMask | asynInt32Mask | asynFloat64Mask | asynOctetMask | asynGenericPointerMask,
           asynFlags, autoConnect, priority, stackSize),
-    deviceIsConnected(true)
+    deviceIsReachable(true)
 
 {
     //char *functionName = "ADDriver";

--- a/ADApp/ADSrc/ADDriver.h
+++ b/ADApp/ADSrc/ADDriver.h
@@ -139,6 +139,7 @@ public:
 
     /* These are the methods that we override from asynPortDriver */
     virtual asynStatus writeInt32(asynUser *pasynUser, epicsInt32 value);
+    virtual asynStatus connect(asynUser *pasynUser);
 
     /* These are the methods that are new to this class */
     virtual void setShutter(int open);
@@ -179,6 +180,8 @@ protected:
     int ADStatusMessage;
     int ADStringToServer;
     int ADStringFromServer;
+    
+    bool deviceIsConnected;
 };
 
 #endif

--- a/ADApp/ADSrc/ADDriver.h
+++ b/ADApp/ADSrc/ADDriver.h
@@ -181,7 +181,7 @@ protected:
     int ADStringToServer;
     int ADStringFromServer;
     
-    bool deviceIsConnected;
+    bool deviceIsReachable;
 };
 
 #endif


### PR DESCRIPTION
This PR addresses issue #448.

It does the following:
- Adds a new bool member variable `deviceIsConnected` to ADDriver.
- Initializes `deviceIsConnected` to `true` in the ADDriver constructor.
- Adds the `ADDriver::connect()` method.  This method looks at the value of `deviceIsConnected`.  If it is `true` then it calls `asynNDArrayDriver::connect()`, which ultimately that calls `asynPortDriver::connect()`.  That method calls `pasynManager->exceptionConnect()`.  This method is needed to prevent asynManager from autoconnecting to the driver when `deviceIsConnected` is `false`.

Real drivers can now signal that they have failed to connect to hardware, and thus set the driver to the `Disconnected` state by doing the following if hardware initialization fails, typically in their constructor:
- Set `this->deviceIsConnected = false`
- Call `this->disconnect(pasynUserSelf)`

The constructor in ADSimDetector was changed with commented out lines as follows to take advantage of this new feature:
```
corvette:ADSimDetector/simDetectorApp/src>git diff  de317041980e95752ab2e31de35a6d55368306a3 simDetector.cpp
diff --git a/simDetectorApp/src/simDetector.cpp b/simDetectorApp/src/simDetector.cpp
index 4e64182..17687b7 100644
--- a/simDetectorApp/src/simDetector.cpp
+++ b/simDetectorApp/src/simDetector.cpp
@@ -1113,6 +1113,11 @@ simDetector::simDetector(const char *portName, int maxSizeX, int maxSizeY, NDDat
         return;
     }

+    // Test setting the device connected to false.
+    // Real drivers should do this if they fail to connect to the hardware
+    //this->deviceIsConnected = false;
+    //this->disconnect(pasynUserSelf);
+
     /* Create the thread that updates the images */
     status = (epicsThreadCreate("SimDetTask",
                                 epicsThreadPriorityMedium,
```

With those 2 lines uncommented the OPI screen looks like this when the IOC is run:

![simdisconnect](https://user-images.githubusercontent.com/6115534/86835840-509cc200-c062-11ea-8aa6-6f7fb146f608.png)

The constructor in ADPerkinElmer has had the following change:

```
diff --git a/perkinElmerApp/src/PerkinElmer.cpp b/perkinElmerApp/src/PerkinElmer.cpp
index 4f3aa64..4990ed6 100755
--- a/perkinElmerApp/src/PerkinElmer.cpp
+++ b/perkinElmerApp/src/PerkinElmer.cpp
@@ -184,7 +184,10 @@ PerkinElmer::PerkinElmer(const char *portName,  int IDType, const char *IDValue,
                               epicsThreadGetStackSize(epicsThreadStackMedium),
                               (EPICSTHREADFUNC)acquireStopTaskC,
                               this) == NULL);
-  initializeDetector();
+  if (!initializeDetector()) {
+    this->deviceIsConnected = false;
+    this->disconnect(pasynUserSelf);
+  }

   // Set exit handler to clean up
   epicsAtExit(exitCallbackC, this);
```

With this change the OPI screen now shows the following when the IOC is run with the detector disconnected.

![image](https://user-images.githubusercontent.com/6115534/86835177-56de6e80-c061-11ea-802b-8e44284ac619.png)


