### PR TITLE
Switch from pvDatabase to SharedPV

### DIFF
--- a/ADApp/pluginSrc/NDPluginPva.h
+++ b/ADApp/pluginSrc/NDPluginPva.h
@@ -23,6 +23,7 @@ public:
     NDPluginPva(const char *portName, int queueSize, int blockingCallbacks,
                  const char *NDArrayPort, int NDArrayAddr, const char *pvName,
                  int maxBuffers, size_t maxMemory, int priority, int stackSize);
+    virtual ~NDPluginPva();
 
     /* These methods override the virtual methods in the base class */
     void processCallbacks(NDArray *pArray);


### PR DESCRIPTION
Quick migration from pvDatabaseCPP to `pvas::SharedPV` from pvAccessCPP.

http://epics-base.github.io/pvAccessCPP/group__pvas.html

I have only done some quick testing using cs-studio.  I think this will behave ~the same as before, excepting pvDatabase specific handling of pvRequest.

May be interesting to test pvRequest "pipeline=true" behavior.