### PR TITLE
Corrected index misunderstanding.

### DIFF
--- a/ADApp/ADSrc/CCDMultiTrack.cpp
+++ b/ADApp/ADSrc/CCDMultiTrack.cpp
@@ -66,8 +66,6 @@ void CCDMultiTrack::writeTrackStart(epicsInt32 *value, size_t nElements)
     std::vector<int> TrackStart(nElements);
     for (size_t TrackNum = 0; TrackNum < TrackStart.size(); TrackNum++)
     {
-        if (value[TrackNum] < 1)
-            throw std::string("Tracks starts must be >= 1");
         if ((TrackNum > 0) && (value[TrackNum] <= CCDMultiTrack::TrackStart(TrackNum - 1)))
             throw std::string("Tracks starts must be in ascending order");
         /* Copy the new data */
@@ -101,8 +99,6 @@ void CCDMultiTrack::writeTrackEnd(epicsInt32 *value, size_t nElements)
     mTrackEnd.resize(nElements);
     for (size_t TrackNum = 0; TrackNum < TrackEnd.size(); TrackNum++)
     {
-        if (value[TrackNum] < 2)
-            throw std::string("Tracks ends must be >= 2");
         if ((TrackNum > 0) && (value[TrackNum] <= CCDMultiTrack::TrackEnd(TrackNum - 1)))
             throw std::string("Tracks ends must be in ascending order");
         /* Copy the new data */


### PR DESCRIPTION
areaDetector uses 0-based pixel indexes - when I wrote this I had assumed 1-based indexes.

Consequently, I have inappropriate range checks.