### PR TITLE
Make full filename large enough for filename and filepath components

### DIFF
--- a/ADApp/Db/NDFile.template
+++ b/ADApp/Db/NDFile.template
@@ -140,7 +140,7 @@ record(waveform, "$(P)$(R)FullFileName_RBV")
     field(DTYP, "asynOctetRead")
     field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))FULL_FILE_NAME")
     field(FTVL, "CHAR")
-    field(NELM, "256")
+    field(NELM, "512")
     field(SCAN, "I/O Intr")
 }
 

--- a/ADApp/pluginSrc/NDPluginFile.cpp
+++ b/ADApp/pluginSrc/NDPluginFile.cpp
@@ -24,13 +24,13 @@ static const char *driverName="NDPluginFile";
 
 
 /** Base method for opening a file
-  * Creates the file name with NDPluginBase::createFileName, then calls the pure virtual function openFile
+  * Creates the file name with asynNDArrayDriver::createFileName, then calls the pure virtual function openFile
   * in the derived class. */
 asynStatus NDPluginFile::openFileBase(NDFileOpenMode_t openMode, NDArray *pArray)
 {
     /* Opens a file for reading or writing */
     asynStatus status = asynSuccess;
-    char fullFileName[MAX_FILENAME_LEN];
+    char fullFileName[2*MAX_FILENAME_LEN];
     char tempSuffix[MAX_FILENAME_LEN];
     char errorMessage[256];
     static const char* functionName = "openFileBase";
@@ -40,7 +40,7 @@ asynStatus NDPluginFile::openFileBase(NDFileOpenMode_t openMode, NDArray *pArray
 
     setIntegerParam(NDFileWriteStatus, NDFileWriteOK);
     setStringParam(NDFileWriteMessage, "");
-    status = (asynStatus)createFileName(MAX_FILENAME_LEN, fullFileName);
+    status = (asynStatus)createFileName(2*MAX_FILENAME_LEN, fullFileName);
     if (status) {
         asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
               "%s::%s error creating full file name, fullFileName=%s, status=%d\n",
@@ -84,7 +84,7 @@ asynStatus NDPluginFile::closeFileBase()
 {
     /* Closes a file */
     asynStatus status = asynSuccess;
-    char fullFileName[MAX_FILENAME_LEN];
+    char fullFileName[2*MAX_FILENAME_LEN];
     char tempSuffix[MAX_FILENAME_LEN];
     char tempFileName[MAX_FILENAME_LEN];
     char errorMessage[256];
@@ -131,12 +131,12 @@ asynStatus NDPluginFile::closeFileBase()
 }
 
 /** Base method for reading a file
-  * Creates the file name with NDPluginBase::createFileName, then calls the pure virtual functions openFile,
+  * Creates the file name with asynNDArrayDriver::createFileName, then calls the pure virtual functions openFile,
   * readFile and closeFile in the derived class.  Does callbacks with the NDArray that was read in. */
 asynStatus NDPluginFile::readFileBase(void)
 {
     asynStatus status = asynSuccess;
-    char fullFileName[MAX_FILENAME_LEN];
+    char fullFileName[2*MAX_FILENAME_LEN];
     NDArray *pArray=NULL;
     char errorMessage[256];
     static const char* functionName = "readFileBase";
@@ -144,7 +144,7 @@ asynStatus NDPluginFile::readFileBase(void)
     setIntegerParam(NDFileWriteStatus, NDFileWriteOK);
     setStringParam(NDFileWriteMessage, "");
 
-    status = (asynStatus)createFileName(MAX_FILENAME_LEN, fullFileName);
+    status = (asynStatus)createFileName(2*MAX_FILENAME_LEN, fullFileName);
     if (status) {
         asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
               "%s::%s error creating full file name, fullFileName=%s, status=%d\n",


### PR DESCRIPTION
I was having issues with full filenames being truncated due to the full filename being limited to the same size to the filename and filepath components.

This is a minimal change which increases the size of the full filename compared to the filename and filepath components. NDFileNexus.cpp already does something similar, but has a fixed format.

I'm not sure if the factor should be 3*MAX_FILENAME_LEN instead to account for possible extra characters in the file template on top of the substitution (although this will be slightly less than 256 characters depending on the formatting).