### PR TITLE
Fix typo in SortMode mode selection.

### DIFF
--- a/docs/ADCore/NDPluginDriver.rst
+++ b/docs/ADCore/NDPluginDriver.rst
@@ -109,7 +109,7 @@ following table.
     - longout, longin
   * - asynInt32
     - r/w
-    - Selects whether the plugin outputs NDArrays in the order in which they arrive (Unsorted=1)
+    - Selects whether the plugin outputs NDArrays in the order in which they arrive (Unsorted=0)
       or sorted by UniqueId (Sorted=1).
     - SORT_MODE
     - $(P)$(R)SortMode, $(P)$(R)SortMode_RBV


### PR DESCRIPTION
Based on
https://github.com/areaDetector/ADCore/blob/7debeba5c6a3840460fb592d32c6976d0c4d94ff/ADApp/Db/NDPluginBase.template#L300-L308V