### PR TITLE
NDPluginROIStat: Clear the time series data without also starting acquisition

### DIFF
--- a/ADApp/Db/NDROIStat.template
+++ b/ADApp/Db/NDROIStat.template
@@ -43,7 +43,9 @@ record(mbbo, "$(P)$(R)TSControl")
    field(TWVL, "2")
    field(TWST, "Stop")
    field(THVL, "3")
-   field(THST, "Read") 
+   field(THST, "Read")
+   field(FRVL, "4")
+   field(FRST, "Erase")
 }
 
 # This record periodically pokes the TSControl record with 3 to read the time series

--- a/ADApp/pluginSrc/NDPluginROIStat.cpp
+++ b/ADApp/pluginSrc/NDPluginROIStat.cpp
@@ -361,10 +361,8 @@ asynStatus NDPluginROIStat::writeInt32(asynUser *pasynUser, epicsInt32 value)
     } else if (function == NDPluginROIStatTSControl) {
         switch (value) {
           case TSEraseStart:
-            currentTSPoint_ = 0;
-            setIntegerParam(NDPluginROIStatTSCurrentPoint, currentTSPoint_);
+            clearTimeSeries();
             setIntegerParam(NDPluginROIStatTSAcquiring, 1);
-            memset(timeSeries_, 0, maxROIs_*MAX_TIME_SERIES_TYPES*numTSPoints_*sizeof(double));
             break;
           case TSStart:
             if (currentTSPoint_ < numTSPoints_) {
@@ -376,6 +374,10 @@ asynStatus NDPluginROIStat::writeInt32(asynUser *pasynUser, epicsInt32 value)
             doTimeSeriesCallbacks();
             break;
           case TSRead:
+            doTimeSeriesCallbacks();
+            break;
+          case TSErase:
+            clearTimeSeries();
             doTimeSeriesCallbacks();
             break;
         }
@@ -430,6 +432,19 @@ asynStatus NDPluginROIStat::clear(epicsUInt32 roi)
   }
 
   return status;
+}
+
+/**
+ * Reset the time series data.
+ * This is meant to be called in writeInt32.
+ */
+void NDPluginROIStat::clearTimeSeries()
+{
+  currentTSPoint_ = 0;
+  setIntegerParam(NDPluginROIStatTSCurrentPoint, currentTSPoint_);
+  if (timeSeries_) {
+    memset(timeSeries_, 0, maxROIs_*MAX_TIME_SERIES_TYPES*numTSPoints_*sizeof(double));
+  }
 }
 
 void NDPluginROIStat::doTimeSeriesCallbacks()

--- a/ADApp/pluginSrc/NDPluginROIStat.h
+++ b/ADApp/pluginSrc/NDPluginROIStat.h
@@ -62,7 +62,8 @@ typedef enum {
     TSEraseStart,
     TSStart,
     TSStop,
-    TSRead
+    TSRead,
+    TSErase
 } NDPluginROIStatsTSControl_t;
 
 /** Structure defining a Region-Of-Interest and Stats */
@@ -140,6 +141,7 @@ private:
     template <typename epicsType> asynStatus doComputeStatisticsT(NDArray *pArray, NDROI_t *pROI);
     asynStatus doComputeStatistics(NDArray *pArray, NDROI_t *pStats);
     asynStatus clear(epicsUInt32 roi);
+    void clearTimeSeries();
     void doTimeSeriesCallbacks();
 
     int maxROIs_;
@@ -149,3 +151,5 @@ private:
 };
 
 #endif //NDPluginROIStat_H
+
+

--- a/docs/ADCore/NDPluginROIStat.rst
+++ b/docs/ADCore/NDPluginROIStat.rst
@@ -93,7 +93,9 @@ tables.
       ROISTAT_TS_CURRENT_POINT. Used to restart collection after a Stop operation. |br|
       **Stop**: Stops times-series data collection. Performs callbacks on all time-series
       waveform records. |br|
-      **Read**: Performs callbacks on all time-series waveform records, updating the values.
+      **Read**: Performs callbacks on all time-series waveform records, updating the values. |br|
+      **Erase**: Clears all time-series arrays, sets ROISTAT_TS_CURRENT_POINT=0, and performs 
+      callbacks on all time-series waveform records.
     - ROISTAT_TS_CONTROL
     - $(P)$(R)TSControl
     - mbbo


### PR DESCRIPTION
This adds the ability to clear the time series data without also starting acquisition. This can be useful when the use of the time series capture is intermittent or on-demand, and we do not always want the prior data in the waveform.