### PR TITLE
Remove erroneous variable type information.

### DIFF
--- a/docs/ADCore/ADDriver.rst
+++ b/docs/ADCore/ADDriver.rst
@@ -323,14 +323,14 @@ possible.
   * - ADShutterOpenDelay 
     - asynFloat64 
     - r/w 
-    - Time required for the shutter to actually open (ADShutterStatus_t) 
+    - Time required for the shutter to actually open 
     - SHUTTER_OPEN_DELAY 
     - $(P)$(R)ShutterOpenDelay, $(P)$(R)ShutterOpenDelay_RBV 
     - ao, ai 
   * - ADShutterCloseDelay 
     - asynFloat64 
     - r/w 
-    - Time required for the shutter to actually close (ADShutterStatus_t) 
+    - Time required for the shutter to actually close 
     - SHUTTER_CLOSE_DELAY 
     - $(P)$(R)ShutterCloseDelay, $(P)$(R)ShutterCloseDelay_RBV 
     - ao, ai 


### PR DESCRIPTION
Even though the shutter open and close delay times are related to the shutter mode, that isn't their type.