### PR TITLE
remove destroy

### DIFF
--- a/ADApp/pluginSrc/NDPluginPva.cpp
+++ b/ADApp/pluginSrc/NDPluginPva.cpp
@@ -43,7 +43,6 @@ public:
     virtual ~NTNDArrayRecord () {}
     static NTNDArrayRecordPtr create (string const & name);
     virtual bool init ();
-    virtual void destroy ();
     virtual void process () {}
     void update (NDArray *pArray);
 };
@@ -68,11 +67,6 @@ bool NTNDArrayRecord::init ()
     m_ntndArray = NTNDArray::wrap(getPVStructure());
     m_converter.reset(new NTNDArrayConverter(m_ntndArray));
     return true;
-}
-
-void NTNDArrayRecord::destroy()
-{
-    PVRecord::destroy();
 }
 
 void NTNDArrayRecord::update(NDArray *pArray)


### PR DESCRIPTION
Starting with the next epics 7 release pvDatabase.cpp will no longer have any destroy methods.
With this change NDPluginPva will not build unless it's destroy methods are removed.

Note that for at least the last couple of epics7 releases pvDatabase.cpp has only had empty destroy methods.
Thus even with this change to NDPluginPva, ADCore will still build for at least the last couple of epics7 releases.