### PR TITLE
Added cursor value computation to ND Stats plugin.

### DIFF
--- a/ADApp/Db/NDStats.template
+++ b/ADApp/Db/NDStats.template
@@ -642,6 +642,7 @@ record(longout, "$(P)$(R)CursorX")
    field(DTYP, "asynInt32")
    field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))CURSOR_X")
    field(VAL,  "256")
+   field(FLNK, "$(P)$(R)ProcessPlugin")
    info(autosaveFields, "VAL")
 }
 
@@ -658,6 +659,7 @@ record(longout, "$(P)$(R)CursorY")
    field(DTYP, "asynInt32")
    field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))CURSOR_Y")
    field(VAL,  "256")
+   field(FLNK, "$(P)$(R)ProcessPlugin")
    info(autosaveFields, "VAL")
 }
 
@@ -665,6 +667,14 @@ record(longin, "$(P)$(R)CursorY_RBV")
 {
    field(DTYP, "asynInt32")
    field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))CURSOR_Y")
+   field(SCAN, "I/O Intr")
+}
+
+record(ai, "$(P)$(R)CursorVal")
+{
+   field(DTYP, "asynFloat64")
+   field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))CURSOR_VAL")
+   field(PREC, "1")
    field(SCAN, "I/O Intr")
 }
 

--- a/ADApp/pluginSrc/NDPluginStats.cpp
+++ b/ADApp/pluginSrc/NDPluginStats.cpp
@@ -367,6 +367,8 @@ asynStatus NDPluginStats::doComputeProfilesT(NDArray *pArray, NDStats_t *pStats)
     ix = MAX(ix, 0);
     ix = MIN(ix, pStats->profileSizeX-1);
     pCursor = pData + ix;
+    /* Compute cursor value. */
+    pStats->cursorValue = *(pData + iy * pStats->profileSizeX + ix);
     for (iy=0; iy<pStats->profileSizeY; iy++) {
         pStats->profileY[profCentroid][iy] = (double)*pCentroid;
         pStats->profileY[profCursor][iy]   = (double)*pCursor;
@@ -626,6 +628,7 @@ void NDPluginStats::processCallbacks(NDArray *pArray)
         doCallbacksFloat64Array(pStats->profileY[profCentroid],  pStats->profileSizeY, NDPluginStatsProfileCentroidY, 0);
         doCallbacksFloat64Array(pStats->profileX[profCursor],    pStats->profileSizeX, NDPluginStatsProfileCursorX, 0);
         doCallbacksFloat64Array(pStats->profileY[profCursor],    pStats->profileSizeY, NDPluginStatsProfileCursorY, 0);
+        setDoubleParam(NDPluginStatsCursorVal,     pStats->cursorValue);
     }
 
     if (computeHistogram) {
@@ -815,6 +818,7 @@ NDPluginStats::NDPluginStats(const char *portName, int queueSize, int blockingCa
     createParam(NDPluginStatsProfileSizeYString,      asynParamInt32,         &NDPluginStatsProfileSizeY);
     createParam(NDPluginStatsCursorXString,           asynParamInt32,         &NDPluginStatsCursorX);
     createParam(NDPluginStatsCursorYString,           asynParamInt32,         &NDPluginStatsCursorY);
+    createParam(NDPluginStatsCursorValString,         asynParamFloat64,       &NDPluginStatsCursorVal);
     createParam(NDPluginStatsProfileAverageXString,   asynParamFloat64Array,  &NDPluginStatsProfileAverageX);
     createParam(NDPluginStatsProfileAverageYString,   asynParamFloat64Array,  &NDPluginStatsProfileAverageY);
     createParam(NDPluginStatsProfileThresholdXString, asynParamFloat64Array,  &NDPluginStatsProfileThresholdX);

--- a/ADApp/pluginSrc/NDPluginStats.h
+++ b/ADApp/pluginSrc/NDPluginStats.h
@@ -78,6 +78,7 @@ typedef struct NDStats {
     size_t profileSizeY;
     size_t cursorX;
     size_t cursorY;
+    double  cursorValue;
     epicsInt32 *totalArray;
     epicsInt32 *netArray;
     int histSize;
@@ -125,6 +126,7 @@ typedef struct NDStats {
 #define NDPluginStatsProfileSizeYString       "PROFILE_SIZE_Y"      /* (asynInt32,        r/o) Y profile size */
 #define NDPluginStatsCursorXString            "CURSOR_X"            /* (asynInt32,        r/w) X cursor position */
 #define NDPluginStatsCursorYString            "CURSOR_Y"            /* (asynInt32,        r/w) Y cursor position */
+#define NDPluginStatsCursorValString          "CURSOR_VAL"          /* (asynFloat64,      r/o) value at cursor position */
 #define NDPluginStatsProfileAverageXString    "PROFILE_AVERAGE_X"   /* (asynFloat64Array, r/o) X average profile array */
 #define NDPluginStatsProfileAverageYString    "PROFILE_AVERAGE_Y"   /* (asynFloat64Array, r/o) Y average profile array */
 #define NDPluginStatsProfileThresholdXString  "PROFILE_THRESHOLD_X" /* (asynFloat64Array, r/o) X average profile array after threshold */
@@ -212,6 +214,7 @@ protected:
     int NDPluginStatsProfileSizeY;
     int NDPluginStatsCursorX;
     int NDPluginStatsCursorY;
+    int NDPluginStatsCursorVal;
     int NDPluginStatsProfileAverageX;
     int NDPluginStatsProfileAverageY;
     int NDPluginStatsProfileThresholdX;

--- a/documentation/NDPluginStats.html
+++ b/documentation/NDPluginStats.html
@@ -998,6 +998,30 @@
       <tr>
         <td>
           NDPluginStats<br />
+          CursorVal
+        </td>
+        <td>
+          asynFloat64
+        </td>
+        <td>
+          r/o
+        </td>
+        <td>
+          Image pixel value at cursor position.
+        </td>
+        <td>
+          CURSOR_VAL
+        </td>
+        <td>
+          $(P)$(R)CursorVal
+        </td>
+        <td>
+          ai
+        </td>
+      </tr>
+      <tr>
+        <td>
+          NDPluginStats<br />
           ProfileAverageX
         </td>
         <td>


### PR DESCRIPTION
Provides access to image pixel value at cursor position.

This enhancement and pull request suggested by colleague and EPICS mentor, Matt Pearson.

Added forward links to CursorX and CursorY to assure cursor value is updated when cursor changes.
