### PR TITLE
Eliminate shareLib.h

### DIFF
--- a/ADApp/ADSrc/ADCoreAPI.h
+++ b/ADApp/ADSrc/ADCoreAPI.h
@@ -1,0 +1,33 @@
+/* This is a generated file, do not edit! */
+
+#ifndef INC_ADCoreAPI_H
+#define INC_ADCoreAPI_H
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+
+#  if !defined(epicsStdCall)
+#    define epicsStdCall __stdcall
+#  endif
+
+#  if defined(BUILDING_ADCore_API) && defined(EPICS_BUILD_DLL)
+/* Building library as dll */
+#    define ADCORE_API __declspec(dllexport)
+#  elif !defined(BUILDING_ADCore_API) && defined(EPICS_CALL_DLL)
+/* Calling library in dll form */
+#    define ADCORE_API __declspec(dllimport)
+#  endif
+
+#elif __GNUC__ >= 4
+#  define ADCORE_API __attribute__ ((visibility("default")))
+#endif
+
+#if !defined(ADCORE_API)
+#  define ADCORE_API
+#endif
+
+#if !defined(epicsStdCall)
+#  define epicsStdCall
+#endif
+
+#endif /* INC_ADCoreAPI_H */
+

--- a/ADApp/ADSrc/ADCoreAPI.h
+++ b/ADApp/ADSrc/ADCoreAPI.h
@@ -3,6 +3,22 @@
 #ifndef INC_ADCoreAPI_H
 #define INC_ADCoreAPI_H
 
+#include <epicsVersion.h>
+
+#ifndef VERSION_INT
+//! Construct version number constant.
+#  define VERSION_INT(V,R,M,P) ( ((V)<<24) | ((R)<<16) | ((M)<<8) | (P))
+#endif
+
+#ifndef EPICS_VERSION_INT
+#  define EPICS_VERSION_INT VERSION_INT(EPICS_VERSION, EPICS_REVISION, EPICS_MODIFICATION, EPICS_PATCH_LEVEL)
+#endif
+
+#if defined(_WIN32) && EPICS_VERSION_INT<VERSION_INT(3,15,0,0) && !defined(EPICS_DLL_NO)
+#    define EPICS_BUILD_DLL
+#    define EPICS_CALL_DLL
+#endif
+
 #if defined(_WIN32) || defined(__CYGWIN__)
 
 #  if !defined(epicsStdCall)

--- a/ADApp/ADSrc/ADDriver.cpp
+++ b/ADApp/ADSrc/ADDriver.cpp
@@ -11,13 +11,10 @@
 
 #include <stdio.h>
 
-#include <epicsString.h>
 #include <epicsThread.h>
-#include <asynStandardInterfaces.h>
 
 #include <asynPortDriver.h>
 
-#include <epicsExport.h>
 #include "ADDriver.h"
 
 static const char *driverName = "ADDriver";

--- a/ADApp/ADSrc/ADDriver.h
+++ b/ADApp/ADSrc/ADDriver.h
@@ -4,7 +4,6 @@
 #include <epicsTypes.h>
 #include <epicsMessageQueue.h>
 #include <epicsTime.h>
-#include <asynStandardInterfaces.h>
 
 #include "asynNDArrayDriver.h"
 
@@ -130,7 +129,7 @@ typedef enum
 #define ADStringFromServerString    "STRING_FROM_SERVER"    /**< (asynOctet,    r/o) String received from server for message-based drivers */
 
 /** Class from which areaDetector drivers are directly derived. */
-class epicsShareClass ADDriver : public asynNDArrayDriver {
+class ADCORE_API ADDriver : public asynNDArrayDriver {
 public:
     /* This is the constructor for the class. */
     ADDriver(const char *portName, int maxAddr, int numParams, int maxBuffers, size_t maxMemory,

--- a/ADApp/ADSrc/CCDMultiTrack.cpp
+++ b/ADApp/ADSrc/CCDMultiTrack.cpp
@@ -16,9 +16,7 @@
  * @date Nov 2019
  *
  */
-#include <asynPortDriver.h>
 
-#include <epicsExport.h>
 #include "CCDMultiTrack.h"
 
 static const char* CCDMultiTrackStartString = "CCD_MULTI_TRACK_START";

--- a/ADApp/ADSrc/CCDMultiTrack.h
+++ b/ADApp/ADSrc/CCDMultiTrack.h
@@ -13,9 +13,9 @@
 
 #include <asynPortDriver.h>
 #include <NDAttributeList.h>
-#include <shareLib.h>
+#include <ADCoreAPI.h>
 
-class epicsShareClass CCDMultiTrack
+class ADCORE_API CCDMultiTrack
 {
     asynPortDriver* mPortDriver;
 

--- a/ADApp/ADSrc/Makefile
+++ b/ADApp/ADSrc/Makefile
@@ -17,9 +17,11 @@ ifeq ($(GNU),NO)
 endif
 
 USR_CFLAGS += -DUSE_TYPED_RSET
+USR_CPPFLAGS += -DBUILDING_ADCore_API
 
 DBD += ADSupport.dbd
 
+INC += ADCoreAPI.h
 INC += ADCoreVersion.h
 INC += NDAttribute.h
 INC += NDAttributeList.h

--- a/ADApp/ADSrc/NDArray.cpp
+++ b/ADApp/ADSrc/NDArray.cpp
@@ -16,13 +16,8 @@
 #include <ellLib.h>
 #include <vector>
 
-#include <epicsMutex.h>
-#include <epicsTime.h>
-#include <ellLib.h>
 #include <epicsTypes.h>
 #include <cantProceed.h>
-
-#include <epicsExport.h>
 
 #include "NDArray.h"
 

--- a/ADApp/ADSrc/NDArray.h
+++ b/ADApp/ADSrc/NDArray.h
@@ -90,7 +90,7 @@ typedef struct NDArrayInfo {
 /** N-dimensional array class; each array has a set of dimensions, a data type, pointer to data, and optional attributes.
   * An NDArray also has a uniqueId and timeStamp that to identify it. NDArray objects can be allocated
   * by an NDArrayPool object, which maintains a free list of NDArrays for efficient memory management. */
-class epicsShareClass NDArray {
+class ADCORE_API NDArray {
 public:
     /* Methods */
     NDArray();
@@ -159,7 +159,7 @@ class freeListElement {
   * array. When the reference count reaches 0 again the NDArray object is placed back
   * on the free list. This mechanism minimizes the copying of array data in plugins.
   */
-class epicsShareClass NDArrayPool {
+class ADCORE_API NDArrayPool {
 public:
     NDArrayPool  (class asynNDArrayDriver *pDriver, size_t maxMemory);
     virtual ~NDArrayPool() {}

--- a/ADApp/ADSrc/NDArrayPool.cpp
+++ b/ADApp/ADSrc/NDArrayPool.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <string.h>
 #include <stdlib.h>
 #include <dbDefs.h>
 #include <stdint.h>
@@ -14,9 +15,6 @@
 #include <epicsTime.h>
 #include <ellLib.h>
 #include <cantProceed.h>
-
-#include <asynPortDriver.h>
-
 #include <epicsExport.h>
 
 #include "asynNDArrayDriver.h"

--- a/ADApp/ADSrc/NDArrayPool.cpp
+++ b/ADApp/ADSrc/NDArrayPool.cpp
@@ -12,6 +12,7 @@
 #include <stdint.h>
 
 #include <epicsMutex.h>
+#include <epicsThread.h>
 #include <epicsTime.h>
 #include <ellLib.h>
 #include <cantProceed.h>

--- a/ADApp/ADSrc/NDArrayPool.cpp
+++ b/ADApp/ADSrc/NDArrayPool.cpp
@@ -15,6 +15,9 @@
 #include <epicsTime.h>
 #include <ellLib.h>
 #include <cantProceed.h>
+
+#include <asynDriver.h>
+
 #include <epicsExport.h>
 
 #include "asynNDArrayDriver.h"

--- a/ADApp/ADSrc/NDArrayPool.cpp
+++ b/ADApp/ADSrc/NDArrayPool.cpp
@@ -17,7 +17,7 @@
 #include <ellLib.h>
 #include <cantProceed.h>
 
-#include <asynDriver.h>
+#include <asynPortDriver.h>
 
 #include <epicsExport.h>
 

--- a/ADApp/ADSrc/NDAttribute.cpp
+++ b/ADApp/ADSrc/NDAttribute.cpp
@@ -8,10 +8,7 @@
 
 #include <string>
 #include <stdlib.h>
-
-#include <epicsString.h>
-
-#include <epicsExport.h>
+#include <string.h>
 
 #include "NDAttribute.h"
 

--- a/ADApp/ADSrc/NDAttribute.h
+++ b/ADApp/ADSrc/NDAttribute.h
@@ -10,15 +10,14 @@
 #define NDAttribute_H
 
 #include <string>
-
 #include <stdio.h>
-#include <string.h>
 
 #include <ellLib.h>
 #include <epicsTypes.h>
 
 /* asynDriver.h is needed only to define epicsInt64 on 3.14 */
 #include <asynDriver.h>
+#include <ADCoreAPI.h>
 
 /** Success return code  */
 #define ND_SUCCESS 0
@@ -93,7 +92,7 @@ typedef struct NDAttributeListNode {
 /** NDAttribute class; an attribute has a name, description, source type, source string,
   * data type, and value.
   */
-class epicsShareClass NDAttribute {
+class ADCORE_API NDAttribute {
 public:
     /* Methods */
     NDAttribute(const char *pName, const char *pDescription,

--- a/ADApp/ADSrc/NDAttributeList.cpp
+++ b/ADApp/ADSrc/NDAttributeList.cpp
@@ -8,8 +8,6 @@
 
 #include <stdlib.h>
 
-#include <epicsExport.h>
-
 #include "NDAttributeList.h"
 
 /** NDAttributeList constructor

--- a/ADApp/ADSrc/NDAttributeList.h
+++ b/ADApp/ADSrc/NDAttributeList.h
@@ -18,7 +18,7 @@
 
 /** NDAttributeList class; this is a linked list of attributes.
   */
-class epicsShareClass NDAttributeList {
+class ADCORE_API NDAttributeList {
 public:
     NDAttributeList();
     ~NDAttributeList();

--- a/ADApp/ADSrc/PVAttribute.cpp
+++ b/ADApp/ADSrc/PVAttribute.cpp
@@ -12,16 +12,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <ellLib.h>
-#include <epicsMutex.h>
 #include <epicsString.h>
-#include <cadef.h>
-#include <epicsEvent.h>
 
-#include <asynDriver.h>
-
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "PVAttribute.h"
 
 static const char *driverName = "PVAttribute";

--- a/ADApp/ADSrc/PVAttribute.h
+++ b/ADApp/ADSrc/PVAttribute.h
@@ -15,14 +15,14 @@
 #include <epicsMutex.h>
 #include <epicsEvent.h>
 
-#include "NDArray.h"
+#include "NDAttribute.h"
 
 /** Use native type for channel access */
 #define DBR_NATIVE -1
 
 /** Attribute that gets its value from an EPICS PV.
   */
-class PVAttribute : public NDAttribute {
+class ADCORE_API PVAttribute : public NDAttribute {
 public:
     PVAttribute(const char *pName, const char *pDescription, const char *pSource, chtype dbrType);
     PVAttribute(PVAttribute& attribute);

--- a/ADApp/ADSrc/asynNDArrayDriver.cpp
+++ b/ADApp/ADSrc/asynNDArrayDriver.cpp
@@ -20,16 +20,9 @@
 #include <libxml/parser.h>
 
 #include <epicsString.h>
-#include <epicsMutex.h>
-#include <epicsMutex.h>
 #include <macLib.h>
 #include <cantProceed.h>
 
-#include <asynPortDriver.h>
-
-
-#define epicsExportSharedSymbols
-#include <shareLib.h>
 #include "PVAttribute.h"
 #include "paramAttribute.h"
 #include "functAttribute.h"

--- a/ADApp/ADSrc/asynNDArrayDriver.cpp
+++ b/ADApp/ADSrc/asynNDArrayDriver.cpp
@@ -20,6 +20,7 @@
 #include <libxml/parser.h>
 
 #include <epicsString.h>
+#include <epicsThread.h>
 #include <macLib.h>
 #include <cantProceed.h>
 

--- a/ADApp/ADSrc/asynNDArrayDriver.h
+++ b/ADApp/ADSrc/asynNDArrayDriver.h
@@ -129,7 +129,7 @@ typedef enum {
   * For areaDetector, both plugins and detector drivers are indirectly derived from this class.
   * asynNDArrayDriver inherits from asynPortDriver.
   */
-class epicsShareFunc asynNDArrayDriver : public asynPortDriver {
+class ADCORE_API asynNDArrayDriver : public asynPortDriver {
 public:
     asynNDArrayDriver(const char *portName, int maxAddr, int maxBuffers, size_t maxMemory,
                       int interfaceMask, int interruptMask,

--- a/ADApp/ADSrc/functAttribute.cpp
+++ b/ADApp/ADSrc/functAttribute.cpp
@@ -8,22 +8,12 @@
  *
  */
 
-#include <string.h>
-#include <stdio.h>
 #include <stdlib.h>
 
-#include <epicsMutex.h>
-#include <epicsTime.h>
-#include <ellLib.h>
 #include <epicsString.h>
+
 #include <registryFunction.h>
 
-#include <asynPortDriver.h>
-
-#define epicsExportSharedSymbols
-#include <shareLib.h>
-#include <asynNDArrayDriver.h>
-#include "NDArray.h"
 #include "functAttribute.h"
 
 static const char *driverName = "functAttribute";

--- a/ADApp/ADSrc/functAttribute.h
+++ b/ADApp/ADSrc/functAttribute.h
@@ -11,14 +11,16 @@
 #ifndef INCfunctAttributeH
 #define INCfunctAttributeH
 
-#include "NDArray.h"
+#include <stdio.h>
+
+#include "NDAttribute.h"
 
 typedef int (*NDAttributeFunction)(const char *functParam, void **functionPvt, class functAttribute *pAttribute);
 
 /** Attribute that gets its value from a user-defined function
   * The updateValue() method for this class retrieves the current value from the function.
   */
-class functAttribute : public NDAttribute {
+class ADCORE_API functAttribute : public NDAttribute {
 public:
     functAttribute(const char *pName, const char *pDescription, const char *pSource, const char *pParam);
     functAttribute(functAttribute& attribute);

--- a/ADApp/ADSrc/myAttributeFunctions.cpp
+++ b/ADApp/ADSrc/myAttributeFunctions.cpp
@@ -4,6 +4,8 @@
 #include <registryFunction.h>
 #include <epicsTime.h>
 
+#include <asynPortDriver.h>
+
 #include <epicsExport.h>
 #include "functAttribute.h"
 

--- a/ADApp/ADSrc/paramAttribute.cpp
+++ b/ADApp/ADSrc/paramAttribute.cpp
@@ -18,11 +18,6 @@
 #include <ellLib.h>
 #include <epicsString.h>
 
-#include <asynPortDriver.h>
-
-#define epicsExportSharedSymbols
-#include <shareLib.h>
-#include <asynNDArrayDriver.h>
 #include "NDArray.h"
 #include "paramAttribute.h"
 

--- a/ADApp/ADSrc/paramAttribute.h
+++ b/ADApp/ADSrc/paramAttribute.h
@@ -11,7 +11,8 @@
 #ifndef INCparamAttributeH
 #define INCparamAttributeH
 
-#include "NDArray.h"
+#include "NDAttribute.h"
+#include "asynNDArrayDriver.h"
 
 /** Use native type for channel access */
 #define DBR_NATIVE -1
@@ -27,7 +28,7 @@ typedef enum {
 /** Attribute that gets its value from an asynNDArrayDriver driver parameter.
   * The updateValue() method for this class retrieves the current value of the driver parameter.
   */
-class paramAttribute : public NDAttribute {
+class ADCORE_API paramAttribute : public NDAttribute {
 public:
     paramAttribute(const char *pName, const char *pDescription, const char *pSource, int addr,
                     class asynNDArrayDriver *pDriver, const char *dataType);

--- a/ADApp/ntndArrayConverterSrc/Makefile
+++ b/ADApp/ntndArrayConverterSrc/Makefile
@@ -5,8 +5,11 @@ include $(TOP)/configure/CONFIG
 #=============================
 
 LIBRARY_IOC += ntndArrayConverter
+INC += ntndArrayConverterAPI.h
 INC += ntndArrayConverter.h
 LIB_SRCS += ntndArrayConverter.cpp
+
+USR_CPPFLAGS += -DBUILDING_ntndArrayConverter_API
 
 LIB_LIBS              += ADBase
 LIB_LIBS              += pvData

--- a/ADApp/ntndArrayConverterSrc/ntndArrayConverter.cpp
+++ b/ADApp/ntndArrayConverterSrc/ntndArrayConverter.cpp
@@ -1,7 +1,3 @@
-#include <math.h>
-#include <epicsTime.h>
-
-#include <epicsExport.h>
 #include "ntndArrayConverter.h"
 
 using namespace std;

--- a/ADApp/ntndArrayConverterSrc/ntndArrayConverter.h
+++ b/ADApp/ntndArrayConverterSrc/ntndArrayConverter.h
@@ -1,3 +1,6 @@
+#include <math.h>
+
+#include <ntndArrayConverterAPI.h>
 #include <NDArray.h>
 #include <pv/ntndarray.h>
 
@@ -18,7 +21,7 @@ typedef struct NTNDArrayInfo
     }x, y, color;
 }NTNDArrayInfo_t;
 
-class epicsShareClass NTNDArrayConverter
+class NTNDARRAYCONVERTER_API NTNDArrayConverter
 {
 public:
     NTNDArrayConverter(epics::nt::NTNDArrayPtr array);

--- a/ADApp/ntndArrayConverterSrc/ntndArrayConverterAPI.h
+++ b/ADApp/ntndArrayConverterSrc/ntndArrayConverterAPI.h
@@ -1,0 +1,33 @@
+/* This is a generated file, do not edit! */
+
+#ifndef INC_ntndArrayConverterAPI_H
+#define INC_ntndArrayConverterAPI_H
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+
+#  if !defined(epicsStdCall)
+#    define epicsStdCall __stdcall
+#  endif
+
+#  if defined(BUILDING_ntndArrayConverter_API) && defined(EPICS_BUILD_DLL)
+/* Building library as dll */
+#    define NTNDARRAYCONVERTER_API __declspec(dllexport)
+#  elif !defined(BUILDING_ntndArrayConverter_API) && defined(EPICS_CALL_DLL)
+/* Calling library in dll form */
+#    define NTNDARRAYCONVERTER_API __declspec(dllimport)
+#  endif
+
+#elif __GNUC__ >= 4
+#  define NTNDARRAYCONVERTER_API __attribute__ ((visibility("default")))
+#endif
+
+#if !defined(NTNDARRAYCONVERTER_API)
+#  define NTNDARRAYCONVERTER_API
+#endif
+
+#if !defined(epicsStdCall)
+#  define epicsStdCall
+#endif
+
+#endif /* INC_ntndArrayConverterAPI_H */
+

--- a/ADApp/pluginSrc/Makefile
+++ b/ADApp/pluginSrc/Makefile
@@ -14,7 +14,9 @@ ifneq ($(SHARED_LIBRARIES), YES)
    USR_CFLAGS_WIN32 += -DLIBXML_STATIC
    USR_CXXFLAGS_WIN32 += -DLIBXML_STATIC
 endif
+USR_CPPFLAGS += -DBUILDING_NDPlugin_API
 
+INC      += NDPluginAPI.h
 INC      += NDPluginDriver.h
 LIB_SRCS += NDPluginDriver.cpp
 LIB_SRCS += throttler.cpp

--- a/ADApp/pluginSrc/Makefile
+++ b/ADApp/pluginSrc/Makefile
@@ -14,6 +14,8 @@ ifneq ($(SHARED_LIBRARIES), YES)
    USR_CFLAGS_WIN32 += -DLIBXML_STATIC
    USR_CXXFLAGS_WIN32 += -DLIBXML_STATIC
 endif
+
+# This flag is what switches to declspec(dllexport) when building the library
 USR_CPPFLAGS += -DBUILDING_NDPlugin_API
 
 INC      += NDPluginAPI.h

--- a/ADApp/pluginSrc/NDArrayRing.cpp
+++ b/ADApp/pluginSrc/NDArrayRing.cpp
@@ -7,15 +7,6 @@
  * Created June 21, 2013
  */
 
-#include <stdlib.h>
-#include <string.h>
-#include <stdio.h>
-#include <math.h>
-
-#include <epicsString.h>
-#include <epicsMutex.h>
-#include <iocsh.h>
-
 #include "NDArrayRing.h"
 
 NDArrayRing::NDArrayRing(int noOfBuffers)

--- a/ADApp/pluginSrc/NDFileHDF5.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5.cpp
@@ -29,7 +29,7 @@
 #include <epicsAssert.h>
 #include <osiSock.h>
 
-#include <asynDriver.h>
+#include <asynPortDriver.h>
 
 #include <epicsExport.h>
 

--- a/ADApp/pluginSrc/NDFileHDF5.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5.cpp
@@ -10,8 +10,6 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#include <string.h>
-#include <list>
 #include <cmath>
 #include <iostream>
 #include <sstream>
@@ -20,11 +18,9 @@
 // #include <hdf5_hl.h> // high level HDF5 API not currently used (requires use of library hdf5_hl)
 
 #include <epicsTypes.h>
-#include <epicsMessageQueue.h>
 #include <epicsThread.h>
 #include <epicsEvent.h>
 #include <epicsTime.h>
-#include <epicsString.h>
 #include <iocsh.h>
 #ifdef epicsAssertAuthor
   #undef epicsAssertAuthor
@@ -32,10 +28,8 @@
 #define epicsAssertAuthor "the EPICS areaDetector collaboration (https://github.com/areaDetector/ADCore/issues)"
 #include <epicsAssert.h>
 #include <osiSock.h>
-
-#include <asynDriver.h>
-
 #include <epicsExport.h>
+
 #include "NDFileHDF5.h"
 
 #define METADATA_NDIMS 1

--- a/ADApp/pluginSrc/NDFileHDF5.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5.cpp
@@ -28,6 +28,9 @@
 #define epicsAssertAuthor "the EPICS areaDetector collaboration (https://github.com/areaDetector/ADCore/issues)"
 #include <epicsAssert.h>
 #include <osiSock.h>
+
+#include <asynDriver.h>
+
 #include <epicsExport.h>
 
 #include "NDFileHDF5.h"

--- a/ADApp/pluginSrc/NDFileHDF5.h
+++ b/ADApp/pluginSrc/NDFileHDF5.h
@@ -8,8 +8,8 @@
 #define NDFileHDF5_H
 
 #include <list>
+#include <string.h>
 #include <hdf5.h>
-#include <asynDriver.h>
 #include <NDPluginFile.h>
 #include <NDArray.h>
 #include "NDFileHDF5Layout.h"
@@ -64,7 +64,7 @@
 
 /** Writes NDArrays in the HDF5 file format; an XML file can control the structure of the HDF5 file.
   */
-class epicsShareClass NDFileHDF5 : public NDPluginFile
+class NDPLUGIN_API NDFileHDF5 : public NDPluginFile
 {
   public:
     static const char *str_NDFileHDF5_chunkSize[MAX_CHUNK_DIMS];

--- a/ADApp/pluginSrc/NDFileHDF5AttributeDataset.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5AttributeDataset.cpp
@@ -5,11 +5,14 @@
  *      Author: gnx91527
  */
 
-#include "NDFileHDF5AttributeDataset.h"
-#include <epicsString.h>
 #include <iostream>
 #include <stdlib.h>
+#include <string.h>
+
+#include <epicsString.h>
 #include <epicsMath.h>
+
+#include "NDFileHDF5AttributeDataset.h"
 
 #define MAX_ATTRIBUTE_STRING_SIZE 256
 

--- a/ADApp/pluginSrc/NDFileHDF5AttributeDataset.h
+++ b/ADApp/pluginSrc/NDFileHDF5AttributeDataset.h
@@ -11,8 +11,7 @@
 #include <string>
 #include <hdf5.h>
 #include <asynDriver.h>
-#include <NDPluginFile.h>
-#include <NDArray.h>
+#include <NDAttribute.h>
 #include "NDFileHDF5Layout.h"
 #include "NDFileHDF5VersionCheck.h"
 

--- a/ADApp/pluginSrc/NDFileHDF5Dataset.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5Dataset.cpp
@@ -1,9 +1,12 @@
-#include "NDFileHDF5Dataset.h"
 #include <iostream>
 #include <stdlib.h>
+#include <string.h>
+
 #include <osiSock.h>
 
 #include <hdf5_hl.h>
+
+#include "NDFileHDF5Dataset.h"
 
 #ifndef htonll
 #define htonll(x) ( ( (uint64_t)(htonl( (uint32_t)(((uint64_t)x << 32) >> 32)))<< 32) | htonl( ((uint32_t)((uint64_t)x >> 32)) ))

--- a/ADApp/pluginSrc/NDFileHDF5LayoutXML.h
+++ b/ADApp/pluginSrc/NDFileHDF5LayoutXML.h
@@ -15,6 +15,8 @@
 #include <log4cxx/logger.h>
 #else
 
+#include <NDPluginAPI.h>
+
 // std::cout logging if log4cxx is not defined
 // define HDF5_LOGGING 1 to print log messages
 //#define HDF5_LOGGING 1
@@ -56,7 +58,7 @@ namespace hdf5
 
   /**  Used to define layout of HDF5 file with NDFileHDF5 plugin
     */
-  class epicsShareClass LayoutXML
+  class NDPLUGIN_API LayoutXML
   {
     public:
       static const std::string ATTR_ELEMENT_NAME;

--- a/ADApp/pluginSrc/NDFileJPEG.cpp
+++ b/ADApp/pluginSrc/NDFileJPEG.cpp
@@ -9,14 +9,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <epicsTypes.h>
-#include <epicsMessageQueue.h>
-#include <epicsThread.h>
-#include <epicsEvent.h>
-#include <epicsTime.h>
 #include <iocsh.h>
-
-#include <asynDriver.h>
 
 #include <epicsExport.h>
 #include "NDPluginFile.h"

--- a/ADApp/pluginSrc/NDFileJPEG.cpp
+++ b/ADApp/pluginSrc/NDFileJPEG.cpp
@@ -11,6 +11,7 @@
 
 #include <iocsh.h>
 #include <epicsThread.h>
+#include <epicsTime.h>
 
 #include <asynPortDriver.h>
 

--- a/ADApp/pluginSrc/NDFileJPEG.cpp
+++ b/ADApp/pluginSrc/NDFileJPEG.cpp
@@ -10,8 +10,12 @@
 #include <string.h>
 
 #include <iocsh.h>
+#include <epicsThread.h>
+
+#include <asynDriver.h>
 
 #include <epicsExport.h>
+
 #include "NDPluginFile.h"
 #include "NDFileJPEG.h"
 

--- a/ADApp/pluginSrc/NDFileJPEG.cpp
+++ b/ADApp/pluginSrc/NDFileJPEG.cpp
@@ -12,7 +12,7 @@
 #include <iocsh.h>
 #include <epicsThread.h>
 
-#include <asynDriver.h>
+#include <asynPortDriver.h>
 
 #include <epicsExport.h>
 

--- a/ADApp/pluginSrc/NDFileJPEG.h
+++ b/ADApp/pluginSrc/NDFileJPEG.h
@@ -32,7 +32,7 @@ typedef struct {
 /** Writes NDArrays in the JPEG file format, which is a lossy compression format.
   * This plugin was developed using the libjpeg library to write the file.
   */
-class epicsShareClass NDFileJPEG : public NDPluginFile {
+class NDPLUGIN_API NDFileJPEG : public NDPluginFile {
 public:
     NDFileJPEG(const char *portName, int queueSize, int blockingCallbacks,
                const char *NDArrayPort, int NDArrayAddr,

--- a/ADApp/pluginSrc/NDFileMagick.cpp
+++ b/ADApp/pluginSrc/NDFileMagick.cpp
@@ -16,7 +16,7 @@
 #include <epicsTime.h>
 #include <iocsh.h>
 
-#include <asynDriver.h>
+#include <asynPortDriver.h>
 
 #include <epicsExport.h>
 

--- a/ADApp/pluginSrc/NDFileMagick.cpp
+++ b/ADApp/pluginSrc/NDFileMagick.cpp
@@ -15,11 +15,8 @@
 #include <epicsEvent.h>
 #include <epicsTime.h>
 #include <iocsh.h>
-
-#include <asynDriver.h>
-
 #include <epicsExport.h>
-#include "NDPluginFile.h"
+
 #include "NDFileMagick.h"
 
 static const char *driverName = "NDFileMagick";

--- a/ADApp/pluginSrc/NDFileMagick.cpp
+++ b/ADApp/pluginSrc/NDFileMagick.cpp
@@ -15,6 +15,9 @@
 #include <epicsEvent.h>
 #include <epicsTime.h>
 #include <iocsh.h>
+
+#include <asynDriver.h>
+
 #include <epicsExport.h>
 
 #include "NDFileMagick.h"

--- a/ADApp/pluginSrc/NDFileMagick.h
+++ b/ADApp/pluginSrc/NDFileMagick.h
@@ -19,7 +19,7 @@ using namespace std;
 
 /** Writes NDArrays to files using the GraphicsMagick library; can write many different file formats.
   */
-class epicsShareClass NDFileMagick : public NDPluginFile {
+class NDPLUGIN_API NDFileMagick : public NDPluginFile {
 public:
     NDFileMagick(const char *portName, int queueSize, int blockingCallbacks,
                  const char *NDArrayPort, int NDArrayAddr,

--- a/ADApp/pluginSrc/NDFileNetCDF.cpp
+++ b/ADApp/pluginSrc/NDFileNetCDF.cpp
@@ -16,6 +16,9 @@
 #include <epicsEvent.h>
 #include <epicsTime.h>
 #include <iocsh.h>
+
+#include <asynDriver.h>
+
 #include <epicsExport.h>
 
 #include "NDPluginFile.h"

--- a/ADApp/pluginSrc/NDFileNetCDF.cpp
+++ b/ADApp/pluginSrc/NDFileNetCDF.cpp
@@ -16,10 +16,8 @@
 #include <epicsEvent.h>
 #include <epicsTime.h>
 #include <iocsh.h>
-
-#include <asynDriver.h>
-
 #include <epicsExport.h>
+
 #include "NDPluginFile.h"
 #include "NDFileNetCDF.h"
 

--- a/ADApp/pluginSrc/NDFileNetCDF.cpp
+++ b/ADApp/pluginSrc/NDFileNetCDF.cpp
@@ -17,7 +17,7 @@
 #include <epicsTime.h>
 #include <iocsh.h>
 
-#include <asynDriver.h>
+#include <asynPortDriver.h>
 
 #include <epicsExport.h>
 

--- a/ADApp/pluginSrc/NDFileNetCDF.h
+++ b/ADApp/pluginSrc/NDFileNetCDF.h
@@ -26,7 +26,7 @@
   * If also can store all of the attributes associated with an NDArray.
   * This class implements the 4 pure virtual functions from
   * NDPluginFile: openFile, readFile, writeFile and closeFile. */
-class epicsShareClass NDFileNetCDF : public NDPluginFile {
+class NDPLUGIN_API NDFileNetCDF : public NDPluginFile {
 public:
     NDFileNetCDF(const char *portName, int queueSize, int blockingCallbacks,
                  const char *NDArrayPort, int NDArrayAddr,

--- a/ADApp/pluginSrc/NDFileNexus.cpp
+++ b/ADApp/pluginSrc/NDFileNexus.cpp
@@ -20,11 +20,8 @@
 #include <libxml/parser.h>
 #include <napi.h>
 #include <string.h>
-
-#include <asynDriver.h>
-
 #include <epicsExport.h>
-#include "NDPluginFile.h"
+
 #include "NDFileNexus.h"
 
 static const char *driverName="NDFileNexus";

--- a/ADApp/pluginSrc/NDFileNexus.cpp
+++ b/ADApp/pluginSrc/NDFileNexus.cpp
@@ -20,6 +20,9 @@
 #include <libxml/parser.h>
 #include <napi.h>
 #include <string.h>
+
+#include <asynDriver.h>
+
 #include <epicsExport.h>
 
 #include "NDFileNexus.h"

--- a/ADApp/pluginSrc/NDFileNexus.cpp
+++ b/ADApp/pluginSrc/NDFileNexus.cpp
@@ -21,7 +21,7 @@
 #include <napi.h>
 #include <string.h>
 
-#include <asynDriver.h>
+#include <asynPortDriver.h>
 
 #include <epicsExport.h>
 

--- a/ADApp/pluginSrc/NDFileNexus.h
+++ b/ADApp/pluginSrc/NDFileNexus.h
@@ -28,7 +28,7 @@
   * This version is currently limited to writing a single NDArray to each NeXus file.
   * Future releases will be capable of storing multiple NDArrays in each NeXus file.
   */
-class epicsShareClass NDFileNexus : public NDPluginFile {
+class NDPLUGIN_API NDFileNexus : public NDPluginFile {
 public:
     NDFileNexus(const char *portName, int queueSize, int blockingCallbacks,
                  const char *NDArrayPort, int NDArrayAddr,

--- a/ADApp/pluginSrc/NDFileNull.cpp
+++ b/ADApp/pluginSrc/NDFileNull.cpp
@@ -16,6 +16,9 @@
 #include <epicsEvent.h>
 #include <epicsTime.h>
 #include <iocsh.h>
+
+#include <asynPortDriver.h>
+
 #include <epicsExport.h>
 
 #include "NDFileNull.h"

--- a/ADApp/pluginSrc/NDFileNull.cpp
+++ b/ADApp/pluginSrc/NDFileNull.cpp
@@ -16,10 +16,8 @@
 #include <epicsEvent.h>
 #include <epicsTime.h>
 #include <iocsh.h>
-
-#include <asynDriver.h>
-
 #include <epicsExport.h>
+
 #include "NDFileNull.h"
 
 //static const char *driverName = "NDFileNull";

--- a/ADApp/pluginSrc/NDFileNull.h
+++ b/ADApp/pluginSrc/NDFileNull.h
@@ -14,7 +14,7 @@
 
 /** Writes NDArrays in the Null file format. */
 
-class epicsShareClass NDFileNull : public NDPluginFile {
+class NDPLUGIN_API NDFileNull : public NDPluginFile {
 public:
     NDFileNull(const char *portName, int queueSize, int blockingCallbacks,
                  const char *NDArrayPort, int NDArrayAddr,

--- a/ADApp/pluginSrc/NDFileTIFF.cpp
+++ b/ADApp/pluginSrc/NDFileTIFF.cpp
@@ -29,6 +29,9 @@
 #include <epicsEvent.h>
 #include <epicsTime.h>
 #include <iocsh.h>
+
+#include <asynDriver.h>
+
 #include <epicsExport.h>
 
 #include "tiffio.h"

--- a/ADApp/pluginSrc/NDFileTIFF.cpp
+++ b/ADApp/pluginSrc/NDFileTIFF.cpp
@@ -30,7 +30,7 @@
 #include <epicsTime.h>
 #include <iocsh.h>
 
-#include <asynDriver.h>
+#include <asynPortDriver.h>
 
 #include <epicsExport.h>
 

--- a/ADApp/pluginSrc/NDFileTIFF.cpp
+++ b/ADApp/pluginSrc/NDFileTIFF.cpp
@@ -29,11 +29,8 @@
 #include <epicsEvent.h>
 #include <epicsTime.h>
 #include <iocsh.h>
-
-#include <asynDriver.h>
-
 #include <epicsExport.h>
-#include "NDPluginFile.h"
+
 #include "tiffio.h"
 #include "NDFileTIFF.h"
 

--- a/ADApp/pluginSrc/NDFileTIFF.h
+++ b/ADApp/pluginSrc/NDFileTIFF.h
@@ -21,7 +21,7 @@
     The current version is only capable of writing 2-D images with one image per file.
     */
 
-class epicsShareClass NDFileTIFF : public NDPluginFile {
+class NDPLUGIN_API NDFileTIFF : public NDPluginFile {
 public:
     NDFileTIFF(const char *portName, int queueSize, int blockingCallbacks,
                  const char *NDArrayPort, int NDArrayAddr,

--- a/ADApp/pluginSrc/NDPluginAPI.h
+++ b/ADApp/pluginSrc/NDPluginAPI.h
@@ -3,6 +3,22 @@
 #ifndef INC_NDPluginAPI_H
 #define INC_NDPluginAPI_H
 
+#include <epicsVersion.h>
+
+#ifndef VERSION_INT
+//! Construct version number constant.
+#  define VERSION_INT(V,R,M,P) ( ((V)<<24) | ((R)<<16) | ((M)<<8) | (P))
+#endif
+
+#ifndef EPICS_VERSION_INT
+#  define EPICS_VERSION_INT VERSION_INT(EPICS_VERSION, EPICS_REVISION, EPICS_MODIFICATION, EPICS_PATCH_LEVEL)
+#endif
+
+#if defined(_WIN32) && EPICS_VERSION_INT<VERSION_INT(3,15,0,0) && !defined(EPICS_DLL_NO)
+#    define EPICS_BUILD_DLL
+#    define EPICS_CALL_DLL
+#endif
+
 #if defined(_WIN32) || defined(__CYGWIN__)
 
 #  if !defined(epicsStdCall)

--- a/ADApp/pluginSrc/NDPluginAPI.h
+++ b/ADApp/pluginSrc/NDPluginAPI.h
@@ -1,0 +1,33 @@
+/* This is a generated file, do not edit! */
+
+#ifndef INC_NDPluginAPI_H
+#define INC_NDPluginAPI_H
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+
+#  if !defined(epicsStdCall)
+#    define epicsStdCall __stdcall
+#  endif
+
+#  if defined(BUILDING_NDPlugin_API) && defined(EPICS_BUILD_DLL)
+/* Building library as dll */
+#    define NDPLUGIN_API __declspec(dllexport)
+#  elif !defined(BUILDING_NDPlugin_API) && defined(EPICS_CALL_DLL)
+/* Calling library in dll form */
+#    define NDPLUGIN_API __declspec(dllimport)
+#  endif
+
+#elif __GNUC__ >= 4
+#  define NDPLUGIN_API __attribute__ ((visibility("default")))
+#endif
+
+#if !defined(NDPLUGIN_API)
+#  define NDPLUGIN_API
+#endif
+
+#if !defined(epicsStdCall)
+#  define epicsStdCall
+#endif
+
+#endif /* INC_NDPluginAPI_H */
+

--- a/ADApp/pluginSrc/NDPluginAttrPlot.cpp
+++ b/ADApp/pluginSrc/NDPluginAttrPlot.cpp
@@ -7,8 +7,8 @@
 #include <initHooks.h>
 #include <epicsMath.h>
 #include <epicsThread.h>
-
 #include <epicsExport.h>
+
 #include "NDPluginAttrPlot.h"
 #include "CircularBuffer.h"
 

--- a/ADApp/pluginSrc/NDPluginAttrPlot.cpp
+++ b/ADApp/pluginSrc/NDPluginAttrPlot.cpp
@@ -7,6 +7,10 @@
 #include <initHooks.h>
 #include <epicsMath.h>
 #include <epicsThread.h>
+#include <epicsTime.h>
+
+#include <asynPortDriver.h>
+
 #include <epicsExport.h>
 
 #include "NDPluginAttrPlot.h"

--- a/ADApp/pluginSrc/NDPluginAttrPlot.h
+++ b/ADApp/pluginSrc/NDPluginAttrPlot.h
@@ -90,7 +90,7 @@ private:
  * and populated in first come first served fashion (unpredictable order).
  * On reset or reacquistion the cache is cleared and all data is discarded.
  */
-class NDPluginAttrPlot : public NDPluginDriver
+class NDPLUGIN_API NDPluginAttrPlot : public NDPluginDriver
 {
     typedef CircularBuffer<double> CB;
 

--- a/ADApp/pluginSrc/NDPluginAttribute.cpp
+++ b/ADApp/pluginSrc/NDPluginAttribute.cpp
@@ -13,6 +13,7 @@
 #include <algorithm>
 
 #include <iocsh.h>
+#include <epicsThread.h>
 
 #include <asynDriver.h>
 

--- a/ADApp/pluginSrc/NDPluginAttribute.cpp
+++ b/ADApp/pluginSrc/NDPluginAttribute.cpp
@@ -14,6 +14,7 @@
 
 #include <iocsh.h>
 #include <epicsThread.h>
+#include <epicsTime.h>
 
 #include <asynPortDriver.h>
 

--- a/ADApp/pluginSrc/NDPluginAttribute.cpp
+++ b/ADApp/pluginSrc/NDPluginAttribute.cpp
@@ -10,20 +10,11 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
-#include <math.h>
 #include <algorithm>
 
-#include <epicsTypes.h>
-#include <epicsMessageQueue.h>
-#include <epicsThread.h>
-#include <epicsEvent.h>
-#include <epicsTime.h>
 #include <iocsh.h>
-
-#include <asynDriver.h>
-
 #include <epicsExport.h>
-#include "NDPluginDriver.h"
+
 #include "NDPluginAttribute.h"
 
 const epicsInt32 NDPluginAttribute::MAX_ATTR_NAME_      = 256;

--- a/ADApp/pluginSrc/NDPluginAttribute.cpp
+++ b/ADApp/pluginSrc/NDPluginAttribute.cpp
@@ -15,7 +15,7 @@
 #include <iocsh.h>
 #include <epicsThread.h>
 
-#include <asynDriver.h>
+#include <asynPortDriver.h>
 
 #include <epicsExport.h>
 

--- a/ADApp/pluginSrc/NDPluginAttribute.cpp
+++ b/ADApp/pluginSrc/NDPluginAttribute.cpp
@@ -13,6 +13,9 @@
 #include <algorithm>
 
 #include <iocsh.h>
+
+#include <asynDriver.h>
+
 #include <epicsExport.h>
 
 #include "NDPluginAttribute.h"

--- a/ADApp/pluginSrc/NDPluginAttribute.h
+++ b/ADApp/pluginSrc/NDPluginAttribute.h
@@ -13,7 +13,7 @@
 #define NDPluginAttributeValSumString         "ATTR_VAL_SUM"          /* (asynFloat64,      r/o) Integrated Value of Attribute */
 
 /** Extract an Attribute from an NDArray and publish the value (and array of values) over channel access.  */
-class epicsShareClass NDPluginAttribute : public NDPluginDriver {
+class NDPLUGIN_API NDPluginAttribute : public NDPluginDriver {
 public:
     NDPluginAttribute(const char *portName, int queueSize, int blockingCallbacks,
                       const char *NDArrayPort, int NDArrayAddr, int maxAttributes,

--- a/ADApp/pluginSrc/NDPluginCircularBuff.cpp
+++ b/ADApp/pluginSrc/NDPluginCircularBuff.cpp
@@ -14,7 +14,11 @@
 
 #include <epicsTypes.h>
 #include <epicsMath.h>
+#include <epicsThread.h>
 #include <iocsh.h>
+
+#include <asynDriver.h>
+
 #include <epicsExport.h>
 
 #include "NDPluginCircularBuff.h"

--- a/ADApp/pluginSrc/NDPluginCircularBuff.cpp
+++ b/ADApp/pluginSrc/NDPluginCircularBuff.cpp
@@ -17,7 +17,7 @@
 #include <epicsThread.h>
 #include <iocsh.h>
 
-#include <asynDriver.h>
+#include <asynPortDriver.h>
 
 #include <epicsExport.h>
 

--- a/ADApp/pluginSrc/NDPluginCircularBuff.cpp
+++ b/ADApp/pluginSrc/NDPluginCircularBuff.cpp
@@ -15,6 +15,7 @@
 #include <epicsTypes.h>
 #include <epicsMath.h>
 #include <epicsThread.h>
+#include <epicsTime.h>
 #include <iocsh.h>
 
 #include <asynPortDriver.h>

--- a/ADApp/pluginSrc/NDPluginCircularBuff.cpp
+++ b/ADApp/pluginSrc/NDPluginCircularBuff.cpp
@@ -13,17 +13,10 @@
 #include <math.h>
 
 #include <epicsTypes.h>
-#include <epicsMessageQueue.h>
-#include <epicsThread.h>
-#include <epicsEvent.h>
-#include <epicsTime.h>
 #include <epicsMath.h>
 #include <iocsh.h>
-#include <postfix.h>
-
-#include <asynDriver.h>
-
 #include <epicsExport.h>
+
 #include "NDPluginCircularBuff.h"
 
 static const char *driverName="NDPluginCircularBuff";

--- a/ADApp/pluginSrc/NDPluginCircularBuff.h
+++ b/ADApp/pluginSrc/NDPluginCircularBuff.h
@@ -30,7 +30,7 @@
 /** Performs a scope like capture.  Records a quantity
   * of pre-trigger and post-trigger images
   */
-class epicsShareClass NDPluginCircularBuff : public NDPluginDriver {
+class NDPLUGIN_API NDPluginCircularBuff : public NDPluginDriver {
 public:
     NDPluginCircularBuff(const char *portName, int queueSize, int blockingCallbacks,
                  const char *NDArrayPort, int NDArrayAddr,

--- a/ADApp/pluginSrc/NDPluginCodec.cpp
+++ b/ADApp/pluginSrc/NDPluginCodec.cpp
@@ -44,15 +44,9 @@
 #include <math.h>
 
 #include <epicsTypes.h>
-#include <epicsMessageQueue.h>
-#include <epicsThread.h>
-#include <epicsEvent.h>
-#include <epicsTime.h>
 #include <iocsh.h>
-
-#include <asynDriver.h>
-
 #include <epicsExport.h>
+
 #include "Codec.h"
 #include "NDPluginCodec.h"
 

--- a/ADApp/pluginSrc/NDPluginCodec.cpp
+++ b/ADApp/pluginSrc/NDPluginCodec.cpp
@@ -45,6 +45,7 @@
 
 #include <epicsTypes.h>
 #include <epicsThread.h>
+#include <epicsTime.h>
 #include <iocsh.h>
 
 #include <asynPortDriver.h>

--- a/ADApp/pluginSrc/NDPluginCodec.cpp
+++ b/ADApp/pluginSrc/NDPluginCodec.cpp
@@ -47,7 +47,7 @@
 #include <epicsThread.h>
 #include <iocsh.h>
 
-#include <asynDriver.h>
+#include <asynPortDriver.h>
 
 #include <epicsExport.h>
 

--- a/ADApp/pluginSrc/NDPluginCodec.cpp
+++ b/ADApp/pluginSrc/NDPluginCodec.cpp
@@ -44,7 +44,11 @@
 #include <math.h>
 
 #include <epicsTypes.h>
+#include <epicsThread.h>
 #include <iocsh.h>
+
+#include <asynDriver.h>
+
 #include <epicsExport.h>
 
 #include "Codec.h"

--- a/ADApp/pluginSrc/NDPluginCodec.h
+++ b/ADApp/pluginSrc/NDPluginCodec.h
@@ -1,8 +1,6 @@
 #ifndef NDPluginCodec_H
 #define NDPluginCodec_H
 
-#include <epicsTypes.h>
-
 #include "NDPluginDriver.h"
 
 #define NDCodecModeString             "MODE"             /* (NDCodecMode_t r/w) Mode: Compress/Decompress */
@@ -66,7 +64,7 @@ NDArray *compressBSLZ4(NDArray *input, NDCodecStatus_t *status, char *errorMessa
 NDArray *decompressBSLZ4(NDArray *input, NDCodecStatus_t *status, char *errorMessage);
 
 
-class epicsShareClass NDPluginCodec : public NDPluginDriver {
+class NDPLUGIN_API NDPluginCodec : public NDPluginDriver {
 public:
     NDPluginCodec(const char *portName, int queueSize, int blockingCallbacks,
                   const char *NDArrayPort, int NDArrayAddr,

--- a/ADApp/pluginSrc/NDPluginColorConvert.cpp
+++ b/ADApp/pluginSrc/NDPluginColorConvert.cpp
@@ -15,6 +15,7 @@
 
 #include <epicsTypes.h>
 #include <epicsThread.h>
+#include <epicsTime.h>
 #include <iocsh.h>
 
 #include <asynPortDriver.h>

--- a/ADApp/pluginSrc/NDPluginColorConvert.cpp
+++ b/ADApp/pluginSrc/NDPluginColorConvert.cpp
@@ -14,6 +14,7 @@
 #include <math.h>
 
 #include <epicsTypes.h>
+#include <epicsThread.h>
 #include <iocsh.h>
 
 #include <asynDriver.h>

--- a/ADApp/pluginSrc/NDPluginColorConvert.cpp
+++ b/ADApp/pluginSrc/NDPluginColorConvert.cpp
@@ -14,10 +14,6 @@
 #include <math.h>
 
 #include <epicsTypes.h>
-#include <epicsMessageQueue.h>
-#include <epicsThread.h>
-#include <epicsEvent.h>
-#include <epicsTime.h>
 #include <iocsh.h>
 
 #include <asynDriver.h>

--- a/ADApp/pluginSrc/NDPluginColorConvert.cpp
+++ b/ADApp/pluginSrc/NDPluginColorConvert.cpp
@@ -17,7 +17,7 @@
 #include <epicsThread.h>
 #include <iocsh.h>
 
-#include <asynDriver.h>
+#include <asynPortDriver.h>
 
 #include <epicsExport.h>
 #include "NDPluginDriver.h"

--- a/ADApp/pluginSrc/NDPluginColorConvert.h
+++ b/ADApp/pluginSrc/NDPluginColorConvert.h
@@ -23,7 +23,7 @@
   * It also applies a false color map if requested for 8 bit data
   * If the conversion required by the input color mode and output color mode are not
   * in this supported list then the NDArray is passed on without conversion. */
-class epicsShareClass NDPluginColorConvert : public NDPluginDriver {
+class NDPLUGIN_API NDPluginColorConvert : public NDPluginDriver {
 public:
     NDPluginColorConvert(const char *portName, int queueSize, int blockingCallbacks,
                          const char *NDArrayPort, int NDArrayAddr,

--- a/ADApp/pluginSrc/NDPluginDriver.cpp
+++ b/ADApp/pluginSrc/NDPluginDriver.cpp
@@ -20,7 +20,7 @@
 #include <epicsTime.h>
 #include <cantProceed.h>
 
-#include <asynDriver.h>
+#include <asynPortDriver.h>
 
 #include <epicsExport.h>
 #include "NDPluginDriver.h"

--- a/ADApp/pluginSrc/NDPluginDriver.h
+++ b/ADApp/pluginSrc/NDPluginDriver.h
@@ -7,6 +7,8 @@
 #include <epicsThread.h>
 #include <epicsTime.h>
 
+#include <NDPluginAPI.h>
+
 #include "asynNDArrayDriver.h"
 
 class Throttler;
@@ -52,7 +54,7 @@ class sortedListElement {
                                                                          *to execute plugin code */
 #define NDPluginDriverMaxByteRateString         "MAX_BYTE_RATE"         /**< (asynFloat64,  r/w) Limit on byte rate output of plugin */
 /** Class from which actual plugin drivers are derived; derived from asynNDArrayDriver */
-class epicsShareClass NDPluginDriver : public asynNDArrayDriver, public epicsThreadRunable {
+class NDPLUGIN_API NDPluginDriver : public asynNDArrayDriver, public epicsThreadRunable {
 public:
     NDPluginDriver(const char *portName, int queueSize, int blockingCallbacks,
                    const char *NDArrayPort, int NDArrayAddr, int maxAddr,

--- a/ADApp/pluginSrc/NDPluginFFT.cpp
+++ b/ADApp/pluginSrc/NDPluginFFT.cpp
@@ -19,7 +19,7 @@
 #include <epicsTime.h>
 #include <iocsh.h>
 
-#include <asynDriver.h>
+#include <asynPortDriver.h>
 
 #include <NDArray.h>
 

--- a/ADApp/pluginSrc/NDPluginFFT.h
+++ b/ADApp/pluginSrc/NDPluginFFT.h
@@ -10,9 +10,6 @@
 #ifndef NDPluginFFT_H
 #define NDPluginFFT_H
 
-#include <epicsTypes.h>
-#include <epicsTime.h>
-
 #include "NDPluginDriver.h"
 
 #define FFTTimeAxisString        "FFT_TIME_AXIS"        /* (asynFloat64Array, r/o) Time axis array */
@@ -46,7 +43,7 @@ typedef struct {
 } fftPvt_t;
 
 /** Compute FFTs on signals */
-class epicsShareClass NDPluginFFT : public NDPluginDriver {
+class NDPLUGIN_API NDPluginFFT : public NDPluginDriver {
 public:
   NDPluginFFT(const char *portName, int queueSize, int blockingCallbacks,
               const char *NDArrayPort, int NDArrayAddr,

--- a/ADApp/pluginSrc/NDPluginFile.cpp
+++ b/ADApp/pluginSrc/NDPluginFile.cpp
@@ -16,6 +16,7 @@
 #include <epicsTypes.h>
 #include <epicsString.h>
 #include <epicsThread.h>
+#include <epicsTime.h>
 
 #include <asynPortDriver.h>
 

--- a/ADApp/pluginSrc/NDPluginFile.cpp
+++ b/ADApp/pluginSrc/NDPluginFile.cpp
@@ -14,10 +14,6 @@
 #include <errno.h>
 
 #include <epicsTypes.h>
-#include <epicsMessageQueue.h>
-#include <epicsThread.h>
-#include <epicsEvent.h>
-#include <epicsTime.h>
 #include <epicsString.h>
 
 #include <asynDriver.h>

--- a/ADApp/pluginSrc/NDPluginFile.cpp
+++ b/ADApp/pluginSrc/NDPluginFile.cpp
@@ -15,6 +15,7 @@
 
 #include <epicsTypes.h>
 #include <epicsString.h>
+#include <epicsThread.h>
 
 #include <asynDriver.h>
 

--- a/ADApp/pluginSrc/NDPluginFile.cpp
+++ b/ADApp/pluginSrc/NDPluginFile.cpp
@@ -17,7 +17,7 @@
 #include <epicsString.h>
 #include <epicsThread.h>
 
-#include <asynDriver.h>
+#include <asynPortDriver.h>
 
 #include <epicsExport.h>
 #include <NDPluginDriver.h>

--- a/ADApp/pluginSrc/NDPluginFile.h
+++ b/ADApp/pluginSrc/NDPluginFile.h
@@ -25,7 +25,7 @@ typedef int NDFileOpenMode_t;
   * This class handles the logic of single file per image, capture into buffer or streaming multiple images
   * to a single file.
   * Derived classes must implement the 4 pure virtual functions: openFile, readFile, writeFile and closeFile. */
-class epicsShareClass NDPluginFile : public NDPluginDriver {
+class NDPLUGIN_API NDPluginFile : public NDPluginDriver {
 public:
     NDPluginFile(const char *portName, int queueSize, int blockingCallbacks,
                  const char *NDArrayPort, int NDArrayAddr, int maxAddr,

--- a/ADApp/pluginSrc/NDPluginGather.cpp
+++ b/ADApp/pluginSrc/NDPluginGather.cpp
@@ -15,7 +15,7 @@
 #include <epicsThread.h>
 #include <iocsh.h>
 
-#include <asynDriver.h>
+#include <asynPortDriver.h>
 
 #include <epicsExport.h>
 

--- a/ADApp/pluginSrc/NDPluginGather.cpp
+++ b/ADApp/pluginSrc/NDPluginGather.cpp
@@ -8,18 +8,13 @@
  */
 
 #include <stdlib.h>
+#include <string.h>
 #include <stdio.h>
 
 #include <epicsTypes.h>
-#include <epicsMessageQueue.h>
-#include <epicsThread.h>
-#include <epicsTime.h>
 #include <iocsh.h>
-
-#include <asynDriver.h>
-
 #include <epicsExport.h>
-#include "NDPluginDriver.h"
+
 #include "NDPluginGather.h"
 
 static const char *driverName="NDPluginGather";

--- a/ADApp/pluginSrc/NDPluginGather.cpp
+++ b/ADApp/pluginSrc/NDPluginGather.cpp
@@ -12,7 +12,11 @@
 #include <stdio.h>
 
 #include <epicsTypes.h>
+#include <epicsThread.h>
 #include <iocsh.h>
+
+#include <asynDriver.h>
+
 #include <epicsExport.h>
 
 #include "NDPluginGather.h"

--- a/ADApp/pluginSrc/NDPluginGather.cpp
+++ b/ADApp/pluginSrc/NDPluginGather.cpp
@@ -13,6 +13,7 @@
 
 #include <epicsTypes.h>
 #include <epicsThread.h>
+#include <epicsTime.h>
 #include <iocsh.h>
 
 #include <asynPortDriver.h>

--- a/ADApp/pluginSrc/NDPluginGather.h
+++ b/ADApp/pluginSrc/NDPluginGather.h
@@ -14,7 +14,7 @@ typedef struct {
 } NDGatherNDArraySource_t;
 
 /** A plugin that subscribes to callbacks from multiple ports, not just a single port  */
-class epicsShareClass NDPluginGather : public NDPluginDriver {
+class NDPLUGIN_API NDPluginGather : public NDPluginDriver {
 public:
     NDPluginGather(const char *portName, int queueSize, int blockingCallbacks,
                    int maxPorts,

--- a/ADApp/pluginSrc/NDPluginOverlay.cpp
+++ b/ADApp/pluginSrc/NDPluginOverlay.cpp
@@ -13,7 +13,7 @@
 #include <iocsh.h>
 #include <epicsThread.h>
 
-#include <asynDriver.h>
+#include <asynPortDriver.h>
 
 #include <epicsExport.h>
 

--- a/ADApp/pluginSrc/NDPluginOverlay.cpp
+++ b/ADApp/pluginSrc/NDPluginOverlay.cpp
@@ -7,24 +7,12 @@
  * Created March 22, 2010
  */
 
-#include <stdlib.h>
 #include <string.h>
-#include <stdio.h>
 #include <math.h>
-#include <time.h>
 
-#include <cantProceed.h>
-#include <epicsTypes.h>
-#include <epicsMessageQueue.h>
-#include <epicsThread.h>
-#include <epicsEvent.h>
-#include <epicsTime.h>
 #include <iocsh.h>
-
-#include <asynDriver.h>
-
 #include <epicsExport.h>
-#include "NDPluginDriver.h"
+
 #include "NDPluginOverlayTextFont.h"
 #include "NDPluginOverlay.h"
 

--- a/ADApp/pluginSrc/NDPluginOverlay.cpp
+++ b/ADApp/pluginSrc/NDPluginOverlay.cpp
@@ -11,6 +11,10 @@
 #include <math.h>
 
 #include <iocsh.h>
+#include <epicsThread.h>
+
+#include <asynDriver.h>
+
 #include <epicsExport.h>
 
 #include "NDPluginOverlayTextFont.h"

--- a/ADApp/pluginSrc/NDPluginOverlay.cpp
+++ b/ADApp/pluginSrc/NDPluginOverlay.cpp
@@ -12,6 +12,7 @@
 
 #include <iocsh.h>
 #include <epicsThread.h>
+#include <epicsTime.h>
 
 #include <asynPortDriver.h>
 

--- a/ADApp/pluginSrc/NDPluginOverlay.h
+++ b/ADApp/pluginSrc/NDPluginOverlay.h
@@ -67,7 +67,7 @@ typedef struct NDOverlay {
 #define NDPluginOverlayDisplayTextString        "OVERLAY_DISPLAY_TEXT"  /* (asynOctet,   r/w) The text to display */
 
 /** Overlay graphics on top of an image.  Useful for highlighting ROIs and displaying cursors */
-class epicsShareClass NDPluginOverlay : public NDPluginDriver {
+class NDPLUGIN_API NDPluginOverlay : public NDPluginDriver {
 public:
     NDPluginOverlay(const char *portName, int queueSize, int blockingCallbacks,
                  const char *NDArrayPort, int NDArrayAddr, int maxOverlays,

--- a/ADApp/pluginSrc/NDPluginProcess.cpp
+++ b/ADApp/pluginSrc/NDPluginProcess.cpp
@@ -11,6 +11,7 @@
 
 #include <iocsh.h>
 #include <epicsThread.h>
+#include <epicsTime.h>
 
 #include <asynPortDriver.h>
 

--- a/ADApp/pluginSrc/NDPluginProcess.cpp
+++ b/ADApp/pluginSrc/NDPluginProcess.cpp
@@ -7,22 +7,11 @@
  * Created March 12, 2010
  */
 
-#include <stdlib.h>
-#include <string.h>
-#include <stdio.h>
 #include <math.h>
 
-#include <epicsTypes.h>
-#include <epicsMessageQueue.h>
-#include <epicsThread.h>
-#include <epicsEvent.h>
-#include <epicsTime.h>
 #include <iocsh.h>
-
-#include <asynDriver.h>
-
 #include <epicsExport.h>
-#include "NDPluginDriver.h"
+
 #include "NDPluginProcess.h"
 
 static const char *driverName="NDPluginProcess";

--- a/ADApp/pluginSrc/NDPluginProcess.cpp
+++ b/ADApp/pluginSrc/NDPluginProcess.cpp
@@ -10,6 +10,10 @@
 #include <math.h>
 
 #include <iocsh.h>
+#include <epicsThread.h>
+
+#include <asynDriver.h>
+
 #include <epicsExport.h>
 
 #include "NDPluginProcess.h"

--- a/ADApp/pluginSrc/NDPluginProcess.cpp
+++ b/ADApp/pluginSrc/NDPluginProcess.cpp
@@ -12,7 +12,7 @@
 #include <iocsh.h>
 #include <epicsThread.h>
 
-#include <asynDriver.h>
+#include <asynPortDriver.h>
 
 #include <epicsExport.h>
 

--- a/ADApp/pluginSrc/NDPluginProcess.h
+++ b/ADApp/pluginSrc/NDPluginProcess.h
@@ -1,7 +1,6 @@
 #ifndef NDPluginProcess_H
 #define NDPluginProcess_H
 
-#include <epicsTypes.h>
 #include "NDPluginDriver.h"
 
 /* Background array subtraction */
@@ -60,7 +59,7 @@
   * Low clipping
   * High clipping
   * Frame averaging */
-class epicsShareClass NDPluginProcess : public NDPluginDriver {
+class NDPLUGIN_API NDPluginProcess : public NDPluginDriver {
 public:
     NDPluginProcess(const char *portName, int queueSize, int blockingCallbacks,
                  const char *NDArrayPort, int NDArrayAddr,

--- a/ADApp/pluginSrc/NDPluginPva.cpp
+++ b/ADApp/pluginSrc/NDPluginPva.cpp
@@ -1,20 +1,17 @@
-#include <pv/pvDatabase.h>
-#include <pv/nt.h>
-#include <pv/channelProviderLocal.h>
-
-#include <epicsThread.h>
-#include <iocsh.h>
-
-#include <ntndArrayConverter.h>
-
-#include <asynDriver.h>
-
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
 
+#include <epicsThread.h>
+#include <iocsh.h>
 #include <epicsExport.h>
-#include "NDPluginDriver.h"
+
+#include <pv/pvDatabase.h>
+#include <pv/nt.h>
+#include <pv/channelProviderLocal.h>
+
+
+#include <ntndArrayConverter.h>
 #include "NDPluginPva.h"
 
 static const char *driverName="NDPluginPva";
@@ -26,7 +23,7 @@ using namespace epics::pvDatabase;
 using namespace epics::nt;
 using namespace std;
 
-class epicsShareClass NTNDArrayRecord :
+class NDPLUGIN_API NTNDArrayRecord :
     public PVRecord
 {
 

--- a/ADApp/pluginSrc/NDPluginPva.cpp
+++ b/ADApp/pluginSrc/NDPluginPva.cpp
@@ -7,7 +7,10 @@
 #include <pv/channelProviderLocal.h>
 
 #include <epicsThread.h>
+#include <epicsTime.h>
 #include <iocsh.h>
+
+#include <asynPortDriver.h>
 
 #include <ntndArrayConverter.h>
 

--- a/ADApp/pluginSrc/NDPluginPva.cpp
+++ b/ADApp/pluginSrc/NDPluginPva.cpp
@@ -2,16 +2,17 @@
 #include <string.h>
 #include <stdio.h>
 
-#include <epicsThread.h>
-#include <iocsh.h>
-#include <epicsExport.h>
-
 #include <pv/pvDatabase.h>
 #include <pv/nt.h>
 #include <pv/channelProviderLocal.h>
 
+#include <epicsThread.h>
+#include <iocsh.h>
 
 #include <ntndArrayConverter.h>
+
+#include <epicsExport.h>
+
 #include "NDPluginPva.h"
 
 static const char *driverName="NDPluginPva";

--- a/ADApp/pluginSrc/NDPluginPva.h
+++ b/ADApp/pluginSrc/NDPluginPva.h
@@ -1,9 +1,6 @@
 #ifndef NDPluginPva_H
 #define NDPluginPva_H
 
-#include <epicsTypes.h>
-#include <epicsMutex.h>
-
 #include "NDPluginDriver.h"
 
 #include <pv/serverContext.h>
@@ -18,7 +15,7 @@ typedef std::tr1::shared_ptr<NTNDArrayRecord> NTNDArrayRecordPtr;
 
 /** Converts NDArray callback data into EPICS V4 NTNDArray data and exposes it
   * as an EPICS V4 PV  */
-class NDPluginPva : public NDPluginDriver,
+class NDPLUGIN_API NDPluginPva : public NDPluginDriver,
                      public std::tr1::enable_shared_from_this<NDPluginPva>
 {
 public:

--- a/ADApp/pluginSrc/NDPluginROI.cpp
+++ b/ADApp/pluginSrc/NDPluginROI.cpp
@@ -7,21 +7,11 @@
  * Created April 23, 2008
  */
 
-#include <stdlib.h>
 #include <string.h>
-#include <stdio.h>
-#include <math.h>
 
-#include <epicsTypes.h>
-#include <epicsMessageQueue.h>
-#include <epicsThread.h>
-#include <epicsEvent.h>
-#include <epicsTime.h>
 #include <iocsh.h>
-
-#include <asynDriver.h>
-
 #include <epicsExport.h>
+
 #include "NDPluginDriver.h"
 #include "NDPluginROI.h"
 

--- a/ADApp/pluginSrc/NDPluginROI.cpp
+++ b/ADApp/pluginSrc/NDPluginROI.cpp
@@ -11,6 +11,7 @@
 
 #include <iocsh.h>
 #include <epicsThread.h>
+#include <epicsTime.h>
 
 #include <asynPortDriver.h>
 

--- a/ADApp/pluginSrc/NDPluginROI.cpp
+++ b/ADApp/pluginSrc/NDPluginROI.cpp
@@ -10,6 +10,10 @@
 #include <string.h>
 
 #include <iocsh.h>
+#include <epicsThread.h>
+
+#include <asynDriver.h>
+
 #include <epicsExport.h>
 
 #include "NDPluginDriver.h"

--- a/ADApp/pluginSrc/NDPluginROI.cpp
+++ b/ADApp/pluginSrc/NDPluginROI.cpp
@@ -12,7 +12,7 @@
 #include <iocsh.h>
 #include <epicsThread.h>
 
-#include <asynDriver.h>
+#include <asynPortDriver.h>
 
 #include <epicsExport.h>
 

--- a/ADApp/pluginSrc/NDPluginROI.h
+++ b/ADApp/pluginSrc/NDPluginROI.h
@@ -36,7 +36,7 @@
 /** Extract Regions-Of-Interest (ROI) from NDArray data; the plugin can be a source of NDArray callbacks for
   * other plugins, passing these sub-arrays.
   * The plugin also optionally computes a statistics on the ROI. */
-class epicsShareClass NDPluginROI : public NDPluginDriver {
+class NDPLUGIN_API NDPluginROI : public NDPluginDriver {
 public:
     NDPluginROI(const char *portName, int queueSize, int blockingCallbacks,
                  const char *NDArrayPort, int NDArrayAddr,

--- a/ADApp/pluginSrc/NDPluginROIStat.cpp
+++ b/ADApp/pluginSrc/NDPluginROIStat.cpp
@@ -13,6 +13,10 @@
 
 #include <cantProceed.h>
 #include <iocsh.h>
+#include <epicsThread.h>
+
+#include <asynDriver.h>
+
 #include <epicsExport.h>
 
 #include "NDPluginROIStat.h"

--- a/ADApp/pluginSrc/NDPluginROIStat.cpp
+++ b/ADApp/pluginSrc/NDPluginROIStat.cpp
@@ -14,6 +14,7 @@
 #include <cantProceed.h>
 #include <iocsh.h>
 #include <epicsThread.h>
+#include <epicsTime.h>
 
 #include <asynPortDriver.h>
 

--- a/ADApp/pluginSrc/NDPluginROIStat.cpp
+++ b/ADApp/pluginSrc/NDPluginROIStat.cpp
@@ -15,7 +15,7 @@
 #include <iocsh.h>
 #include <epicsThread.h>
 
-#include <asynDriver.h>
+#include <asynPortDriver.h>
 
 #include <epicsExport.h>
 

--- a/ADApp/pluginSrc/NDPluginROIStat.cpp
+++ b/ADApp/pluginSrc/NDPluginROIStat.cpp
@@ -9,22 +9,12 @@
  * @date Nov 2014
  */
 
-#include <stdlib.h>
 #include <string.h>
-#include <stdio.h>
-#include <math.h>
 
 #include <cantProceed.h>
-#include <epicsTypes.h>
-#include <epicsMessageQueue.h>
-#include <epicsThread.h>
-#include <epicsEvent.h>
-#include <epicsTime.h>
 #include <iocsh.h>
-
-#include <asynDriver.h>
-
 #include <epicsExport.h>
+
 #include "NDPluginROIStat.h"
 
 #define MAX(A,B) (A)>(B)?(A):(B)

--- a/ADApp/pluginSrc/NDPluginROIStat.h
+++ b/ADApp/pluginSrc/NDPluginROIStat.h
@@ -81,7 +81,7 @@ typedef struct NDROI {
 
 
 /** Compute statistics on ROIs in an array */
-class epicsShareClass NDPluginROIStat : public NDPluginDriver {
+class NDPLUGIN_API NDPluginROIStat : public NDPluginDriver {
 public:
     NDPluginROIStat(const char *portName, int queueSize, int blockingCallbacks,
                  const char *NDArrayPort, int NDArrayAddr, int maxROIs,

--- a/ADApp/pluginSrc/NDPluginScatter.cpp
+++ b/ADApp/pluginSrc/NDPluginScatter.cpp
@@ -10,6 +10,10 @@
 #include <stdlib.h>
 
 #include <iocsh.h>
+#include <epicsThread.h>
+
+#include <asynDriver.h>
+
 #include <epicsExport.h>
 
 #include "NDPluginScatter.h"

--- a/ADApp/pluginSrc/NDPluginScatter.cpp
+++ b/ADApp/pluginSrc/NDPluginScatter.cpp
@@ -11,6 +11,7 @@
 
 #include <iocsh.h>
 #include <epicsThread.h>
+#include <epicsTime.h>
 
 #include <asynPortDriver.h>
 

--- a/ADApp/pluginSrc/NDPluginScatter.cpp
+++ b/ADApp/pluginSrc/NDPluginScatter.cpp
@@ -9,16 +9,9 @@
 
 #include <stdlib.h>
 
-#include <epicsTypes.h>
-#include <epicsMessageQueue.h>
-#include <epicsThread.h>
-#include <epicsTime.h>
 #include <iocsh.h>
-
-#include <asynDriver.h>
-
 #include <epicsExport.h>
-#include "NDPluginDriver.h"
+
 #include "NDPluginScatter.h"
 
 static const char *driverName="NDPluginScatter";

--- a/ADApp/pluginSrc/NDPluginScatter.cpp
+++ b/ADApp/pluginSrc/NDPluginScatter.cpp
@@ -12,7 +12,7 @@
 #include <iocsh.h>
 #include <epicsThread.h>
 
-#include <asynDriver.h>
+#include <asynPortDriver.h>
 
 #include <epicsExport.h>
 

--- a/ADApp/pluginSrc/NDPluginScatter.h
+++ b/ADApp/pluginSrc/NDPluginScatter.h
@@ -7,7 +7,7 @@
 #define NDPluginScatterMethodString          "SCATTER_METHOD"            /* (asynInt32,        r/w) Algorithm for scatter */
 
 /** A plugin that does callbacks in round-robin fashion rather than passing every NDArray to every callback client  */
-class epicsShareClass NDPluginScatter : public NDPluginDriver {
+class NDPLUGIN_API NDPluginScatter : public NDPluginDriver {
 public:
     NDPluginScatter(const char *portName, int queueSize, int blockingCallbacks,
                       const char *NDArrayPort, int NDArrayAddr,

--- a/ADApp/pluginSrc/NDPluginStats.cpp
+++ b/ADApp/pluginSrc/NDPluginStats.cpp
@@ -11,6 +11,10 @@
 #include <math.h>
 
 #include <iocsh.h>
+#include <epicsThread.h>
+
+#include <asynDriver.h>
+
 #include <epicsExport.h>
 
 #include "NDPluginStats.h"

--- a/ADApp/pluginSrc/NDPluginStats.cpp
+++ b/ADApp/pluginSrc/NDPluginStats.cpp
@@ -13,7 +13,7 @@
 #include <iocsh.h>
 #include <epicsThread.h>
 
-#include <asynDriver.h>
+#include <asynPortDriver.h>
 
 #include <epicsExport.h>
 

--- a/ADApp/pluginSrc/NDPluginStats.cpp
+++ b/ADApp/pluginSrc/NDPluginStats.cpp
@@ -8,21 +8,11 @@
  */
 
 #include <stdlib.h>
-#include <string.h>
-#include <stdio.h>
 #include <math.h>
 
-#include <epicsTypes.h>
-#include <epicsMessageQueue.h>
-#include <epicsThread.h>
-#include <epicsEvent.h>
-#include <epicsTime.h>
 #include <iocsh.h>
-
-#include <asynDriver.h>
-
 #include <epicsExport.h>
-#include "NDPluginDriver.h"
+
 #include "NDPluginStats.h"
 
 #define MAX(A,B) (A)>(B)?(A):(B)

--- a/ADApp/pluginSrc/NDPluginStats.cpp
+++ b/ADApp/pluginSrc/NDPluginStats.cpp
@@ -12,6 +12,7 @@
 
 #include <iocsh.h>
 #include <epicsThread.h>
+#include <epicsTime.h>
 
 #include <asynPortDriver.h>
 

--- a/ADApp/pluginSrc/NDPluginStats.h
+++ b/ADApp/pluginSrc/NDPluginStats.h
@@ -1,8 +1,6 @@
 #ifndef NDPluginStats_H
 #define NDPluginStats_H
 
-#include <epicsTypes.h>
-
 #include "NDPluginDriver.h"
 
 typedef enum {
@@ -156,7 +154,7 @@ typedef struct NDStats {
   * X and Y centroid and sigma
   * Histogram
   */
-class epicsShareClass NDPluginStats : public NDPluginDriver {
+class NDPLUGIN_API NDPluginStats : public NDPluginDriver {
 public:
     NDPluginStats(const char *portName, int queueSize, int blockingCallbacks,
                  const char *NDArrayPort, int NDArrayAddr,

--- a/ADApp/pluginSrc/NDPluginStdArrays.cpp
+++ b/ADApp/pluginSrc/NDPluginStdArrays.cpp
@@ -13,6 +13,7 @@
 
 #include <iocsh.h>
 #include <epicsThread.h>
+#include <epicsTime.h>
 
 #include <asynPortDriver.h>
 

--- a/ADApp/pluginSrc/NDPluginStdArrays.cpp
+++ b/ADApp/pluginSrc/NDPluginStdArrays.cpp
@@ -9,21 +9,11 @@
  * Created April 25, 2008
  */
 
-#include <stdlib.h>
 #include <string.h>
-#include <stdio.h>
 
-#include <epicsTypes.h>
-#include <epicsMessageQueue.h>
-#include <epicsThread.h>
-#include <epicsEvent.h>
-#include <epicsTime.h>
 #include <iocsh.h>
-
-#include <asynDriver.h>
-
 #include <epicsExport.h>
-#include "NDPluginDriver.h"
+
 #include "NDPluginStdArrays.h"
 
 static const char *driverName="NDPluginStdArrays";

--- a/ADApp/pluginSrc/NDPluginStdArrays.cpp
+++ b/ADApp/pluginSrc/NDPluginStdArrays.cpp
@@ -12,6 +12,10 @@
 #include <string.h>
 
 #include <iocsh.h>
+#include <epicsThread.h>
+
+#include <asynDriver.h>
+
 #include <epicsExport.h>
 
 #include "NDPluginStdArrays.h"

--- a/ADApp/pluginSrc/NDPluginStdArrays.cpp
+++ b/ADApp/pluginSrc/NDPluginStdArrays.cpp
@@ -14,7 +14,7 @@
 #include <iocsh.h>
 #include <epicsThread.h>
 
-#include <asynDriver.h>
+#include <asynPortDriver.h>
 
 #include <epicsExport.h>
 

--- a/ADApp/pluginSrc/NDPluginStdArrays.h
+++ b/ADApp/pluginSrc/NDPluginStdArrays.h
@@ -1,8 +1,6 @@
 #ifndef NDPluginStdArrays_H
 #define NDPluginStdArrays_H
 
-#include <epicsTypes.h>
-
 #include "NDPluginDriver.h"
 
 #define NDPluginStdArraysDataString "STD_ARRAY_DATA"           /* (asynXXXArray, r/w) Array data waveform */
@@ -11,7 +9,7 @@
   * asynFloat32Array or asynFloat64Array); normally used for putting NDArray data in EPICS waveform records.
   * It handles the data type conversion if the NDArray data type differs from the data type of the asyn interface.
   * It flattens the NDArrays to a single dimension because asyn and EPICS do not support multi-dimensional arrays. */
-class epicsShareClass NDPluginStdArrays : public NDPluginDriver {
+class NDPLUGIN_API NDPluginStdArrays : public NDPluginDriver {
 public:
     NDPluginStdArrays(const char *portName, int queueSize, int blockingCallbacks,
                       const char *NDArrayPort, int NDArrayAddr, int maxBuffers, size_t maxMemory,

--- a/ADApp/pluginSrc/NDPluginTimeSeries.cpp
+++ b/ADApp/pluginSrc/NDPluginTimeSeries.cpp
@@ -13,7 +13,7 @@
 #include <iocsh.h>
 #include <epicsThread.h>
 
-#include <asynDriver.h>
+#include <asynPortDriver.h>
 
 #include <epicsExport.h>
 

--- a/ADApp/pluginSrc/NDPluginTimeSeries.cpp
+++ b/ADApp/pluginSrc/NDPluginTimeSeries.cpp
@@ -11,6 +11,10 @@
 #include <string.h>
 
 #include <iocsh.h>
+#include <epicsThread.h>
+
+#include <asynDriver.h>
+
 #include <epicsExport.h>
 
 #include "NDPluginTimeSeries.h"

--- a/ADApp/pluginSrc/NDPluginTimeSeries.cpp
+++ b/ADApp/pluginSrc/NDPluginTimeSeries.cpp
@@ -12,6 +12,7 @@
 
 #include <iocsh.h>
 #include <epicsThread.h>
+#include <epicsTime.h>
 
 #include <asynPortDriver.h>
 

--- a/ADApp/pluginSrc/NDPluginTimeSeries.cpp
+++ b/ADApp/pluginSrc/NDPluginTimeSeries.cpp
@@ -9,20 +9,8 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <stdio.h>
-#include <math.h>
 
-#include <epicsTypes.h>
-#include <epicsMessageQueue.h>
-#include <epicsThread.h>
-#include <epicsEvent.h>
-#include <epicsTime.h>
 #include <iocsh.h>
-
-#include <asynDriver.h>
-
-#include <NDArray.h>
-
 #include <epicsExport.h>
 
 #include "NDPluginTimeSeries.h"

--- a/ADApp/pluginSrc/NDPluginTimeSeries.h
+++ b/ADApp/pluginSrc/NDPluginTimeSeries.h
@@ -10,7 +10,6 @@
 #ifndef NDPluginTimeSeries_H
 #define NDPluginTimeSeries_H
 
-#include <epicsTypes.h>
 #include <epicsTime.h>
 
 #include "NDPluginDriver.h"
@@ -34,7 +33,7 @@
 
 
 /** Compute time series on signals */
-class epicsShareClass NDPluginTimeSeries : public NDPluginDriver {
+class NDPLUGIN_API NDPluginTimeSeries : public NDPluginDriver {
 public:
   NDPluginTimeSeries(const char *portName, int queueSize, int blockingCallbacks,
                      const char *NDArrayPort, int NDArrayAddr,

--- a/ADApp/pluginSrc/NDPluginTransform.cpp
+++ b/ADApp/pluginSrc/NDPluginTransform.cpp
@@ -11,22 +11,11 @@
  * 27 April 2014
  */
 
-#include <stdlib.h>
 #include <string.h>
-#include <stdio.h>
-#include <math.h>
 
-#include <epicsTypes.h>
-#include <epicsMessageQueue.h>
-#include <epicsThread.h>
-#include <epicsEvent.h>
-#include <epicsTime.h>
 #include <iocsh.h>
-
-#include <asynDriver.h>
-
 #include <epicsExport.h>
-#include "NDPluginDriver.h"
+
 #include "NDPluginTransform.h"
 
 /* Enums to describe the types of transformations */

--- a/ADApp/pluginSrc/NDPluginTransform.cpp
+++ b/ADApp/pluginSrc/NDPluginTransform.cpp
@@ -14,6 +14,10 @@
 #include <string.h>
 
 #include <iocsh.h>
+#include <epicsThread.h>
+
+#include <asynDriver.h>
+
 #include <epicsExport.h>
 
 #include "NDPluginTransform.h"

--- a/ADApp/pluginSrc/NDPluginTransform.cpp
+++ b/ADApp/pluginSrc/NDPluginTransform.cpp
@@ -15,6 +15,7 @@
 
 #include <iocsh.h>
 #include <epicsThread.h>
+#include <epicsTime.h>
 
 #include <asynPortDriver.h>
 

--- a/ADApp/pluginSrc/NDPluginTransform.cpp
+++ b/ADApp/pluginSrc/NDPluginTransform.cpp
@@ -16,7 +16,7 @@
 #include <iocsh.h>
 #include <epicsThread.h>
 
-#include <asynDriver.h>
+#include <asynPortDriver.h>
 
 #include <epicsExport.h>
 

--- a/ADApp/pluginSrc/NDPluginTransform.h
+++ b/ADApp/pluginSrc/NDPluginTransform.h
@@ -1,9 +1,6 @@
 #ifndef NDPluginTransform_H
 #define NDPluginTransform_H
 
-#include <epicsTypes.h>
-#include <asynStandardInterfaces.h>
-
 #include "NDPluginDriver.h"
 
 /** Map parameter enums to strings that will be used to set up EPICS databases
@@ -13,7 +10,7 @@
 static const char* pluginName = "NDPluginTransform";
 
 /** Perform transformations (rotations, flips) on NDArrays.   */
-class epicsShareClass NDPluginTransform : public NDPluginDriver {
+class NDPLUGIN_API NDPluginTransform : public NDPluginDriver {
 public:
     NDPluginTransform(const char *portName, int queueSize, int blockingCallbacks,
                  const char *NDArrayPort, int NDArrayAddr,

--- a/ADApp/pluginSrc/NDPosPlugin.cpp
+++ b/ADApp/pluginSrc/NDPosPlugin.cpp
@@ -14,13 +14,7 @@
 #include <map>
 #include <vector>
 
-#include <epicsTypes.h>
-#include <epicsThread.h>
-
-#include <asynDriver.h>
-
 #include <epicsExport.h>
-#include "NDPluginDriver.h"
 
 #include "NDPosPlugin.h"
 #include "NDPosPluginFileReader.h"

--- a/ADApp/pluginSrc/NDPosPlugin.cpp
+++ b/ADApp/pluginSrc/NDPosPlugin.cpp
@@ -14,6 +14,10 @@
 #include <map>
 #include <vector>
 
+#include <epicsThread.h>
+
+#include <asynDriver.h>
+
 #include <epicsExport.h>
 
 #include "NDPosPlugin.h"

--- a/ADApp/pluginSrc/NDPosPlugin.cpp
+++ b/ADApp/pluginSrc/NDPosPlugin.cpp
@@ -16,7 +16,7 @@
 
 #include <epicsThread.h>
 
-#include <asynDriver.h>
+#include <asynPortDriver.h>
 
 #include <epicsExport.h>
 

--- a/ADApp/pluginSrc/NDPosPlugin.cpp
+++ b/ADApp/pluginSrc/NDPosPlugin.cpp
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include <epicsThread.h>
+#include <epicsTime.h>
 
 #include <asynPortDriver.h>
 

--- a/ADApp/pluginSrc/NDPosPlugin.h
+++ b/ADApp/pluginSrc/NDPosPlugin.h
@@ -30,7 +30,6 @@
 #ifndef NDPosPluginAPP_SRC_NDPOSPLUGIN_H_
 #define NDPosPluginAPP_SRC_NDPOSPLUGIN_H_
 
-#include <epicsTypes.h>
 #include <string>
 #include <list>
 #include <map>
@@ -61,7 +60,7 @@
 #define NDPOS_IDLE    0
 #define NDPOS_RUNNING 1
 
-class NDPosPlugin : public NDPluginDriver
+class NDPLUGIN_API NDPosPlugin : public NDPluginDriver
 {
 
 public:


### PR DESCRIPTION
This PR converts ADCore from using the traditional shareLib.h with epicsShareFunc, epicsShareExtern, epicsShareClass, etc. to using the mechanism now used in base. 

- Added ADCoreAPI.h, NDPluginAPI.h, and ntndArrayConverterAPI.h.  
- Modified Makefiles.
- Modified all code to use the new mechanism.

