### PR TITLE
Fix: plug memory leak in NDCodec (de)compressJPEG

### DIFF
--- a/ADApp/pluginSrc/NDPluginCodec.cpp
+++ b/ADApp/pluginSrc/NDPluginCodec.cpp
@@ -245,6 +245,8 @@ NDArray *compressJPEG(NDArray *input, int quality, NDCodecStatus_t *status, char
 
     output = allocArray(input, -1, outSize, outData);
 
+    jpeg_destroy_compress(&jpegInfo);
+
     if (!output) {
         sprintf(errorMessage, "Failed to allocate JPEG array");
         *status = NDCODEC_ERROR;
@@ -319,6 +321,8 @@ NDArray *decompressJPEG(NDArray *input, NDCodecStatus_t *status, char *errorMess
     output->pAttributeList->add("ColorMode", "Color Mode", NDAttrInt32,
             &colorMode);
     output->codec.clear();
+
+    jpeg_destroy_decompress(&jpegInfo);
 
     return output;
 }


### PR DESCRIPTION
Addresses #539.

Before:
<img width="1225" height="857" alt="Screenshot from 2025-07-14 15-32-22" src="https://github.com/user-attachments/assets/b92da7df-b401-41dd-bca6-e5149731e221" />

After:
<img width="1225" height="857" alt="Screenshot from 2025-07-14 15-31-52" src="https://github.com/user-attachments/assets/a5ec1f1b-f56e-4345-8d66-aae1471c2cba" />
