### PR TITLE
Fix typo in NDCodecCompressor record name.

### DIFF
--- a/docs/ADCore/NDPluginCodec.rst
+++ b/docs/ADCore/NDPluginCodec.rst
@@ -161,7 +161,7 @@ following table.
     - r/w
     - Compression factor.
     - COMP_FACTOR
-    - $(P)$(R)CompFactor
+    - $(P)$(R)CompFactor_RBV
     - ai
   * -
     -


### PR DESCRIPTION
Missing '_RBV', based on
https://github.com/areaDetector/ADCore/blob/94414af0d3fbbc3acacaaa7a73b5b8fbc68b907b/ADApp/Db/NDCodec.template#L67