### PR TITLE
Update URL of legacy pre-built artifacts and NTNDArray specification

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,7 +9,7 @@ https://github.com/areaDetector/ADCore.
 
 Tagged source code and pre-built binary releases prior to R2-0 are included
 in the areaDetector releases available via links at
-https://cars.uchicago.edu/software/epics/areaDetector.html.
+https://areadetector.github.io/areaDetector/legacy_versions.html.
 
 Tagged source code releases from R2-0 onward can be obtained at
 https://github.com/areaDetector/ADCore/releases.

--- a/docs/ADCore/NDPluginPva.rst
+++ b/docs/ADCore/NDPluginPva.rst
@@ -10,7 +10,7 @@ Overview
 This plugin converts NDArray data produced by asynNDArrayDrivers into
 the EPICSv4 normative type NTNDArray. An embedded EPICSv4 server is
 created to serve the new NTNDArray structure as an EPICSv4 PV. A
-`description <http://epics-pvdata.sourceforge.net/alpha/normativeTypes/normativeTypesNDArray.html>`__
+`description <https://docs.epics-controls.org/en/latest/pv-access/Normative-Types-Specification.html#ntndarray>`__
 of the structure of the NTNDArray normative type is available.
 
 NDPluginPva defines the following parameters.


### PR DESCRIPTION
The cars.uchicago.edu areaDetector URL currently redirects to the GitHub areaDetector repository instead of the previously provided page. Update the URL so that it is consistent with the existing text.

Accessing NTNDArray link gives a 404 on the other hand. Update it to the current PVAccess documentation.