### PR TITLE
Remove comparing NexusDataType codes with NDDataTypeCodes

### DIFF
--- a/ADApp/pluginSrc/NDFileNexus.cpp
+++ b/ADApp/pluginSrc/NDFileNexus.cpp
@@ -660,7 +660,6 @@ void * NDFileNexus::allocConstValue(int dataType, size_t length ) {
     case NX_CHAR:
       pValue = calloc( length + 1 , sizeof(char) );
       break;
-    case NDAttrUndefined:
     default:
       pValue = NULL;
       break;
@@ -724,7 +723,6 @@ void NDFileNexus::constTextToDataType(char *inText, int dataType, void *pValue) 
       ((char *)pValue)[strlen(inText)] = '\0';
       //sscanf((const char *)inText, "%s", (char *)pValue);
       break;
-    case NDAttrUndefined:
     default:
       break;
   }


### PR DESCRIPTION
HI! We stumbled upon this when trying to add vector options to NDAttrDataType_t.

Regardless if vector options are actually going to be added, when NDAttrUndefined was moved to the 21th position of NDAttrDataType_t it collided with NX_UINT8 in NDFileNexus.cpp:663:

```
../ADApp/pluginSrc/NDFileNexus.cpp: In member function 'void NDFileNexus::constTextToDataType(char*, int, void*)':
../ADApp/pluginSrc/NDFileNexus.cpp:726:5: error: duplicate case value
     case NDAttrUndefined:
     ^~~~
../ADApp/pluginSrc/NDFileNexus.cpp:681:5: note: previously used here
     case NX_UINT8:
     ^~~~
```

Since that case condition actually does nothing but fall to the default case, we thought it would be healthy to remove it.