### PR TITLE
Destroyed pool fix: prevent SIGSEGV on IOC exit when pvAccess holds NDArrays after driver/pool destroyed

### DIFF
--- a/ADApp/ADSrc/NDArray.cpp
+++ b/ADApp/ADSrc/NDArray.cpp
@@ -235,6 +235,11 @@ int NDArray::release()
     printf("%s: WARNING, no owner\n", functionName);
     return(ND_ERROR);
   }
+  /* No-op if pool was already destroyed (e.g. IOC exit: PVA tears down after driver). */
+  if (NDArrayPool::isPoolDestroyed(pNDArrayPool)) {
+    pNDArrayPool = NULL;
+    return(ND_ERROR);
+  }
   return(pNDArrayPool->release(this));
 }
 

--- a/ADApp/ADSrc/NDArray.h
+++ b/ADApp/ADSrc/NDArray.h
@@ -187,6 +187,13 @@ public:
     size_t       getMemorySize();
     int          getNumFree();
     void         emptyFreeList();
+
+    /** Register a pool as being destroyed so late NDArray::release() calls no-op (avoids SIGSEGV
+     * when pvAccess tears down MonitorElements after the driver and pool are deleted). */
+    static void registerDestroyingPool(NDArrayPool *p);
+    /** Check if the given pool address was registered as destroyed (pointer not dereferenced). */
+    static bool isPoolDestroyed(NDArrayPool *p);
+
     static void  setDefaultFrameMemoryFunctions(MallocFunc_t newMalloc,
                                                 FreeFunc_t newFree);
     virtual void* frameMalloc(size_t size);

--- a/ADApp/ADSrc/NDArrayPool.cpp
+++ b/ADApp/ADSrc/NDArrayPool.cpp
@@ -8,6 +8,7 @@
 
 #include <string.h>
 #include <stdlib.h>
+#include <set>
 #include <dbDefs.h>
 #include <stdint.h>
 
@@ -45,6 +46,33 @@ FreeFunc_t defaultFrameFree = free;
 
 volatile int eraseNDAttributes=0;
 extern "C" {epicsExportAddress(int, eraseNDAttributes);}
+
+/* Registry of pool addresses being destroyed so NDArray::release() can no-op (avoids SIGSEGV
+ * when pvAccess tears down after the driver). Only the address is used; the pointer is never
+ * dereferenced in isPoolDestroyed(). */
+static std::set<NDArrayPool *> *destroyedPools = NULL;
+static epicsMutexId destroyedPoolsMutex = NULL;
+
+void NDArrayPool::registerDestroyingPool(NDArrayPool *p)
+{
+    if (!p) return;
+    if (!destroyedPoolsMutex)
+        destroyedPoolsMutex = epicsMutexCreate();
+    if (!destroyedPools)
+        destroyedPools = new std::set<NDArrayPool *>();
+    epicsMutexLock(destroyedPoolsMutex);
+    destroyedPools->insert(p);
+    epicsMutexUnlock(destroyedPoolsMutex);
+}
+
+bool NDArrayPool::isPoolDestroyed(NDArrayPool *p)
+{
+    if (!p || !destroyedPoolsMutex || !destroyedPools) return false;
+    epicsMutexLock(destroyedPoolsMutex);
+    bool found = (destroyedPools->find(p) != destroyedPools->end());
+    epicsMutexUnlock(destroyedPoolsMutex);
+    return found;
+}
 
 /** NDArrayPool constructor
   * \param[in] pDriver Pointer to the asynNDArrayDriver that created this object.

--- a/ADApp/ADSrc/asynNDArrayDriver.cpp
+++ b/ADApp/ADSrc/asynNDArrayDriver.cpp
@@ -866,8 +866,8 @@ asynNDArrayDriver::asynNDArrayDriver(const char *portName, int maxAddr, int maxB
                      interfaceMask | asynInt32Mask | asynFloat64Mask | asynOctetMask | asynInt32ArrayMask | asynGenericPointerMask | asynDrvUserMask,
                      interruptMask | asynInt32Mask | asynFloat64Mask | asynOctetMask | asynInt32ArrayMask | asynGenericPointerMask,
                      asynFlags, autoConnect, priority, stackSize),
-      pNDArrayPool(NULL), queuedArrayCountMutex_(NULL), queuedArrayCount_(0),
-      queuedArrayUpdateRun_(true)
+      pNDArrayPool(NULL), maxAddr_(maxAddr), queuedArrayCountMutex_(NULL),
+      queuedArrayCount_(0), queuedArrayUpdateRun_(true)
 {
     char versionString[20];
     static const char *functionName = "asynNDArrayDriver";
@@ -1029,6 +1029,17 @@ asynNDArrayDriver::~asynNDArrayDriver()
     epicsEventSignal(queuedArrayEvent_);
     epicsEventWait(queuedArrayUpdateDone_);
 
+    /* Register pool as destroying so any late NDArray::release() (e.g. from pvAccess
+     * MonitorElement teardown) no-ops instead of touching the pool we are about to delete. */
+    NDArrayPool::registerDestroyingPool(this->pNDArrayPoolPvt_);
+
+    /* Null pNDArrayPool on driver-owned arrays as well (belt and braces). */
+    if (this->pArrays) {
+        for (int i = 0; i < this->maxAddr_; i++) {
+            if (this->pArrays[i])
+                this->pArrays[i]->pNDArrayPool = NULL;
+        }
+    }
     delete this->pNDArrayPoolPvt_;
     free(this->pArrays);
     delete this->pAttributeList;

--- a/ADApp/ADSrc/asynNDArrayDriver.h
+++ b/ADApp/ADSrc/asynNDArrayDriver.h
@@ -241,6 +241,7 @@ protected:
 
 private:
     asynStatus preAllocateBuffers();
+    int maxAddr_;
     NDArrayPool *pNDArrayPoolPvt_;
     epicsMutex *queuedArrayCountMutex_;
     epicsEventId queuedArrayEvent_;

--- a/iocBoot/EXAMPLE_commonPlugins.cmd
+++ b/iocBoot/EXAMPLE_commonPlugins.cmd
@@ -204,11 +204,11 @@ startPVAServer
 
 # Optional: load scan records
 #dbLoadRecords("$(SSCAN)/db/scan.db", "P=$(PREFIX),MAXPTS1=2000,MAXPTS2=200,MAXPTS3=20,MAXPTS4=10,MAXPTSH=10")
-#set_requestfile_path("$(SSCAN)/db")
+#set_requestfile_path("$(SSCAN)/sscanApp/Db")
 
 # Optional: load sseq record for acquisition sequence
 #dbLoadRecords("$(CALC)/db/sseqRecord.db", "P=$(PREFIX), S=AcquireSequence")
-#set_requestfile_path("$(CALC)/db")
+#set_requestfile_path("$(CALC)/calcApp/Db")
 
 # Optional: load devIocStats records (requires DEVIOCSTATS module)
 #dbLoadRecords("$(DEVIOCSTATS)/db/iocAdminSoft.db", "IOC=$(PREFIX)")

--- a/iocBoot/EXAMPLE_commonPlugins.cmd
+++ b/iocBoot/EXAMPLE_commonPlugins.cmd
@@ -204,11 +204,11 @@ startPVAServer
 
 # Optional: load scan records
 #dbLoadRecords("$(SSCAN)/db/scan.db", "P=$(PREFIX),MAXPTS1=2000,MAXPTS2=200,MAXPTS3=20,MAXPTS4=10,MAXPTSH=10")
-#set_requestfile_path("$(SSCAN)/sscanApp/Db")
+#set_requestfile_path("$(SSCAN)/db")
 
 # Optional: load sseq record for acquisition sequence
 #dbLoadRecords("$(CALC)/db/sseqRecord.db", "P=$(PREFIX), S=AcquireSequence")
-#set_requestfile_path("$(CALC)/calcApp/Db")
+#set_requestfile_path("$(CALC)/db")
 
 # Optional: load devIocStats records (requires DEVIOCSTATS module)
 #dbLoadRecords("$(DEVIOCSTATS)/db/iocAdminSoft.db", "IOC=$(PREFIX)")


### PR DESCRIPTION
# Segmentation fault 

"fix: prevent SIGSEGV on IOC exit when pvAccess holds NDArrays after driver/pool destroyed" refers to Segmentation fault after ioc exits, when acquisition was performed (memory/pool allocated).

```
epics> auto_settings.sav: 2354 of 2354 PV's connected
ACQUIRE CHANGE: ADAcquire=1 (was 0), current ADStatus=0
PrvHst: Checking if TCP streaming should start - WritePrvHst=0
PrvHst: WritePrvHst is disabled (0) - TCP streaming not started
After acquireStart: ADStatus=1
ACQUIRE CHANGE: ADAcquire=0 (was 1), current ADStatus=1
PrvImg TCP connection closed by peer
PrvHst TCP disconnected
After acquireStop: ADStatus=0

epics> exit
PrvHst TCP disconnected
./st.cmd: line 5: 2343260 Segmentation fault      ../../bin/linux-x86_64/tpx3App st_base.cmd
```
### Fix applied to ADCore 3.14.0 master.

```
epics> exit
PrvHst TCP disconnected
```

### Problem
When an IOC exits (e.g. user types exit) after acquisition has run, the process can hit a SIGSEGV (signal 11). The crash is in NDArrayPool::release() (or equivalent use of the pool) after the detector driver and its NDArrayPool have already been destroyed.
**Cause**: Shutdown order: the detector driver destructor runs and deletes pNDArrayPoolPvt_. Later, the pvAccess ServerContext is torn down (atexit). Its MonitorElements still hold NDArray-derived data. The deleter used by ntndArrayConverter (freeNDArray) calls NDArray::release() on those arrays. By then the pool is gone, so release() runs against freed memory → SIGSEGV.
This has been seen with areaDetector IOCs (e.g. ADTimePix3) using ADCore 3.12.1 and 3.14.0. See issue areaDetector/ADTimePix3#5.


### Approach
Two parts:
**“Destroyed pool” registry**
* Before the driver deletes its pool, it registers the pool pointer in a static set.
* In NDArray::release(), we check that set using only the pool address (no dereference).
* If the pool was registered as destroying, we set pNDArrayPool = NULL and return without calling the pool.
So any late release() (from PVA or elsewhere) no-ops safely, even for NDArrays that are not the driver’s pArrays[] (e.g. copies handed to PVA).

**asynNDArrayDriver destructor**
* Store maxAddr in a member maxAddr_.
* In ~asynNDArrayDriver(): call NDArrayPool::registerDestroyingPool(pNDArrayPoolPvt_), null pNDArrayPool on each pArrays[i], then delete pNDArrayPoolPvt_.

### Changes

| File | Change |
| :---------------- | :------: |
| NDArray.h | Declare NDArrayPool::registerDestroyingPool(NDArrayPool*) and NDArrayPool::isPoolDestroyed(NDArrayPool*).|
| NDArrayPool.cpp | Implement both with a static std::set<NDArrayPool*> and a mutex. Pools are only ever added; the set is process-lifetime. |
| NDArray.cpp | At the start of NDArray::release(), if isPoolDestroyed(pNDArrayPool) then set pNDArrayPool = NULL and return ND_ERROR without calling the pool. |
| asynNDArrayDriver.h | Add private member int maxAddr_. |
| asynNDArrayDriver.cpp |  Constructor: initialize maxAddr_(maxAddr) (initializer order matches member declaration). Destructor: call registerDestroyingPool(pNDArrayPoolPvt_), then loop over pArrays[0..maxAddr_-1] and set pArrays[i]->pNDArrayPool = NULL, then delete pNDArrayPoolPvt_. |


[ADCore314_fix.md](https://github.com/user-attachments/files/25354999/ADCore314_fix.md)

### References

* areaDetector/ADTimePix3#5 – same issue and fix description (including diff-style notes).