### PR TITLE
Use R macro to distinguish between different ROIs in NDROIStat8.

### DIFF
--- a/ADApp/Db/NDROIStat8.template
+++ b/ADApp/Db/NDROIStat8.template
@@ -26,35 +26,35 @@ include "NDROIStat.template"
 # Instantiate the ROI specific records
 ###################################################################
 
-substitute  "ROI=1:"
+substitute  "R=$(R)1:"
 substitute "ADDR=0"
 include "NDROIStatN.template"
 
-substitute  "ROI=2:"
+substitute  "R=$(R)2:"
 substitute "ADDR=1"
 include "NDROIStatN.template"
 
-substitute  "ROI=3:"
+substitute  "R=$(R)3:"
 substitute "ADDR=2"
 include "NDROIStatN.template"
 
-substitute  "ROI=4:"
+substitute  "R=$(R)4:"
 substitute "ADDR=3"
 include "NDROIStatN.template"
 
-substitute  "ROI=5:"
+substitute  "R=$(R)5:"
 substitute "ADDR=4"
 include "NDROIStatN.template"
 
-substitute  "ROI=6:"
+substitute  "R=$(R)6:"
 substitute "ADDR=5"
 include "NDROIStatN.template"
 
-substitute  "ROI=7:"
+substitute  "R=$(R)7:"
 substitute "ADDR=6"
 include "NDROIStatN.template"
 
-substitute  "ROI=8:"
+substitute  "R=$(R)8:"
 substitute "ADDR=7"
 include "NDROIStatN.template"
 


### PR DESCRIPTION
This is needed to fix a bug where multiple records with the same name were created.

Fix #546 