### PR TITLE
Fixup build with deb12

### DIFF
--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -20,6 +20,7 @@ jobs:
       BCFG: ${{ matrix.configuration }}
       BASE: ${{ matrix.base }}
       SET: ${{ matrix.deps }}
+      EXTRA: ${{ matrix.extra }}
 
     strategy:
       fail-fast: false
@@ -31,6 +32,8 @@ jobs:
             configuration: default
             base: "7.0"
             deps: os
+            extra: "CMD_CFLAGS='-fvisibility=hidden'
+                    CMD_CXXFLAGS='-fvisibility=hidden -fvisibility-inlines-hidden'"
             test: true
 
           - os: ubuntu-latest

--- a/ADApp/pluginSrc/Makefile
+++ b/ADApp/pluginSrc/Makefile
@@ -8,7 +8,7 @@ LIBRARY_IOC += NDPlugin
 DBD         += NDPluginSupport.dbd
 
 # Persuade travis (ubuntu 12.04) to use HDF5 API V2 (1.8 rather than default 1.6)
-USR_CXXFLAGS_Linux += -DH5_NO_DEPRECATED_SYMBOLS -DH5Gopen_vers=2
+USR_CXXFLAGS_Linux += -DH5Gopen_vers=2
 
 # json.hpp requires C++11
 NDPluginBadPixel_CXXFLAGS_Linux += -std=c++11

--- a/ADApp/pluginSrc/NDFileHDF5AttributeDataset.h
+++ b/ADApp/pluginSrc/NDFileHDF5AttributeDataset.h
@@ -12,10 +12,11 @@
 #include <hdf5.h>
 #include <asynDriver.h>
 #include <NDAttribute.h>
+#include <NDPluginAPI.h>
 #include "NDFileHDF5Layout.h"
 #include "NDFileHDF5VersionCheck.h"
 
-class NDFileHDF5AttributeDataset
+class NDPLUGIN_API NDFileHDF5AttributeDataset
 {
 public:
   NDFileHDF5AttributeDataset(hid_t file, const std::string& name, NDAttrDataType_t type);

--- a/ADApp/pluginSrc/NDFileHDF5Dataset.h
+++ b/ADApp/pluginSrc/NDFileHDF5Dataset.h
@@ -3,12 +3,13 @@
 
 #include <string>
 #include <hdf5.h>
+#include <NDPluginAPI.h>
 #include "NDPluginFile.h"
 #include "NDFileHDF5VersionCheck.h"
 
 /** Class used for writing a Dataset with the NDFileHDF5 plugin.
   */
-class NDFileHDF5Dataset
+class NDPLUGIN_API NDFileHDF5Dataset
 {
   public:
     NDFileHDF5Dataset(asynUser *pAsynUser, const std::string& name, hid_t dataset);

--- a/ADApp/pluginSrc/NDPluginAttrPlot.h
+++ b/ADApp/pluginSrc/NDPluginAttrPlot.h
@@ -17,6 +17,7 @@
 
 #include "CircularBuffer.h"
 
+#include <NDPluginAPI.h>
 #include <NDPluginDriver.h>
 #include <epicsThread.h>
 
@@ -42,7 +43,7 @@ class NDPluginAttrPlot;
 /**
  * A task that periodically executes the data exposure method of the plugin.
  */
-class ExposeDataTask : public epicsThreadRunable
+class NDPLUGIN_API ExposeDataTask : public epicsThreadRunable
 {
 public:
     /**

--- a/ADApp/pluginTests/Makefile
+++ b/ADApp/pluginTests/Makefile
@@ -5,8 +5,8 @@ include $(TOP)/configure/CONFIG
 #=============================
 
 # Persuade travis (ubuntu 12.04) to use HDF5 API V2 (1.8 rather than default 1.6)
-USR_CXXFLAGS_Linux += -DH5_NO_DEPRECATED_SYMBOLS -DH5Dopen_vers=2 -DH5Gcreate_vers=2
-USR_CFLAGS_Linux   += -DH5_NO_DEPRECATED_SYMBOLS -DH5Dopen_vers=2 -DH5Gcreate_vers=2
+USR_CXXFLAGS_Linux += -DH5Dopen_vers=2 -DH5Gcreate_vers=2
+USR_CFLAGS_Linux   += -DH5Dopen_vers=2 -DH5Gcreate_vers=2
 
 ifeq ($(SHARED_LIBRARIES), YES)
    USR_CXXFLAGS_WIN32 += -DH5_BUILT_AS_DYNAMIC_LIB

--- a/ADApp/pluginTests/Makefile
+++ b/ADApp/pluginTests/Makefile
@@ -4,6 +4,9 @@ include $(TOP)/configure/CONFIG
 #  ADD MACRO DEFINITIONS AFTER THIS LINE
 #=============================
 
+# Only build static version of ADTestUtility (missing dllimport/export)
+SHARED_LIBRARIES=NO
+
 # Persuade travis (ubuntu 12.04) to use HDF5 API V2 (1.8 rather than default 1.6)
 USR_CXXFLAGS_Linux += -DH5Dopen_vers=2 -DH5Gcreate_vers=2
 USR_CFLAGS_Linux   += -DH5Dopen_vers=2 -DH5Gcreate_vers=2


### PR DESCRIPTION
A couple of somewhat related build fixes.

For my Linux builds I use `-fvisibility=hidden -fvisibility-inlines-hidden` to catch dllimport/export errors.  This is stricter than MSVC.  Which is why the lack of `NDPLUGIN_API` on `class NDFileHDF5Dataset` has not been fatal so far.  However, I think this omission was not intentional, and adding this as a CI check should prevent repeats.

The main issue is that `libADTestUtility` has no API macros at all.  For the time being this can be handled by only linking a static version.

Is `ADTestUtility` intended for external use?

If not, then eg. changing `LIBRARY=` to `TEST_LIBRARY=` will prevent it from being installed.  Otherwise, it needs an `*API.h` and added decorations.

The last change is to omit `-DH5_NO_DEPRECATED_SYMBOLS`.  I think this makes sense for a developer making changes to the HDF5 plugin.  For others, it only complicates portability.  Also, the comment in the Makefile mentions ubuntu 12.04, which is increasingly historical.