### PR TITLE
Include trailing null in size passed to H5Tset_size()

### DIFF
--- a/ADApp/pluginSrc/NDFileHDF5.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5.cpp
@@ -840,7 +840,7 @@ hid_t NDFileHDF5::writeH5dsetStr(hid_t element, const std::string &name, const s
 
   hdfdataspace     = H5Screate_simple(rank, &dims, NULL);
   hdfdatatype      = H5Tcopy(H5T_C_S1);
-  hdfstatus        = H5Tset_size(hdfdatatype, str_value.size());
+  hdfstatus        = H5Tset_size(hdfdatatype, str_value.size()+1);
   hdfstatus        = H5Tset_strpad(hdfdatatype, H5T_STR_NULLTERM);
   hdfdset          = H5Dcreate2(element, name.c_str(), hdfdatatype, hdfdataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
   if (hdfdset < 0) {
@@ -1084,7 +1084,7 @@ void NDFileHDF5::writeH5attrStr(hid_t element, const std::string &attr_name, con
 
   hdfattrdataspace = H5Screate(H5S_SCALAR);
   hdfdatatype      = H5Tcopy(H5T_C_S1);
-  hdfstatus        = H5Tset_size(hdfdatatype, str_attr_value.size());
+  hdfstatus        = H5Tset_size(hdfdatatype, str_attr_value.size()+1);
   hdfstatus        = H5Tset_strpad(hdfdatatype, H5T_STR_NULLTERM);
   hdfattr          = H5Acreate2(element, attr_name.c_str(), hdfdatatype, hdfattrdataspace, H5P_DEFAULT, H5P_DEFAULT);
   if (hdfattr < 0) {
@@ -3017,7 +3017,7 @@ asynStatus NDFileHDF5::writeStringAttribute(hid_t element, const char * attrName
   if (strlen(attrStrValue) > 0){
     hdfattrdataspace = H5Screate(H5S_SCALAR);
     hdfdatatype      = H5Tcopy(H5T_C_S1);
-    H5Tset_size(hdfdatatype, strlen(attrStrValue));
+    H5Tset_size(hdfdatatype, strlen(attrStrValue)+1);
     H5Tset_strpad(hdfdatatype, H5T_STR_NULLTERM);
     hdfattr          = H5Acreate2(element, attrName,
                                   hdfdatatype, hdfattrdataspace,


### PR DESCRIPTION
The size passed to H5Tset_size() is supposed to include the trailing null character.  The current code is not doing that.  This results in error messages from the HDF5 library if a zero length string is passed.  The file structure is also not correct, the string data should include the trailing null character.

This fixes issue #460.