### PR TITLE
Fix/420 xmlfree

### DIFF
--- a/ADApp/pluginSrc/NDFileHDF5.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5.cpp
@@ -3908,8 +3908,8 @@ asynStatus NDFileHDF5::createFileLayout(NDArray *pArray)
       // File specified and exists, use the file
       asynPrint(this->pasynUserSelf, ASYN_TRACE_FLOW, "%s::%s Layout file exists, using the file: %s\n",
                 driverName, functionName, layoutFile);
-    std::string strLayoutFile = std::string(layoutFile);
-    status = this->layout.load_xml(strLayoutFile);
+      std::string strLayoutFile = std::string(layoutFile);
+      status = this->layout.load_xml(strLayoutFile);
       if (status == -1){
         this->layout.unload_xml();
         delete[] layoutFile;

--- a/ADApp/pluginSrc/NDFileHDF5LayoutXML.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5LayoutXML.cpp
@@ -15,12 +15,6 @@
 #include "NDFileHDF5Layout.h"
 #include "NDFileHDF5LayoutXML.h"
 
-// There is a problem with the export of the xmlFree symbol in the xml library on mingw.
-// It is just defined to be free() anyway, so work around the problem here.
-#ifdef __MINGW32__
-  #define xmlFree free
-#endif
-
 namespace hdf5
 {
 
@@ -335,7 +329,7 @@ namespace hdf5
     attr_src = xmlTextReaderGetAttribute(this->xmlreader, (const xmlChar*)LayoutXML::ATTR_SOURCE.c_str());
     if (attr_src == NULL) return ret;
     str_attr_src = (char*)attr_src;
-    xmlFree(attr_src);
+    xmlGetGlobalState()->xmlFree(attr_src);
 
     if (str_attr_src == LayoutXML::ATTR_SRC_DETECTOR){
       out = DataSource( detector );
@@ -363,7 +357,7 @@ namespace hdf5
     attr_src = xmlTextReaderGetAttribute(this->xmlreader, (const xmlChar*)LayoutXML::ATTR_SOURCE.c_str());
     if (attr_src == NULL) return ret;
     str_attr_src = (char*)attr_src;
-    xmlFree(attr_src);
+    xmlGetGlobalState()->xmlFree(attr_src);
 
     std::string str_attr_val = "";
     xmlChar *attr_val = NULL;
@@ -378,14 +372,14 @@ namespace hdf5
       attr_val = xmlTextReaderGetAttribute(this->xmlreader, (const xmlChar*)LayoutXML::ATTR_SRC_NDATTR.c_str());
       if (attr_val != NULL) {
         str_attr_val = (char*)attr_val;
-        xmlFree(attr_val);
+        xmlGetGlobalState()->xmlFree(attr_val);
       }
       out.source = DataSource( ndattribute, str_attr_val );
       // Check for a when="OnFileClose" or when="OnFileOpen" tag
       attr_when = xmlTextReaderGetAttribute(this->xmlreader, (const xmlChar*)LayoutXML::ATTR_SRC_WHEN.c_str());
       if (attr_when != NULL) {
         str_attr_when = (char*)attr_when;
-        xmlFree(attr_when);
+        xmlGetGlobalState()->xmlFree(attr_when);
       }
       if (str_attr_when == "OnFileOpen"){
         out.source.set_when_to_save(OnFileOpen);
@@ -403,13 +397,13 @@ namespace hdf5
       attr_val = xmlTextReaderGetAttribute(this->xmlreader, (const xmlChar*)LayoutXML::ATTR_SRC_CONST_VALUE.c_str());
       if (attr_val != NULL) {
         str_attr_val = (char*)attr_val;
-        xmlFree(attr_val);
+        xmlGetGlobalState()->xmlFree(attr_val);
       }
       out.source = DataSource( constant, str_attr_val );
       attr_type = xmlTextReaderGetAttribute(this->xmlreader, (const xmlChar*)LayoutXML::ATTR_SRC_CONST_TYPE.c_str());
       if (attr_type != NULL) {
         str_attr_type = (char*)attr_type;
-        xmlFree(attr_type);
+        xmlGetGlobalState()->xmlFree(attr_type);
         DataType_t dtype = string;
         if (str_attr_type == "int") dtype = int32;
         else if (str_attr_type == "float") dtype = float64;
@@ -435,7 +429,7 @@ namespace hdf5
 
     // Get the standard string representation of the tag
     std::string str_root_auto((char*)root_auto);
-    xmlFree(root_auto);
+    xmlGetGlobalState()->xmlFree(root_auto);
 
     // Now check if we have the correct string
     if (str_root_auto == "false"){
@@ -461,7 +455,7 @@ namespace hdf5
     if (group_name == NULL) return -1;
 
     std::string str_group_name((const char*)group_name);
-    xmlFree(group_name);
+    xmlGetGlobalState()->xmlFree(group_name);
 
     // Initialise the tree if it has not already been done.
     if (this->ptr_tree == NULL){
@@ -484,7 +478,7 @@ namespace hdf5
       ndattr_default = xmlTextReaderGetAttribute(this->xmlreader, (const xmlChar *)LayoutXML::ATTR_GRP_NDATTR_DEFAULT.c_str());
       if (ndattr_default != NULL){
         std::string str_ndattr_default((char*)ndattr_default);
-        xmlFree(ndattr_default);
+        xmlGetGlobalState()->xmlFree(ndattr_default);
         // if the group has tag: ndattr_default="true" (true in lower case)
         // then set the group as the default container for NDAttributes.
         if (str_ndattr_default == "true"){
@@ -513,7 +507,7 @@ namespace hdf5
     if (dset_name == NULL) return -1;
 
     std::string str_dset_name((char*)dset_name);
-    xmlFree(dset_name);
+    xmlGetGlobalState()->xmlFree(dset_name);
     Group *parent = (Group *)this->ptr_curr_element;
     Dataset *dset = NULL;
     dset = parent->new_dset(str_dset_name);
@@ -526,7 +520,7 @@ namespace hdf5
     attr_def = xmlTextReaderGetAttribute(this->xmlreader, (const xmlChar*)LayoutXML::ATTR_SRC_DET_DEFAULT.c_str());
     if (attr_def != NULL){
       str_attr_def = (char*)attr_def;
-      xmlFree(attr_def);
+      xmlGetGlobalState()->xmlFree(attr_def);
       if (str_attr_def == "true"){
         detector_default = true;
       }
@@ -545,14 +539,14 @@ namespace hdf5
       attr_ndname = xmlTextReaderGetAttribute(this->xmlreader, (const xmlChar*)LayoutXML::ATTR_SRC_NDATTR.c_str());
       if (attr_ndname != NULL){
         str_attr_ndname = (char*)attr_ndname;
-        xmlFree(attr_ndname);
+        xmlGetGlobalState()->xmlFree(attr_ndname);
         dset->set_ndattr_name(str_attr_ndname);
         //if ndattribute, check for 'when' tag
         xmlChar *attr_when = NULL;
         attr_when = xmlTextReaderGetAttribute(this->xmlreader, (const xmlChar*)LayoutXML::ATTR_SRC_WHEN.c_str());
         if (attr_when != NULL){
           std::string str_attr_when( (char*)attr_when );
-          xmlFree(attr_when);
+          xmlGetGlobalState()->xmlFree(attr_when);
           When_t when_to_save = OnFrame; //Default is to save every frame
           if (str_attr_when == "OnFileOpen"){
             when_to_save = OnFileOpen;
@@ -567,12 +561,12 @@ namespace hdf5
       c_val = xmlTextReaderGetAttribute(this->xmlreader, (const xmlChar*)LayoutXML::ATTR_SRC_CONST_VALUE.c_str());
       if (c_val != NULL) {
         str_val = (char*)c_val;
-        xmlFree(c_val);
+        xmlGetGlobalState()->xmlFree(c_val);
       }
       c_type = xmlTextReaderGetAttribute(this->xmlreader, (const xmlChar*)LayoutXML::ATTR_SRC_CONST_TYPE.c_str());
       if (c_type != NULL){
         str_type = (char*)c_type;
-        xmlFree(c_type);
+        xmlGetGlobalState()->xmlFree(c_type);
         DataType_t dtype = string;
         if (str_type == "int") dtype = int32;
         else if (str_type == "float") dtype = float64;
@@ -597,7 +591,7 @@ namespace hdf5
     if (ndattr_name == NULL) return -1;
 
     std::string str_ndattr_name((char*)ndattr_name);
-    xmlFree(ndattr_name);
+    xmlGetGlobalState()->xmlFree(ndattr_name);
     Attribute ndattr(str_ndattr_name);
     this->process_attribute_xml_attribute(ndattr);
 
@@ -614,12 +608,12 @@ namespace hdf5
     global_name = xmlTextReaderGetAttribute(this->xmlreader, (const xmlChar*)LayoutXML::ATTR_GLOBAL_NAME.c_str());
     if (global_name == NULL) return -1;
     std::string str_global_name((char*)global_name);
-    xmlFree(global_name);
+    xmlGetGlobalState()->xmlFree(global_name);
     xmlChar *global_value = NULL;
     global_value = xmlTextReaderGetAttribute(this->xmlreader, (const xmlChar*)LayoutXML::ATTR_GLOBAL_VALUE.c_str());
     if (global_value == NULL) return -1;
     std::string str_global_value((char*)global_value);
-    xmlFree(global_value);
+    xmlGetGlobalState()->xmlFree(global_value);
 
     this->globals[str_global_name] = str_global_value;
     return ret;
@@ -633,12 +627,12 @@ namespace hdf5
     hardlink_name = xmlTextReaderGetAttribute(this->xmlreader, (const xmlChar*)LayoutXML::ATTR_ELEMENT_NAME.c_str());
     if (hardlink_name == NULL) return -1;
     std::string str_hardlink_name((char*)hardlink_name);
-    xmlFree(hardlink_name);
+    xmlGetGlobalState()->xmlFree(hardlink_name);
     xmlChar *hardlink_target = NULL;
     hardlink_target = xmlTextReaderGetAttribute(this->xmlreader, (const xmlChar*)LayoutXML::ATTR_HARDLINK_TARGET.c_str());
     if (hardlink_target == NULL) return -1;
     const std::string str_hardlink_target((char*)hardlink_target);
-    xmlFree(hardlink_target);
+    xmlGetGlobalState()->xmlFree(hardlink_target);
     Group *parent = (Group *)this->ptr_curr_element;
     HardLink *hardlink = NULL;
     hardlink = parent->new_hardlink(str_hardlink_name);


### PR DESCRIPTION
Resolves the LNK2001 unresolved symbol issue in #420 when building ADSupport dynamically and ADCore statically.

This was tested on Windows with EPICS BASE 3.14.12.7 and also tested on RHEL7 (although ADCore is dynamically in this case).