### PR TITLE
Adding optional reccaster support module to commonDriverMakefile

### DIFF
--- a/ADApp/commonDriverMakefile
+++ b/ADApp/commonDriverMakefile
@@ -218,6 +218,11 @@ ifdef FFMPEGSERVER
   PROD_LIBS       += avdevice avformat avcodec swresample swscale avutil
 endif
 
+ifdef RECCASTER
+  $(DBD_NAME)_DBD += reccaster.dbd
+  PROD_LIBS       += reccaster
+endif
+
 ifdef ADPLUGINEDGE
   $(DBD_NAME)_DBD  += NDPluginEdge.dbd
   PROD_LIBS         += NDPluginEdge


### PR DESCRIPTION
Goes along with https://github.com/areaDetector/areaDetector/pull/73. Adds conditional where if RECCASTER is defined in configure/RELEASE_PRODS.local, we include the reccaster dbd and link against the reccaster libarary.