### PR TITLE
use HDF5 API circa 1.10

### DIFF
--- a/ADApp/pluginSrc/Makefile
+++ b/ADApp/pluginSrc/Makefile
@@ -7,8 +7,8 @@ include $(TOP)/configure/CONFIG
 LIBRARY_IOC += NDPlugin
 DBD         += NDPluginSupport.dbd
 
-# Use HDF5 API V2
-USR_CXXFLAGS_Linux += -DH5Gopen_vers=2
+# Use HDF5 API circa v1.10
+USR_CXXFLAGS_Linux += -DH5_USE_110_API
 
 # json.hpp requires C++11
 NDPluginBadPixel_CXXFLAGS_Linux += -std=c++11

--- a/ADApp/pluginTests/Makefile
+++ b/ADApp/pluginTests/Makefile
@@ -8,8 +8,7 @@ include $(TOP)/configure/CONFIG
 SHARED_LIBRARIES=NO
 
 # Use HDF5 API V2
-USR_CXXFLAGS_Linux += -DH5Dopen_vers=2 -DH5Gcreate_vers=2
-USR_CFLAGS_Linux   += -DH5Dopen_vers=2 -DH5Gcreate_vers=2
+USR_CXXFLAGS_Linux += -DH5_USE_110_API
 
 ifeq ($(SHARED_LIBRARIES), YES)
    USR_CXXFLAGS_WIN32 += -DH5_BUILT_AS_DYNAMIC_LIB


### PR DESCRIPTION
Address #557 by selecting libhdf5 [API compatibility](https://support.hdfgroup.org/documentation/hdf5/latest/api-compat-macros.html) uniformly as of 1.10.