### PR TITLE
Set boost_system_DIR to find libboost_system

### DIFF
--- a/ADApp/commonDriverMakefile
+++ b/ADApp/commonDriverMakefile
@@ -190,7 +190,7 @@ ifeq ($(WITH_BOOST),YES)
     PROD_SYS_LIBS += boost_system
   else
     ifdef BOOST_LIB
-      BOOST_DIR        = $(BOOST_LIB)
+      boost_system_DIR = $(BOOST_LIB)
       PROD_LIBS     += boost_system
     else
       PROD_SYS_LIBS += boost_system


### PR DESCRIPTION
This is needed when configured with `BOOST_EXTERNAL=YES`.

BTW with this fix ADSupport and ADCore built fine on MacOS using the default EXAMPLE_CONFIG_SITE.local (plus my own Boost). It also built fine using the system version of Boost that apparently comes with Apple XCode, which I wasn't immediately aware of. The only difference needed between EXAMPLE_CONFIG_SITE.local and a replacement for EXAMPLE_CONFIG_SITE.local.darwin-x86 would appear to be to drop the ARAVIS and GLIB definitions.