### PR TITLE
LIBXML_STATIC needs to be defined in ADSrc for mingw static builds.

### DIFF
--- a/ADApp/ADSrc/Makefile
+++ b/ADApp/ADSrc/Makefile
@@ -11,6 +11,11 @@ ifeq (vxWorks,$(findstring vxWorks, $(T_A)))
 CODE_CXXFLAGS=
 endif
 
+ifneq ($(SHARED_LIBRARIES), YES)
+   USR_CFLAGS_WIN32 += -DLIBXML_STATIC
+   USR_CXXFLAGS_WIN32 += -DLIBXML_STATIC
+endif
+
 # The following flag is need to compile/link NDArray.cpp on Solaris
 ifeq ($(GNU),NO)
   NDArray_CXXFLAGS_solaris += -features=tmplrefstatic

--- a/ADApp/pluginSrc/Makefile
+++ b/ADApp/pluginSrc/Makefile
@@ -238,6 +238,11 @@ ifeq (vxWorks,$(findstring vxWorks, $(T_A)))
   CODE_CXXFLAGS=
 endif
 
+# Hack to allow multiple definition of _Unwind_Resume produced by MingW on Linux.
+ifeq (mingw,$(findstring mingw, $(T_A)))
+  USR_LDFLAGS += -Wl,-allow-multiple-definition
+endif
+
 include $(TOP)/ADApp/commonLibraryMakefile
 
 include $(TOP)/configure/RULES


### PR DESCRIPTION
Mingw still generates multiple definitions of _Unwind_Resume.