### PR TITLE
Fix for changed hsize_t in HDF5 v1.14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ configure/*.local
 O.*/
 *~
 *.swp
+/QtC-*
+/.qtc_*
 .project
 .settings
 .cproject

--- a/ADApp/pluginSrc/NDFileHDF5.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5.cpp
@@ -3550,7 +3550,7 @@ char* NDFileHDF5::getDimsReport()
 
   struct dimsizes_t {
     const char* name;
-    unsigned long long* dimsize;
+    hsize_t* dimsize;
     int nd;
   } dimsizes[7] = {
       {"framesize", this->framesize, this->rank},
@@ -3569,7 +3569,7 @@ char* NDFileHDF5::getDimsReport()
     c = strlen(strdims);
     for(j=0; j<dimsizes[i].nd; j++)
     {
-      epicsSnprintf(strdims+c, maxlen-c, "%6lli,", dimsizes[i].dimsize[j]);
+          epicsSnprintf(strdims+c, maxlen-c, "%6llu,", (unsigned long long) dimsizes[i].dimsize[j]);
       c = strlen(strdims);
     }
     //printf("name=%s c=%d rank=%d strdims: %s\n", dimsizes[i].name, c, dimsizes[i].nd, strdims);
@@ -3771,8 +3771,8 @@ asynStatus NDFileHDF5::createNewFile(const char *fileName)
     hdfstatus = H5Pset_alignment( access_plist, threshold, align );
     if (hdfstatus < 0){
       asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
-          "%s%s Warning: failed to set boundary threshod=%llu and alignment=%llu bytes\n",
-          driverName, functionName, threshold, align);
+          "%s%s Warning: failed to set boundary threshold=%llu and alignment=%llu bytes\n",
+          driverName, functionName, (unsigned long long) threshold, (unsigned long long) align);
       H5Pget_alignment( access_plist, &threshold, &align );
       this->lock();
       setIntegerParam(NDFileHDF5_chunkBoundaryAlign, (int)align);


### PR DESCRIPTION
- use hsize_t for internal variables
- cast to (unsigned long long) and use "%llu" as printf conversion specification


Newer HDF5 provides macros for the specifier (e.g. PRIuHSIZE) but v1.10 in ADSupport doesn't, so casting to the widest type seems the best portable way to handle this.