### PR TITLE
Fix PluginType string for NDFileNexus plugin

### DIFF
--- a/ADApp/pluginSrc/NDFileNexus.cpp
+++ b/ADApp/pluginSrc/NDFileNexus.cpp
@@ -884,6 +884,8 @@ NDFileNexus::NDFileNexus(const char *portName, int queueSize, int blockingCallba
   this->imageNumber = 0;
   setIntegerParam(NDFileNexusTemplateValid, 0);
 
+  /* Set the plugin type string */
+  setStringParam(NDPluginDriverPluginType, "NDFileNexus");
   this->supportsMultipleArrays = 1;
 }
 


### PR DESCRIPTION
This follows what is done in other `NDPluginFile` subclasses, like `NDFileJPEG`. Without it, the value of `{P}{R}PluginType_RBV` for the Nexus plugin is the more general string `NDPluginFile`, while the other file plugins show their specific plugin name.