### PR TITLE
Uncommented NDPluginPva plugin

### DIFF
--- a/iocBoot/EXAMPLE_commonPlugins.cmd
+++ b/iocBoot/EXAMPLE_commonPlugins.cmd
@@ -173,11 +173,11 @@ save_restoreSet_status_prefix("$(PREFIX)")
 dbLoadRecords("$(AUTOSAVE)/db/save_restoreStatus.db", "P=$(PREFIX)")
 dbLoadRecords("$(AUTOSAVE)/db/configMenu.db", "P=$(PREFIX), CONFIG=ADAutoSave")
 
-# Optional: load NDPluginPva plugin
-#NDPvaConfigure("PVA1", $(QSIZE), 0, "$(PORT)", 0, $(PREFIX)Pva1:Image, 0, 0, 0)
-#dbLoadRecords("NDPva.template",  "P=$(PREFIX),R=Pva1:, PORT=PVA1,ADDR=0,TIMEOUT=1,NDARRAY_PORT=$(PORT)")
-# Must start PVA server if this is enabled
-#startPVAServer
+# Load NDPluginPva plugin
+NDPvaConfigure("PVA1", $(QSIZE), 0, "$(PORT)", 0, $(PREFIX)Pva1:Image, 0, 0, 0)
+dbLoadRecords("NDPva.template",  "P=$(PREFIX),R=Pva1:, PORT=PVA1,ADDR=0,TIMEOUT=1,NDARRAY_PORT=$(PORT)")
+#Must start PVA server if this is enabled
+startPVAServer
 
 # Optional: load ffmpegServer plugin
 #ffmpegServerConfigure(8081)


### PR DESCRIPTION
Uncommented NDPluginPva plugin. This is should be used routinely instead of the Image plugin.