### PR TITLE
Transform default trans type optional macro (DFLTTRANSTYPE)

### DIFF
--- a/ADApp/Db/NDTransform.template
+++ b/ADApp/Db/NDTransform.template
@@ -24,6 +24,6 @@ record(mbbo, "$(P)$(R)Type")
    field(SXVL, "6")
    field(SVST, "Rot270Mirror")
    field(SVVL, "7")
-   field(VAL, "$(DEFAULT_TYPE=0)")
+   field(VAL, "$(DFLTTRANSTYPE=0)")
    info(autosaveFields, "VAL")
 }

--- a/ADApp/Db/NDTransform.template
+++ b/ADApp/Db/NDTransform.template
@@ -24,5 +24,6 @@ record(mbbo, "$(P)$(R)Type")
    field(SXVL, "6")
    field(SVST, "Rot270Mirror")
    field(SVVL, "7")
+   field(VAL, "$(DEFAULT_TYPE=0)")
    info(autosaveFields, "VAL")
 }

--- a/docs/ADCore/NDPluginTransform.rst
+++ b/docs/ADCore/NDPluginTransform.rst
@@ -21,7 +21,7 @@ describes this class in detail.
 ``NDPluginTransform.h`` defines the following parameters. It also implements
 all of the standard plugin parameters from
 :doc:`NDPluginDriver`. The EPICS database
-``NDransform.template`` provide access to these parameters, listed in the
+``NDTransform.template`` provides access to these parameters, listed in the
 following table.
 
 .. |br| raw:: html
@@ -46,7 +46,7 @@ following table.
   * - NDPluginTransformType
     - asynInt32
     - r/w
-    - Type of transform. Choices are:|br|
+    - Type of transform.  Choices are:|br|
       **None**: No transform, the output image is the same as the input image. |br|
       **Rot90**: Rotate clockwise 90 degrees. |br|
       **Rot180**: Rotate clockwise 180 degrees. |br|
@@ -58,6 +58,7 @@ following table.
       the central row in the image. |br|
       **Rot270Mirror**: Rot270 followed by Mirror. Equivalent to image transpose followed
       by mirror reflection about the central column in the image. |br|
+      In the template there is an optional macro DFLTTRANSTYPE defaulting to 0 for None for backward compatibility.  |br|
     - TRANSFORM_TYPE
     - $(P)$(R)Type
     - mbbo


### PR DESCRIPTION
Addition of macro so that a transform type can be initialised to a default as part of the definition of the template.  Macro is made optional with default of 0 for "None", so it is backward compatible for existing IOC substitution files which dont specify the new macro.

This is part of working on containerising existing diagnostic camera IOCs at DLS to replicate what they already have.  Diagnostic cameras are often mounted on their side or upside down because of where their screws are, so one specific transform is always required for them for human viewing.