### PR TITLE
Fix attribute datatypes in TIFF plugin

### DIFF
--- a/ADApp/ADSrc/myAttributeFunctions.cpp
+++ b/ADApp/ADSrc/myAttributeFunctions.cpp
@@ -19,7 +19,17 @@ typedef enum {
     functE,
     functTen,
     functGettysburg,
-    functTime64
+    functTime64,
+    functInt8,
+    functUInt8,
+    functInt16,
+    functUInt16,
+    functInt32,
+    functUInt32,
+    functInt64,
+    functUInt64,
+    functFloat32,
+    functFloat64
 } myFunct_t;
 
 static int myAttrFunct1(const char *paramString, void **functionPvt, functAttribute *pAttribute)
@@ -55,6 +65,46 @@ static int myAttrFunct1(const char *paramString, void **functionPvt, functAttrib
             pAttribute->setDataType(NDAttrUInt64);
             *paramIndex = functTime64;
         }
+        else if (!strcmp(paramString, "INT8")) {
+            pAttribute->setDataType(NDAttrInt8);
+            *paramIndex = functInt8;
+        }
+        else if (!strcmp(paramString, "UINT8")) {
+            pAttribute->setDataType(NDAttrUInt8);
+            *paramIndex = functUInt8;
+        }
+        else if (!strcmp(paramString, "INT16")) {
+            pAttribute->setDataType(NDAttrInt16);
+            *paramIndex = functInt16;
+        }
+        else if (!strcmp(paramString, "UINT16")) {
+            pAttribute->setDataType(NDAttrUInt16);
+            *paramIndex = functUInt16;
+        }
+        else if (!strcmp(paramString, "INT32")) {
+            pAttribute->setDataType(NDAttrInt32);
+            *paramIndex = functInt32;
+        }
+        else if (!strcmp(paramString, "UINT32")) {
+            pAttribute->setDataType(NDAttrUInt32);
+            *paramIndex = functUInt32;
+        }
+        else if (!strcmp(paramString, "INT64")) {
+            pAttribute->setDataType(NDAttrInt64);
+            *paramIndex = functInt64;
+        }
+        else if (!strcmp(paramString, "UINT64")) {
+            pAttribute->setDataType(NDAttrUInt64);
+            *paramIndex = functUInt64;
+        }
+        else if (!strcmp(paramString, "FLOAT32")) {
+            pAttribute->setDataType(NDAttrFloat32);
+            *paramIndex = functFloat32;
+        }
+        else if (!strcmp(paramString, "FLOAT64")) {
+            pAttribute->setDataType(NDAttrFloat64);
+            *paramIndex = functFloat64;
+        }
         else {
             printf("Error, unknown parameter string = %s\n", paramString);
             free(paramIndex);
@@ -87,6 +137,66 @@ static int myAttrFunct1(const char *paramString, void **functionPvt, functAttrib
             epicsUInt64 value = now.secPastEpoch;
             value = (value << 32) | now.nsec;
             pAttribute->setValue(&value);
+            break;
+          }
+
+        case functInt8: {
+            epicsInt8 val=-8;
+            pAttribute->setValue(&val);
+            break;
+          }
+
+        case functUInt8: {
+            epicsUInt8 val=8;
+            pAttribute->setValue(&val);
+            break;
+          }
+
+        case functInt16: {
+            epicsInt16 val=-16;
+            pAttribute->setValue(&val);
+            break;
+          }
+
+        case functUInt16: {
+            epicsUInt16 val=16;
+            pAttribute->setValue(&val);
+            break;
+          }
+
+        case functInt32: {
+            epicsInt32 val=-32;
+            pAttribute->setValue(&val);
+            break;
+          }
+
+        case functUInt32: {
+            epicsUInt32 val=32;
+            pAttribute->setValue(&val);
+            break;
+          }
+
+        case functInt64: {
+            epicsInt64 val=-64;
+            pAttribute->setValue(&val);
+            break;
+          }
+
+        case functUInt64: {
+            epicsUInt64 val=64;
+            pAttribute->setValue(&val);
+            break;
+          }
+
+        case functFloat32: {
+            epicsFloat32 val=32.0;
+            pAttribute->setValue(&val);
+            break;
+          }
+
+        case functFloat64: {
+            epicsFloat64 val=64.0;
+            pAttribute->setValue(&val);
             break;
           }
 

--- a/ADApp/pluginSrc/NDFileTIFF.cpp
+++ b/ADApp/pluginSrc/NDFileTIFF.cpp
@@ -299,7 +299,7 @@ asynStatus NDFileTIFF::openFile(const char *fileName, NDFileOpenMode_t openMode,
             case NDAttrInt16:
             case NDAttrInt32:
             case NDAttrInt64: {
-                pAttribute->getValue(attrDataType, &value.i64);
+                pAttribute->getValue(NDAttrInt64, &value.i64);
                 epicsSnprintf(tagString, sizeof(tagString)-1, "%s:%lld", attributeName, value.i64);
                 break;
             }
@@ -307,7 +307,7 @@ asynStatus NDFileTIFF::openFile(const char *fileName, NDFileOpenMode_t openMode,
             case NDAttrUInt16:
             case NDAttrUInt32:
             case NDAttrUInt64: {
-                pAttribute->getValue(attrDataType, &value.ui64);
+                pAttribute->getValue(NDAttrUInt64, &value.ui64);
                 epicsSnprintf(tagString, sizeof(tagString)-1, "%s:%llu", attributeName, value.ui64);
                 break;
             }

--- a/ADApp/pluginSrc/NDFileTIFF.cpp
+++ b/ADApp/pluginSrc/NDFileTIFF.cpp
@@ -296,15 +296,19 @@ asynStatus NDFileTIFF::openFile(const char *fileName, NDFileOpenMode_t openMode,
 
         switch (attrDataType) {
             case NDAttrInt8:
-            case NDAttrUInt8:
             case NDAttrInt16:
-            case NDAttrUInt16:
             case NDAttrInt32:
-            case NDAttrUInt32:
-            case NDAttrInt64:
-            case NDAttrUInt64: {
+            case NDAttrInt64: {
                 pAttribute->getValue(attrDataType, &value.i64);
                 epicsSnprintf(tagString, sizeof(tagString)-1, "%s:%lld", attributeName, value.i64);
+                break;
+            }
+            case NDAttrUInt8:
+            case NDAttrUInt16:
+            case NDAttrUInt32:
+            case NDAttrUInt64: {
+                pAttribute->getValue(attrDataType, &value.ui64);
+                epicsSnprintf(tagString, sizeof(tagString)-1, "%s:%llu", attributeName, value.ui64);
                 break;
             }
             case NDAttrFloat32: {


### PR DESCRIPTION
This PR does 2 things:
- Modifies myAttributeFunctions.cpp to generate attributes of all numeric datatypes.  This allows thorough testing of the TIFF plugin and other applications that handle NDAttributes.
- Fixes the TIFF plugin to handle all numeric attribute datatypes correctly.  Signed and unsigned integers are handled separately.  All integer types are converted to 64-bits before being converted to ASCII.

A new attribute XML file was added to simDetector to generate an instance of each attribute numeric datatype.
https://github.com/areaDetector/ADSimDetector/blob/master/iocs/simDetectorIOC/iocBoot/iocSimDetector/testAttributeDataTypes.xml

I tested ADSimDetector using that XML file.  

I printed out the values of the NDArray attributes:
```
epics> asynReport 20 SIM1
SIM1 multiDevice:No canBlock:No autoConnect:Yes
    enabled:Yes connected:Yes numberConnects 1
    nDevices 0 nQueued 0 blocked:No
    asynManagerLock:No synchronousLock:No
    exceptionActive:No exceptionUsers 1 exceptionNotifys 0
    traceMask:0x1 traceIOMask:0x2 traceInfoMask:0x1
    interposeInterfaceList
        asynOctet pinterface 0x1827b20 drvPvt 0x38e6130
    interfaceList
        asynCommon pinterface 0x18262d0 drvPvt 0x38e2ec0
        asynDrvUser pinterface 0x1826060 drvPvt 0x38e2ec0
        asynOctet pinterface 0x18261a0 drvPvt 0x38e2ec0
        asynInt32 pinterface 0x18262a0 drvPvt 0x38e2ec0
        asynFloat64 pinterface 0x1826200 drvPvt 0x38e2ec0
        asynInt32Array pinterface 0x1826140 drvPvt 0x38e2ec0
        asynGenericPointer pinterface 0x18260c0 drvPvt 0x38e2ec0
Simulation detector SIM1
  NX, NY:            1920  1080
  Data type:         0
Port: SIM1
  Timestamp: 2024/11/14 17:27:36.075
  Input EOS[0]:
  Output EOS[0]:
Parameter list 0
Number of parameters is: 130
Parameter 0 type=string, name=PORT_NAME_SELF, value=SIM1, status=0
Parameter 1 type=string, name=ADCORE_VERSION, value=3.13.0, status=0
Parameter 2 type=string, name=DRIVER_VERSION, value=2.11.0, status=0
Parameter 3 type=string, name=MANUFACTURER, value=Simulated detector, status=0
...
SIM1: pArrays[0] report

NDArray  Array address=0x7f0140003810:
  ndims=2 dims=[1920 1080 ]
  dataType=0, dataSize=2073600, pData=0x7f013b41e010
  uniqueId=0, timeStamp=0.000000, epicsTS.secPastEpoch=0, epicsTS.nsec=0
  referenceCount=1
  number of attributes=11

NDAttributeList: address=0x7f01400039b0:
  number of attributes=11

NDAttribute, address=0x7f0140003a40:
  name=ColorMode
  description=Color mode
  source type=0
  source type string=NDAttrSourceDriver
  source=Driver
  dataType=NDAttrInt32
  value=0

NDAttribute, address=0x7f0140002540:
  name=Int8
  description=Int8 attribute
  source type=3
  source type string=NDAttrSourceFunct
  source=myAttrFunct1
  dataType=NDAttrInt8
  value=-8
  functAttribute
    functParam=INT8
    pFunction=0x702a50
    functionPvt=0x6557940

NDAttribute, address=0x7f01400023c0:
  name=UInt8
  description=UInt8 attribute
  source type=3
  source type string=NDAttrSourceFunct
  source=myAttrFunct1
  dataType=NDAttrUInt8
  value=8
  functAttribute
    functParam=UINT8
    pFunction=0x702a50
    functionPvt=0x6557960

NDAttribute, address=0x7f0140002240:
  name=Int16
  description=Int16 attribute
  source type=3
  source type string=NDAttrSourceFunct
  source=myAttrFunct1
  dataType=NDAttrInt16
  value=-16
  functAttribute
    functParam=INT16
    pFunction=0x702a50
    functionPvt=0x6557980

NDAttribute, address=0x7f0140003b70:
  name=UInt16
  description=UInt16 attribute
  source type=3
  source type string=NDAttrSourceFunct
  source=myAttrFunct1
  dataType=NDAttrUInt16
  value=16
  functAttribute
    functParam=UINT16
    pFunction=0x702a50
    functionPvt=0x65579a0

NDAttribute, address=0x7f0140003c70:
  name=Int32
  description=Int32 attribute
  source type=3
  source type string=NDAttrSourceFunct
  source=myAttrFunct1
  dataType=NDAttrInt32
  value=-32
  functAttribute
    functParam=INT32
    pFunction=0x702a50
    functionPvt=0x65579c0

NDAttribute, address=0x7f0140003d70:
  name=UInt32
  description=UInt32 attribute
  source type=3
  source type string=NDAttrSourceFunct
  source=myAttrFunct1
  dataType=NDAttrUInt32
  value=32
  functAttribute
    functParam=UINT32
    pFunction=0x702a50
    functionPvt=0x65579e0

NDAttribute, address=0x7f0140003e90:
  name=Int64
  description=Int64 attribute
  source type=3
  source type string=NDAttrSourceFunct
  source=myAttrFunct1
  dataType=NDAttrInt64
  value=-64
  functAttribute
    functParam=INT64
    pFunction=0x702a50
    functionPvt=0x6557a00

NDAttribute, address=0x7f0140003fb0:
  name=UInt64
  description=UInt64 attribute
  source type=3
  source type string=NDAttrSourceFunct
  source=myAttrFunct1
  dataType=NDAttrUInt64
  value=64
  functAttribute
    functParam=UINT64
    pFunction=0x702a50
    functionPvt=0x6557a20

NDAttribute, address=0x7f0140004100:
  name=Float32
  description=Float32 attribute
  source type=3
  source type string=NDAttrSourceFunct
  source=myAttrFunct1
  dataType=NDAttrFloat32
  value=32.000000
  functAttribute
    functParam=FLOAT32
    pFunction=0x702a50
    functionPvt=0x6557a40

NDAttribute, address=0x7f0140004280:
  name=Float64
  description=Float64 attribute
  source type=3
  source type string=NDAttrSourceFunct
  source=myAttrFunct1
  dataType=NDAttrFloat64
  value=64.000000
  functAttribute
    functParam=FLOAT64
    pFunction=0x702a50
    functionPvt=0x6557a60
```
The numeric attributes with names like Int8, UInt8, ... Float64 all have the correct data types and values.

I then saved a TIFF file, and ran tiffinfo on it:
```
(base) [epics@corvette data]$ tiffinfo test_006.tif
TIFFReadDirectory: Warning, Unknown field with tag 65000 (0xfde8) encountered.
TIFFReadDirectory: Warning, Unknown field with tag 65001 (0xfde9) encountered.
TIFFReadDirectory: Warning, Unknown field with tag 65002 (0xfdea) encountered.
TIFFReadDirectory: Warning, Unknown field with tag 65003 (0xfdeb) encountered.
TIFFReadDirectory: Warning, Unknown field with tag 65010 (0xfdf2) encountered.
TIFFReadDirectory: Warning, Unknown field with tag 65011 (0xfdf3) encountered.
TIFFReadDirectory: Warning, Unknown field with tag 65012 (0xfdf4) encountered.
TIFFReadDirectory: Warning, Unknown field with tag 65013 (0xfdf5) encountered.
TIFFReadDirectory: Warning, Unknown field with tag 65014 (0xfdf6) encountered.
TIFFReadDirectory: Warning, Unknown field with tag 65015 (0xfdf7) encountered.
TIFFReadDirectory: Warning, Unknown field with tag 65016 (0xfdf8) encountered.
TIFFReadDirectory: Warning, Unknown field with tag 65017 (0xfdf9) encountered.
TIFFReadDirectory: Warning, Unknown field with tag 65018 (0xfdfa) encountered.
TIFFReadDirectory: Warning, Unknown field with tag 65019 (0xfdfb) encountered.
TIFFReadDirectory: Warning, Unknown field with tag 65020 (0xfdfc) encountered.
TIFF Directory at offset 0x1fa408 (2073608)
  Image Width: 1920 Image Length: 1080
  Bits/Sample: 8
  Sample Format: signed integer
  Compression Scheme: None
  Photometric Interpretation: min-is-black
  Samples/Pixel: 1
  Rows/Strip: 1080
  Planar Configuration: single image plane
  Make: Unknown
  Model: Unknown
  Software: EPICS areaDetector
  Tag 65000: 1100473830.931446
  Tag 65001: 35
  Tag 65002: 1100473830
  Tag 65003: 931445520
  Tag 65010: ColorMode:0
  Tag 65011: Int8:-8
  Tag 65012: UInt8:8
  Tag 65013: Int16:-16
  Tag 65014: UInt16:16
  Tag 65015: Int32:-32
  Tag 65016: UInt32:32
  Tag 65017: Int64:-64
  Tag 65018: UInt64:64
  Tag 65019: Float32:32.000000
  Tag 65020: Float64:64.000000
```
The values of all the numeric attribute datatypes are correct.
