### PR TITLE
Fix possible memory leak when using NDFileModeCapture in NDPluginFile

### DIFF
--- a/ADApp/pluginSrc/NDPluginFile.h
+++ b/ADApp/pluginSrc/NDPluginFile.h
@@ -73,6 +73,7 @@ private:
     asynStatus closeFileBase();
     asynStatus doCapture(int capture);
     void       freeCaptureBuffer(int numCapture);
+    void       resetCaptureBuffer();
     asynStatus attrFileCloseCheck();
     asynStatus attrFileNameCheck();
     asynStatus attrFileNameSet();


### PR DESCRIPTION
Previously, when using the Capture mode, if you started a new capture without saving the previously captured frames to a file, the `pCapture` array holding the frames wouldn't be free'd properly, causing a memory leak. Another way of causing such leak was by changing the capture mode to stream without saving the frames to a file.

With this commit, when resetting `NDFileNumCaptured` before starting a new capture, we make sure to also empty the capture buffer if it is not empty yet, so that no buffer is leaked.

I used Valgrind to try to make sure there'd be no other way of reaching those `NDArray`s held in `pCapture` after overriding it or setting `NDFileModeCapture` to zero, but sorry if I missed something! :slightly_smiling_face: 