### PR TITLE
Fix inconsistencies in the documentation of some records

### DIFF
--- a/ADApp/Db/NDFileHDF5.template
+++ b/ADApp/Db/NDFileHDF5.template
@@ -813,17 +813,6 @@ record(bi, "$(P)$(R)DimAttDatasets_RBV")
     field(SCAN, "I/O Intr")
 }
 
-# File path.
-# % autosave 2 
-#record(waveform, "$(P)$(R)XMLPath")
-#{
-#    field(PINI, "YES")
-#    field(DTYP, "asynOctetWrite")
-#    field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))HDF5_layoutDirectory")
-#    field(FTVL, "CHAR")
-#    field(NELM, "256")
-#}
-
 record(waveform, "$(P)$(R)XMLErrorMsg_RBV")
 {
     field(DTYP, "asynOctetRead")

--- a/docs/ADCore/ADDriver.rst
+++ b/docs/ADCore/ADDriver.rst
@@ -57,7 +57,7 @@ possible.
     - r/o 
     - Actual detector temperature 
     - TEMPERATURE_ACTUAL 
-    - $(P)$(R)Temperature_Actual 
+    - $(P)$(R)TemperatureActual
     - ai 
   * -
     -

--- a/docs/ADCore/NDArray.rst
+++ b/docs/ADCore/NDArray.rst
@@ -614,8 +614,8 @@ loading ADBase.template.
       The value of this record must be set with caution, because too large a value could
       use all memory on the system, resulting serious performance degradation.
     - POOL_NUM_PRE_ALLOC_BUFFERS
-    - $(P)$(R)NumPreAllocBuffers
-    - longout
+    - $(P)$(R)NumPreAllocBuffers, $(P)$(R)NumPreAllocBuffers_RBV
+    - longout, longin
   * - NDPoolPreAllocBuffers
     - asynInt32
     - r/w

--- a/docs/ADCore/NDArray.rst
+++ b/docs/ADCore/NDArray.rst
@@ -479,7 +479,7 @@ loading ADBase.template.
     - Compressed size of the array data in bytes. Only meaningful if NDCodec is not empty
       string.
     - COMPRESSED_SIZE
-    - $(P)$(R)Compressed_RBV
+    - $(P)$(R)CompressedSize_RBV
     - longin
   * -
     -

--- a/docs/ADCore/NDArray.rst
+++ b/docs/ADCore/NDArray.rst
@@ -465,13 +465,14 @@ loading ADBase.template.
   * - N.A.
     - N.A
     - r/o
-    - Size of each array dimension, extracted from the $(P)$(R)Dimensions and $(P)$(R)Dimensions_RBV
+    - Size of each array dimension K in [0..9], extracted from the $(P)$(R)Dimensions and $(P)$(R)Dimensions_RBV
       waveform records. Note that these are both longin record, i.e. readonly values using
       subarray records. In the future longout records may be added to write to the individual
       values in $(P)$(R)Dimensions.
     - N.A.
-    - $(P)$(R)ArraySize[N] N=0-9
-      , (P)$(R)ArraySize[N]_RBV
+    - $(P)$(R)ArraySize<K>, $(P)$(R)ArraySize<K>_RBV
+
+      E.g. $(P)$(R)ArraySize0_RBV
     - longin, longin
   * - NDArraySizeX
     - asynInt32

--- a/docs/ADCore/NDArray.rst
+++ b/docs/ADCore/NDArray.rst
@@ -412,6 +412,41 @@ loading ADBase.template.
   * -
     -
     -
+    - **Unique ID and time stamps of the array**
+  * - NDUniqueId
+    - asynInt32
+    - r/o
+    - Unique ID number of array assigned by the EPICS driver.
+    - UNIQUE_ID
+    - $(P)$(R)UniqueId_RBV
+    - longin
+  * - NDTimeStamp
+    - asynFloat64
+    - r/o
+    - Time stamp of array.
+    - TIME_STAMP
+    - $(P)$(R)TimeStamp_RBV
+    - ai
+  * - NDEpicsTSSec
+    - asynInt32
+    - r/o
+    - Seconds past epoch time stamp of array assigned by the EPICS driver. It
+      is based on the EPICS epoch.
+    - EPICS_TS_SEC
+    - $(P)$(R)EpicsTSSec_RBV
+    - longin
+  * - NDEpicsTSNsec
+    - asynInt32
+    - r/o
+    - Nanoseconds time stamp fraction of the EPICS time stamp. It should be
+      composed with $(P)$(R)EpicsTSSec_RBV to get the final time stamp with
+      nanosecond resolution.
+    - EPICS_TS_NSEC
+    - $(P)$(R)EpicsTSNsec_RBV
+    - longin
+  * -
+    -
+    -
     - **Actual dimensions of array data**
   * - NDNDimensions
     - asynInt32

--- a/docs/ADCore/NDArray.rst
+++ b/docs/ADCore/NDArray.rst
@@ -808,7 +808,7 @@ loading ADBase.template.
     - File write status. Gives status information on last file open or file write operation.
       Values are WriteOK (0) and WriteError (1).
     - WRITE_STATUS
-    - $(P)$(R)FileWriteStatus
+    - $(P)$(R)WriteStatus
     - mbbi
   * - NDFileWriteMessage
     - asynOctet
@@ -816,7 +816,7 @@ loading ADBase.template.
     - File write error message. An error message string if the previous file open or file
       write operation resulted in an error.
     - WRITE_MESSAGE
-    - $(P)$(R)FileWriteMessage
+    - $(P)$(R)WriteMessage
     - waveform
   * - NDFileCapture
     - asynInt32

--- a/docs/ADCore/NDFileHDF5.rst
+++ b/docs/ADCore/NDFileHDF5.rst
@@ -924,7 +924,7 @@ Parameters and Records
     - r/o
     - Total runtime in seconds from first frame to file closed
     - HDF5_totalRuntime
-    - $(P)$(R)Runtime
+    - $(P)$(R)RunTime
     - ai
   * - asynFloat64
     - r/o

--- a/docs/ADCore/NDFileHDF5.rst
+++ b/docs/ADCore/NDFileHDF5.rst
@@ -723,7 +723,7 @@ Parameters and Records
     - r/w
     - Number of extra dimensions [0..9]
     - HDF5_nExtraDims
-    - $(P)$(R)NumExtraDims, $(P)$(R)NumExtraDims
+    - $(P)$(R)NumExtraDims, $(P)$(R)NumExtraDims_RBV
     - mbbo, mbbi
   * - asynInt32
     - r/w

--- a/docs/ADCore/NDFileHDF5.rst
+++ b/docs/ADCore/NDFileHDF5.rst
@@ -757,6 +757,12 @@ Parameters and Records
     - stringin
   * - asynInt32
     - r/w
+    - Chunk of extra dimension X
+    - HDF5_extraDimChunkX
+    - $(P)$(R)ExtraDimChunkX, $(P)$(R)ExtraDimChunkX_RBV
+    - longout, longin
+  * - asynInt32
+    - r/w
     - Size of extra dimension Y
     - HDF5_extraDimSizeY
     - $(P)$(R)ExtraDimSizeY, $(P)$(R)ExtraDimSizeY_RBV
@@ -767,6 +773,12 @@ Parameters and Records
     - HDF5_extraDimNameY
     - $(P)$(R)ExtraDimNameY_RBV
     - stringin
+  * - asynInt32
+    - r/w
+    - Chunk of extra dimension Y
+    - HDF5_extraDimChunkY
+    - $(P)$(R)ExtraDimChunkY, $(P)$(R)ExtraDimChunkY_RBV
+    - longout, longin
   * - asynInt32
     - r/w
     - Size of the K'th extra dimension, for K in [3..9]
@@ -783,6 +795,14 @@ Parameters and Records
 
       E.g $(P)$(R)ExtraDimName8_RBV
     - stringin
+  * - asynInt32
+    - r/w
+    - Chunk of the K'th extra dimension, for K in [3..9]
+    - HDF5_extraDimChunk<K>
+    - $(P)$(R)ExtraDimChunk<K>, $(P)$(R)ExtraDimChunk<K>_RBV
+
+      E.g. $(P)$(R)ExtraDimChunk9
+    - longout, longin
   * -
     -
     - **Positional Placement**

--- a/docs/ADCore/NDFileHDF5.rst
+++ b/docs/ADCore/NDFileHDF5.rst
@@ -737,18 +737,36 @@ Parameters and Records
     - HDF5_extraDimSizeN
     - $(P)$(R)ExtraDimSizeN, $(P)$(R)ExtraDimSizeN_RBV
     -
+  * - asynOctet
+    - r/o
+    - HDF5_extraDimNameN
+    - Name of extra dimension N
+    - $(P)$(R)ExtraDimNameN_RBV
+    - stringin
   * - asynInt32
     - r/w
     - Size of extra dimension X
     - HDF5_extraDimSizeX
     - $(P)$(R)ExtraDimSizeX, $(P)$(R)ExtraDimSizeX_RBV
     - longout, longin
+  * - asynOctet
+    - r/o
+    - Name of extra dimension X
+    - HDF5_extraDimNameX
+    - $(P)$(R)ExtraDimNameX_RBV
+    - stringin
   * - asynInt32
     - r/w
     - Size of extra dimension Y
     - HDF5_extraDimSizeY
     - $(P)$(R)ExtraDimSizeY, $(P)$(R)ExtraDimSizeY_RBV
     - longout, longin
+  * - asynOctet
+    - r/o
+    - Name of extra dimension Y
+    - HDF5_extraDimNameY
+    - $(P)$(R)ExtraDimNameY_RBV
+    - stringin
   * - asynInt32
     - r/w
     - Size of the K'th extra dimension, for K in [3..9]
@@ -757,6 +775,14 @@ Parameters and Records
 
       E.g. $(P)$(R)ExtraDimSize3_RBV
     - longout, longin
+  * - asynOctet
+    - r/o
+    - Name of the K'th extra dimension, for K in [3..9]
+    - HDF5_extraDimName<K>
+    - $(P)$(R)ExtraDimName<K>_RBV
+
+      E.g $(P)$(R)ExtraDimName8_RBV
+    - stringin
   * -
     -
     - **Positional Placement**

--- a/docs/ADCore/NDFileHDF5.rst
+++ b/docs/ADCore/NDFileHDF5.rst
@@ -751,45 +751,9 @@ Parameters and Records
     - longout, longin
   * - asynInt32
     - r/w
-    - Size of extra dimension 3
-    - HDF5_extraDimSize3
-    - $(P)$(R)ExtraDimSize3, $(P)$(R)ExtraDimSize3_RBV
-    - longout, longin
-  * - asynInt32
-    - r/w
-    - Size of extra dimension 4
-    - HDF5_extraDimSize4
-    - $(P)$(R)ExtraDimSize4, $(P)$(R)ExtraDimSize4_RBV
-    - longout, longin
-  * - asynInt32
-    - r/w
-    - Size of extra dimension 5
-    - HDF5_extraDimSize5
-    - $(P)$(R)ExtraDimSize5, $(P)$(R)ExtraDimSize5_RBV
-    - longout, longin
-  * - asynInt32
-    - r/w
-    - Size of extra dimension 6
-    - HDF5_extraDimSize6
-    - $(P)$(R)ExtraDimSize6, $(P)$(R)ExtraDimSize6_RBV
-    - longout, longin
-  * - asynInt32
-    - r/w
-    - Size of extra dimension 7
-    - HDF5_extraDimSize7
-    - $(P)$(R)ExtraDimSize7, $(P)$(R)ExtraDimSize7_RBV
-    - longout, longin
-  * - asynInt32
-    - r/w
-    - Size of extra dimension 8
-    - HDF5_extraDimSize8
-    - $(P)$(R)ExtraDimSize8, $(P)$(R)ExtraDimSize8_RBV
-    - longout, longin
-  * - asynInt32
-    - r/w
-    - Size of extra dimension 9
-    - HDF5_extraDimSize9
-    - $(P)$(R)ExtraDimSize9, $(P)$(R)ExtraDimSize9_RBV
+    - Size of the N'th extra dimension, for N in [3..9]
+    - HDF5_extraDimSize[N]
+    - $(P)$(R)ExtraDimSize[N], $(P)$(R)ExtraDimSize[N]_RBV
     - longout, longin
   * -
     -
@@ -820,45 +784,9 @@ Parameters and Records
     - stringout, stringin
   * - asynOctet
     - r/w
-    - Specify the NDAttribute name for the 3rd index
-    - HDF5_posNameDim3
-    - $(P)$(R)PosNameDim3, $(P)$(R)PosNameDim3_RBV
-    - stringout, stringin
-  * - asynOctet
-    - r/w
-    - Specify the NDAttribute name for the 4th index
-    - HDF5_posNameDim4
-    - $(P)$(R)PosNameDim4, $(P)$(R)PosNameDim4_RBV
-    - stringout, stringin
-  * - asynOctet
-    - r/w
-    - Specify the NDAttribute name for the 5th index
-    - HDF5_posNameDim5
-    - $(P)$(R)PosNameDim5, $(P)$(R)PosNameDim5_RBV
-    - stringout, stringin
-  * - asynOctet
-    - r/w
-    - Specify the NDAttribute name for the 6th index
-    - HDF5_posNameDim6
-    - $(P)$(R)PosNameDim6, $(P)$(R)PosNameDim6_RBV
-    - stringout, stringin
-  * - asynOctet
-    - r/w
-    - Specify the NDAttribute name for the 7th index
-    - HDF5_posNameDim7
-    - $(P)$(R)PosNameDim7, $(P)$(R)PosNameDim7_RBV
-    - stringout, stringin
-  * - asynOctet
-    - r/w
-    - Specify the NDAttribute name for the 8th index
-    - HDF5_posNameDim8
-    - $(P)$(R)PosNameDim8, $(P)$(R)PosNameDim8_RBV
-    - stringout, stringin
-  * - asynOctet
-    - r/w
-    - Specify the NDAttribute name for the 9th index
-    - HDF5_posNameDim9
-    - $(P)$(R)PosNameDim9, $(P)$(R)PosNameDim9_RBV
+    - Specify the NDAttribute name for the N'th index, for N in [3..9]
+    - HDF5_posNameDim[N]
+    - $(P)$(R)PosNameDim[N], $(P)$(R)PosNameDim[N]_RBV
     - stringout, stringin
   * -
     -
@@ -873,55 +801,19 @@ Parameters and Records
     - r/w
     - Specify the NDAttribute index for the X dimension
     - HDF5_posIndexDimX
-    - $(P)$(R)posIndexDimX, $(P)$(R)posIndexDimX_RBV
+    - $(P)$(R)PosIndexDimX, $(P)$(R)PosIndexDimX_RBV
     - stringout, stringin
   * - asynOctet
     - r/w
     - Specify the NDAttribute index for the Y dimension
     - HDF5_posIndexDimY
-    - $(P)$(R)posIndexDimY, $(P)$(R)posIndexDimY_RBV
+    - $(P)$(R)PosIndexDimY, $(P)$(R)PosIndexDimY_RBV
     - stringout, stringin
   * - asynOctet
     - r/w
-    - Specify the NDAttribute index for the 3rd dimension
-    - HDF5_posIndexDim3
-    - $(P)$(R)posIndexDim3, $(P)$(R)posIndexDim3_RBV
-    - stringout, stringin
-  * - asynOctet
-    - r/w
-    - Specify the NDAttribute index for the 4th dimension
-    - HDF5_posIndexDim4
-    - $(P)$(R)posIndexDim4, $(P)$(R)posIndexDim4_RBV
-    - stringout, stringin
-  * - asynOctet
-    - r/w
-    - Specify the NDAttribute index for the 5th dimension
-    - HDF5_posIndexDim5
-    - $(P)$(R)posIndexDim5, $(P)$(R)posIndexDim5_RBV
-    - stringout, stringin
-  * - asynOctet
-    - r/w
-    - Specify the NDAttribute index for the 6th dimension
-    - HDF5_posIndexDim6
-    - $(P)$(R)posIndexDim6, $(P)$(R)posIndexDim6_RBV
-    - stringout, stringin
-  * - asynOctet
-    - r/w
-    - Specify the NDAttribute index for the 7th dimension
-    - HDF5_posIndexDim7
-    - $(P)$(R)posIndexDim7, $(P)$(R)posIndexDim7_RBV
-    - stringout, stringin
-  * - asynOctet
-    - r/w
-    - Specify the NDAttribute index for the 8th dimension
-    - HDF5_posIndexDim8
-    - $(P)$(R)posIndexDim8, $(P)$(R)posIndexDim8_RBV
-    - stringout, stringin
-  * - asynOctet
-    - r/w
-    - Specify the NDAttribute index for the 9th dimension
-    - HDF5_posIndexDim9
-    - $(P)$(R)posIndexDim9, $(P)$(R)posIndexDim9_RBV
+    - Specify the NDAttribute index for the N'th dimension, for N in [3..9]
+    - HDF5_posIndexDim[N]
+    - $(P)$(R)PosIndexDim[N], $(P)$(R)PosIndexDim[N]_RBV
     - stringout, stringin
   * -
     -

--- a/docs/ADCore/NDFileHDF5.rst
+++ b/docs/ADCore/NDFileHDF5.rst
@@ -662,6 +662,12 @@ Parameters and Records
     - HDF5_dimAttDatasets
     - $(P)$(R)DimAttDatasets, $(P)$(R)DimAttDatasets_RBV
     - bo, bi
+  * - asynFloat64
+    - r/w
+    - Fill value for the dataset to be set in its creation property list.
+    - HDF5_fillValue
+    - $(P)$(R)FillValue, $(P)$(R)FillValue_RBV
+    - ao, ai
   * -
     -
     - **SWMR**

--- a/docs/ADCore/NDFileHDF5.rst
+++ b/docs/ADCore/NDFileHDF5.rst
@@ -677,7 +677,7 @@ Parameters and Records
     - Turn on or off SWMR mode for the next acquisition (1 = On, 0 = Off). Turning on
       will only work if SWMR mode is supported.
     - HDF5_SWMRMode
-    - $(P)$(R)SWMRMode, $(P)$(R)SMWRMode_RBV
+    - $(P)$(R)SWMRMode, $(P)$(R)SWMRMode_RBV
     - bo, bi
   * - asynInt32
     - r/o

--- a/docs/ADCore/NDFileHDF5.rst
+++ b/docs/ADCore/NDFileHDF5.rst
@@ -751,9 +751,11 @@ Parameters and Records
     - longout, longin
   * - asynInt32
     - r/w
-    - Size of the N'th extra dimension, for N in [3..9]
-    - HDF5_extraDimSize[N]
-    - $(P)$(R)ExtraDimSize[N], $(P)$(R)ExtraDimSize[N]_RBV
+    - Size of the K'th extra dimension, for K in [3..9]
+    - HDF5_extraDimSize<K>
+    - $(P)$(R)ExtraDimSize<K>, $(P)$(R)ExtraDimSize<K>_RBV
+
+      E.g. $(P)$(R)ExtraDimSize3_RBV
     - longout, longin
   * -
     -
@@ -784,9 +786,11 @@ Parameters and Records
     - stringout, stringin
   * - asynOctet
     - r/w
-    - Specify the NDAttribute name for the N'th index, for N in [3..9]
-    - HDF5_posNameDim[N]
-    - $(P)$(R)PosNameDim[N], $(P)$(R)PosNameDim[N]_RBV
+    - Specify the NDAttribute name for the K'th index, for K in [3..9]
+    - HDF5_posNameDim<K>
+    - $(P)$(R)PosNameDim<K>, $(P)$(R)PosNameDim<K>_RBV
+
+      E.g. $(P)$(R)PosNameDim5
     - stringout, stringin
   * -
     -
@@ -797,7 +801,7 @@ Parameters and Records
     - HDF5_posIndexDimN
     - $(P)$(R)PosIndexDimN, $(P)$(R)PosIndexDimN_RBV
     - stringout, stringin
-  * - asynOctet
+  * - asynOcte9
     - r/w
     - Specify the NDAttribute index for the X dimension
     - HDF5_posIndexDimX
@@ -811,9 +815,11 @@ Parameters and Records
     - stringout, stringin
   * - asynOctet
     - r/w
-    - Specify the NDAttribute index for the N'th dimension, for N in [3..9]
-    - HDF5_posIndexDim[N]
-    - $(P)$(R)PosIndexDim[N], $(P)$(R)PosIndexDim[N]_RBV
+    - Specify the NDAttribute index for the K'th dimension, for K in [3..9]
+    - HDF5_posIndexDim<K>
+    - $(P)$(R)PosIndexDim<K>, $(P)$(R)PosIndexDim<K>_RBV
+
+      E.g. $(P)$(R)PosIndexDim9_RBV
     - stringout, stringin
   * -
     -

--- a/docs/ADCore/NDPluginGather.rst
+++ b/docs/ADCore/NDPluginGather.rst
@@ -73,7 +73,7 @@ split into 2 lines, but these are just a single name, for example
       There can be more than one such input port. The maximum is number is specified in
       the NDGatherConfigure command in the startup script.
     - NDARRAY_PORT
-    - $(P)$(R)NDArrayPort_[N], (P)$(R)NDArrayPort_[N]_RBV
+    - $(P)$(R)NDArrayPort_$(N), (P)$(R)NDArrayPort_$(N)_RBV
     - stringout, stringin
   * - NDPluginDriver |br|
       ArrayAddr
@@ -84,7 +84,7 @@ split into 2 lines, but these are just a single name, for example
       in the NDArray driver. There can be more than one such input port. The maximum is
       number is specified in the NDGatherConfigure command in the startup script.
     - NDARRAY_ADDR
-    - $(P)$(R)NDArrayAddress_[N], $(P)$(R)NDArrayAddress_[N]_RBV
+    - $(P)$(R)NDArrayAddress_$(N), $(P)$(R)NDArrayAddress_$(N)_RBV
     - longout, longin
 
 Configuration


### PR DESCRIPTION
While taking a look at the available PVs on the ADDriver, NDArray, and HDF5 plugin pages, I found some inconsistencies in the documentation, mostly typos in PV names, and some missing records.

For the missing records, I've written a quite generic description. Feel free to propose a better description line for each of them.

I haven't gone through all pages, so there might be other inconsistencies around.

As always, I recommend reviewing this patch series commit-wise.