### PR TITLE
Add Constant NDAttributes

### DIFF
--- a/ADApp/ADSrc/NDAttribute.cpp
+++ b/ADApp/ADSrc/NDAttribute.cpp
@@ -17,7 +17,8 @@ static const char *NDAttrSourceStrings[] = {
     "DRIVER",
     "PARAM",
     "EPICS_PV",
-    "FUNCTION"
+    "FUNCTION",
+	"CONST"
 };
 
 const char *NDAttribute::attrSourceString(NDAttrSource_t type)
@@ -56,6 +57,9 @@ const char *NDAttribute::attrSourceString(NDAttrSource_t type)
       break;
     case NDAttrSourceFunct:
       this->sourceTypeString_ = "NDAttrSourceFunct";
+      break;
+    case NDAttrSourceConst:
+      this->sourceTypeString_ = "NDAttrSourceConst";
       break;
     default:
       this->sourceType_ = NDAttrSourceUndefined;

--- a/ADApp/ADSrc/NDAttribute.cpp
+++ b/ADApp/ADSrc/NDAttribute.cpp
@@ -18,7 +18,7 @@ static const char *NDAttrSourceStrings[] = {
     "PARAM",
     "EPICS_PV",
     "FUNCTION",
-	"CONST"
+    "CONST"
 };
 
 const char *NDAttribute::attrSourceString(NDAttrSource_t type)

--- a/ADApp/ADSrc/NDAttribute.h
+++ b/ADApp/ADSrc/NDAttribute.h
@@ -64,6 +64,7 @@ typedef enum
     NDAttrSourceParam,     /**< Attribute is obtained from parameter library */
     NDAttrSourceEPICSPV,   /**< Attribute is obtained from an EPICS PV */
     NDAttrSourceFunct,     /**< Attribute is obtained from a user-specified function */
+    NDAttrSourceConst,     /**< Attribute is obtained from a user-specified value in the xml file */
     NDAttrSourceUndefined  /**< Attribute source is undefined */
 } NDAttrSource_t;
 

--- a/ADApp/ADSrc/asynNDArrayDriver.cpp
+++ b/ADApp/ADSrc/asynNDArrayDriver.cpp
@@ -460,7 +460,7 @@ done_macros:
         } 
         else if (strcmp(pAttrType, NDAttribute::attrSourceString(NDAttrSourceConst)) == 0) {
 #ifndef EPICS_LIBCOM_ONLY			
-			this->pAttributeList->add(pName, pDescription, NDAttrString, pSource);
+			this->pAttributeList->add(pName, pDescription, NDAttrString, (void*) pSource);
 #endif
         } else { 
             asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,

--- a/ADApp/ADSrc/asynNDArrayDriver.cpp
+++ b/ADApp/ADSrc/asynNDArrayDriver.cpp
@@ -457,7 +457,12 @@ done_macros:
             functAttribute *pFunctAttribute = new functAttribute(pName, pDescription, pSource, pParam);
             this->pAttributeList->add(pFunctAttribute);
 #endif
-        } else {
+        } 
+        else if (strcmp(pAttrType, NDAttribute::attrSourceString(NDAttrSourceConst)) == 0) {
+#ifndef EPICS_LIBCOM_ONLY			
+			this->pAttributeList->add(pName, pDescription, NDAttrString, pSource);
+#endif
+        } else { 
             asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
                 "%s:%s: unknown attribute type = %s for attribute %s\n", driverName, functionName, pAttrType, pName);
             return asynError;

--- a/ADApp/ADSrc/asynNDArrayDriver.cpp
+++ b/ADApp/ADSrc/asynNDArrayDriver.cpp
@@ -460,7 +460,7 @@ done_macros:
         } 
         else if (strcmp(pAttrType, NDAttribute::attrSourceString(NDAttrSourceConst)) == 0) {
 #ifndef EPICS_LIBCOM_ONLY			
-			this->pAttributeList->add(pName, pDescription, NDAttrString, (void*) pSource);
+            this->pAttributeList->add(pName, pDescription, NDAttrString, (void*) pSource);
 #endif
         } else { 
             asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,


### PR DESCRIPTION
In relation to issue #478 

Adds NDAttributeConst with the corresponding string "CONST" to the list of acceptable NDAttribute types. If type="CONST" in an attributes XML file, a base NDAttribute with source as the value is added.