### PR TITLE
ADApp/pluginSrc/NDFileTIFF.cpp: restore dedicated handling of 32-bit …

### DIFF
--- a/ADApp/pluginSrc/NDFileTIFF.cpp
+++ b/ADApp/pluginSrc/NDFileTIFF.cpp
@@ -300,7 +300,11 @@ asynStatus NDFileTIFF::openFile(const char *fileName, NDFileOpenMode_t openMode,
             case NDAttrInt16:
             case NDAttrUInt16:
             case NDAttrInt32:
-            case NDAttrUInt32:
+            case NDAttrUInt32: {
+              pAttribute->getValue(attrDataType, &value.i32);
+              epicsSnprintf(tagString, sizeof(tagString)-1, "%s:%d", attributeName, value.i32);
+              break;
+            }
             case NDAttrInt64:
             case NDAttrUInt64: {
                 pAttribute->getValue(attrDataType, &value.i64);


### PR DESCRIPTION
…integers. Having the 32-bit case fall through to the 64-bit case resulted in corrupted data most of the time, and this restores previous behavior without affecting the new 64-bit support.