### PR TITLE
Add support for lz4hdf5 codec

### DIFF
--- a/ADApp/ADSrc/Codec.h
+++ b/ADApp/ADSrc/Codec.h
@@ -6,6 +6,7 @@ static std::string codecName[] = {
     "jpeg",
     "blosc",
     "lz4",
+    "lz4hdf5",
     "bslz4"
 };
 
@@ -14,6 +15,7 @@ typedef enum {
   NDCODEC_JPEG,
   NDCODEC_BLOSC,
   NDCODEC_LZ4,
+  NDCODEC_LZ4HDF5,
   NDCODEC_BSLZ4
 } NDCodecCompressor_t;
 

--- a/ADApp/Db/NDCodec.template
+++ b/ADApp/Db/NDCodec.template
@@ -197,6 +197,23 @@ record(longin, "$(P)$(R)BloscNumThreads_RBV")
     field(SCAN, "I/O Intr")
 }
 
+record(longout, "$(P)$(R)LZ4HDF5BlockSize")
+{
+    field(PINI, "YES")
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))LZ4HDF5_BLOCKSIZE")
+    field(VAL,  "0")
+    field(DRVL, "0")
+    info(autosaveFields, "VAL")
+}
+
+record(longin, "$(P)$(R)LZ4HDF5BlockSize_RBV")
+{
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))LZ4HDF5_BLOCKSIZE")
+    field(SCAN, "I/O Intr")
+}
+
 record(mbbi, "$(P)$(R)CodecStatus")
 {
     field(DTYP, "asynInt32")

--- a/ADApp/Db/NDCodec.template
+++ b/ADApp/Db/NDCodec.template
@@ -42,8 +42,10 @@ record(mbbo, "$(P)$(R)Compressor")
     field(TWVL, "2")
     field(THST, "LZ4")
     field(THVL, "3")
-    field(FRST, "BSLZ4")
+    field(FRST, "LZ4HDF5")
     field(FRVL, "4")
+    field(FVST, "BSLZ4")
+    field(FVVL, "5")
     info(autosaveFields, "VAL")
 }
 
@@ -59,8 +61,10 @@ record(mbbi, "$(P)$(R)Compressor_RBV")
     field(TWVL, "2")
     field(THST, "LZ4")
     field(THVL, "3")
-    field(FRST, "BSLZ4")
+    field(FRST, "LZ4HDF5")
     field(FRVL, "4")
+    field(FVST, "BSLZ4")
+    field(FVVL, "5")
     field(SCAN, "I/O Intr")
 }
 

--- a/ADApp/Db/NDCodec_settings.req
+++ b/ADApp/Db/NDCodec_settings.req
@@ -5,4 +5,5 @@ $(P)$(R)BloscCompressor
 $(P)$(R)BloscCLevel
 $(P)$(R)BloscShuffle
 $(P)$(R)BloscNumThreads
+$(P)$(R)LZ4HDF5BlockSize
 file "NDPluginBase_settings.req", P=$(P), R=$(R)

--- a/ADApp/commonDriverMakefile
+++ b/ADApp/commonDriverMakefile
@@ -153,6 +153,7 @@ ifeq ($(WITH_BITSHUFFLE),YES)
       PROD_SYS_LIBS += bitshuffle
     endif
   endif
+  PROD_LIBS += lz4hdf5
 endif
 
 ifeq ($(WITH_BLOSC),YES)

--- a/ADApp/commonLibraryMakefile
+++ b/ADApp/commonLibraryMakefile
@@ -118,6 +118,7 @@ ifeq ($(WITH_BITSHUFFLE),YES)
       LIB_SYS_LIBS += bitshuffle
     endif
   endif
+  LIB_LIBS += lz4hdf5
 endif
 
 ifeq ($(WITH_BLOSC),YES)

--- a/ADApp/op/adl/NDCodec.adl
+++ b/ADApp/op/adl/NDCodec.adl
@@ -1,7 +1,7 @@
 
 file {
-	name="/home/epics/devel/areaDetector-3-3-2/ADCore/ADApp/op/adl/NDCodec.adl"
-	version=030109
+	name="/home/epics/devel/areaDetector-3-14/ADCore/ADApp/op/adl/NDCodec.adl"
+	version=030117
 }
 display {
 	object {
@@ -116,7 +116,7 @@ rectangle {
 		x=390
 		y=40
 		width=380
-		height=260
+		height=285
 	}
 	"basic attribute" {
 		clr=14
@@ -135,7 +135,7 @@ composite {
 }
 "text update" {
 	object {
-		x=676
+		x=675
 		y=51
 		width=90
 		height=18
@@ -151,7 +151,7 @@ composite {
 }
 "text update" {
 	object {
-		x=666
+		x=665
 		y=76
 		width=100
 		height=18
@@ -167,7 +167,7 @@ composite {
 }
 menu {
 	object {
-		x=581
+		x=580
 		y=51
 		width=90
 		height=18
@@ -180,7 +180,7 @@ menu {
 }
 menu {
 	object {
-		x=581
+		x=580
 		y=76
 		width=80
 		height=18
@@ -193,7 +193,7 @@ menu {
 }
 text {
 	object {
-		x=536
+		x=535
 		y=50
 		width=40
 		height=20
@@ -206,7 +206,7 @@ text {
 }
 text {
 	object {
-		x=476
+		x=475
 		y=75
 		width=100
 		height=20
@@ -219,7 +219,7 @@ text {
 }
 "text update" {
 	object {
-		x=666
+		x=665
 		y=126
 		width=100
 		height=18
@@ -234,7 +234,7 @@ text {
 }
 "text entry" {
 	object {
-		x=581
+		x=580
 		y=125
 		width=80
 		height=20
@@ -249,7 +249,7 @@ text {
 }
 text {
 	object {
-		x=456
+		x=455
 		y=125
 		width=120
 		height=20
@@ -262,7 +262,7 @@ text {
 }
 "text update" {
 	object {
-		x=666
+		x=665
 		y=151
 		width=100
 		height=18
@@ -278,7 +278,7 @@ text {
 }
 "text update" {
 	object {
-		x=666
+		x=665
 		y=176
 		width=100
 		height=18
@@ -293,7 +293,7 @@ text {
 }
 "text update" {
 	object {
-		x=666
+		x=665
 		y=201
 		width=100
 		height=18
@@ -307,24 +307,9 @@ text {
 	limits {
 	}
 }
-"text update" {
-	object {
-		x=666
-		y=226
-		width=100
-		height=18
-	}
-	monitor {
-		chan="$(P)$(R)BloscNumThreads_RBV"
-		clr=54
-		bclr=4
-	}
-	limits {
-	}
-}
 menu {
 	object {
-		x=581
+		x=580
 		y=151
 		width=80
 		height=18
@@ -337,7 +322,7 @@ menu {
 }
 "text entry" {
 	object {
-		x=581
+		x=580
 		y=175
 		width=80
 		height=20
@@ -352,7 +337,7 @@ menu {
 }
 menu {
 	object {
-		x=581
+		x=580
 		y=201
 		width=80
 		height=18
@@ -363,24 +348,9 @@ menu {
 		bclr=51
 	}
 }
-"text entry" {
-	object {
-		x=581
-		y=225
-		width=80
-		height=20
-	}
-	control {
-		chan="$(P)$(R)BloscNumThreads"
-		clr=14
-		bclr=51
-	}
-	limits {
-	}
-}
 text {
 	object {
-		x=416
+		x=415
 		y=150
 		width=160
 		height=20
@@ -393,7 +363,7 @@ text {
 }
 text {
 	object {
-		x=406
+		x=405
 		y=175
 		width=170
 		height=20
@@ -406,7 +376,7 @@ text {
 }
 text {
 	object {
-		x=446
+		x=445
 		y=200
 		width=130
 		height=20
@@ -419,20 +389,7 @@ text {
 }
 text {
 	object {
-		x=406
-		y=225
-		width=170
-		height=20
-	}
-	"basic attribute" {
-		clr=14
-	}
-	textix="Blosc Num Threads"
-	align="horiz. right"
-}
-text {
-	object {
-		x=396
+		x=395
 		y=100
 		width=180
 		height=20
@@ -445,7 +402,7 @@ text {
 }
 "text update" {
 	object {
-		x=581
+		x=580
 		y=101
 		width=80
 		height=18
@@ -460,8 +417,8 @@ text {
 }
 text {
 	object {
-		x=456
-		y=250
+		x=455
+		y=275
 		width=120
 		height=20
 	}
@@ -473,8 +430,8 @@ text {
 }
 "text update" {
 	object {
-		x=581
-		y=251
+		x=580
+		y=276
 		width=80
 		height=18
 	}
@@ -491,8 +448,8 @@ text {
 }
 text {
 	object {
-		x=396
-		y=275
+		x=395
+		y=300
 		width=110
 		height=20
 	}
@@ -504,8 +461,8 @@ text {
 }
 "text update" {
 	object {
-		x=511
-		y=278
+		x=510
+		y=303
 		width=255
 		height=14
 	}
@@ -517,4 +474,90 @@ text {
 	format="string"
 	limits {
 	}
+}
+"text update" {
+	object {
+		x=665
+		y=226
+		width=100
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)BloscNumThreads_RBV"
+		clr=54
+		bclr=4
+	}
+	limits {
+	}
+}
+"text entry" {
+	object {
+		x=580
+		y=225
+		width=80
+		height=20
+	}
+	control {
+		chan="$(P)$(R)BloscNumThreads"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+text {
+	object {
+		x=405
+		y=225
+		width=170
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Blosc Num Threads"
+	align="horiz. right"
+}
+"text update" {
+	object {
+		x=664
+		y=251
+		width=100
+		height=18
+	}
+	monitor {
+		chan="$(P)$(R)LZ4HDF5BlockSize_RBV"
+		clr=54
+		bclr=4
+	}
+	limits {
+	}
+}
+"text entry" {
+	object {
+		x=579
+		y=250
+		width=80
+		height=20
+	}
+	control {
+		chan="$(P)$(R)LZ4HDF5BlockSize"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+text {
+	object {
+		x=394
+		y=250
+		width=180
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="LZ4HDF5 Block Size"
+	align="horiz. right"
 }

--- a/ADApp/op/bob/autoconvert/NDCodec.bob
+++ b/ADApp/op/bob/autoconvert/NDCodec.bob
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--Saved on 2024-03-25 15:22:23 by epics-->
+<!--Saved on 2026-04-07 18:02:36 by epics-->
 <display version="2.0.0">
   <name>NDCodec</name>
   <x>330</x>
@@ -46,7 +46,7 @@
     <x>390</x>
     <y>40</y>
     <width>380</width>
-    <height>260</height>
+    <height>285</height>
     <line_width>1</line_width>
     <line_color>
       <color red="0" green="0" blue="0">
@@ -69,7 +69,7 @@
   <widget type="textupdate" version="2.0.0">
     <name>text update #17</name>
     <pv_name>$(P)$(R)Mode_RBV</pv_name>
-    <x>676</x>
+    <x>675</x>
     <y>51</y>
     <width>90</width>
     <height>18</height>
@@ -92,7 +92,7 @@
   <widget type="textupdate" version="2.0.0">
     <name>text update #21</name>
     <pv_name>$(P)$(R)Compressor_RBV</pv_name>
-    <x>666</x>
+    <x>665</x>
     <y>76</y>
     <height>18</height>
     <font>
@@ -114,7 +114,7 @@
   <widget type="combo" version="2.0.0">
     <name>menu #25</name>
     <pv_name>$(P)$(R)Mode</pv_name>
-    <x>581</x>
+    <x>580</x>
     <y>51</y>
     <width>90</width>
     <height>18</height>
@@ -127,7 +127,7 @@
   <widget type="combo" version="2.0.0">
     <name>menu #28</name>
     <pv_name>$(P)$(R)Compressor</pv_name>
-    <x>581</x>
+    <x>580</x>
     <y>76</y>
     <width>80</width>
     <height>18</height>
@@ -140,7 +140,7 @@
   <widget type="label" version="2.0.0">
     <name>text #31</name>
     <text>Mode</text>
-    <x>536</x>
+    <x>535</x>
     <y>50</y>
     <width>40</width>
     <font>
@@ -152,7 +152,7 @@
   <widget type="label" version="2.0.0">
     <name>text #34</name>
     <text>Compressor</text>
-    <x>476</x>
+    <x>475</x>
     <y>75</y>
     <font>
       <font family="Liberation Sans" style="REGULAR" size="16.0">
@@ -163,7 +163,7 @@
   <widget type="textupdate" version="2.0.0">
     <name>text update #37</name>
     <pv_name>$(P)$(R)JPEGQuality_RBV</pv_name>
-    <x>666</x>
+    <x>665</x>
     <y>126</y>
     <height>18</height>
     <font>
@@ -185,7 +185,7 @@
   <widget type="textentry" version="3.0.0">
     <name>text entry #41</name>
     <pv_name>$(P)$(R)JPEGQuality</pv_name>
-    <x>581</x>
+    <x>580</x>
     <y>125</y>
     <width>80</width>
     <font>
@@ -203,7 +203,7 @@
   <widget type="label" version="2.0.0">
     <name>text #45</name>
     <text>JPEG Quality</text>
-    <x>456</x>
+    <x>455</x>
     <y>125</y>
     <width>120</width>
     <font>
@@ -215,7 +215,7 @@
   <widget type="textupdate" version="2.0.0">
     <name>text update #48</name>
     <pv_name>$(P)$(R)BloscCompressor_RBV</pv_name>
-    <x>666</x>
+    <x>665</x>
     <y>151</y>
     <height>18</height>
     <font>
@@ -237,7 +237,7 @@
   <widget type="textupdate" version="2.0.0">
     <name>text update #52</name>
     <pv_name>$(P)$(R)BloscCLevel_RBV</pv_name>
-    <x>666</x>
+    <x>665</x>
     <y>176</y>
     <height>18</height>
     <font>
@@ -259,7 +259,7 @@
   <widget type="textupdate" version="2.0.0">
     <name>text update #56</name>
     <pv_name>$(P)$(R)BloscShuffle_RBV</pv_name>
-    <x>666</x>
+    <x>665</x>
     <y>201</y>
     <height>18</height>
     <font>
@@ -278,32 +278,10 @@
     <show_units>false</show_units>
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
-  <widget type="textupdate" version="2.0.0">
-    <name>text update #60</name>
-    <pv_name>$(P)$(R)BloscNumThreads_RBV</pv_name>
-    <x>666</x>
-    <y>226</y>
-    <height>18</height>
-    <font>
-      <font family="Liberation Sans" style="REGULAR" size="16.0">
-      </font>
-    </font>
-    <foreground_color>
-      <color red="10" green="0" blue="184">
-      </color>
-    </foreground_color>
-    <background_color>
-      <color red="187" green="187" blue="187">
-      </color>
-    </background_color>
-    <format>1</format>
-    <show_units>false</show_units>
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-  </widget>
   <widget type="combo" version="2.0.0">
-    <name>menu #64</name>
+    <name>menu #60</name>
     <pv_name>$(P)$(R)BloscCompressor</pv_name>
-    <x>581</x>
+    <x>580</x>
     <y>151</y>
     <width>80</width>
     <height>18</height>
@@ -314,9 +292,9 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="textentry" version="3.0.0">
-    <name>text entry #67</name>
+    <name>text entry #63</name>
     <pv_name>$(P)$(R)BloscCLevel</pv_name>
-    <x>581</x>
+    <x>580</x>
     <y>175</y>
     <width>80</width>
     <font>
@@ -332,9 +310,9 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="combo" version="2.0.0">
-    <name>menu #71</name>
+    <name>menu #67</name>
     <pv_name>$(P)$(R)BloscShuffle</pv_name>
-    <x>581</x>
+    <x>580</x>
     <y>201</y>
     <width>80</width>
     <height>18</height>
@@ -344,28 +322,10 @@
     </background_color>
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
-  <widget type="textentry" version="3.0.0">
-    <name>text entry #74</name>
-    <pv_name>$(P)$(R)BloscNumThreads</pv_name>
-    <x>581</x>
-    <y>225</y>
-    <width>80</width>
-    <font>
-      <font family="Liberation Sans" style="REGULAR" size="16.0">
-      </font>
-    </font>
-    <background_color>
-      <color red="115" green="223" blue="255">
-      </color>
-    </background_color>
-    <format>1</format>
-    <show_units>false</show_units>
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-  </widget>
   <widget type="label" version="2.0.0">
-    <name>text #78</name>
+    <name>text #70</name>
     <text>Blosc Compressor</text>
-    <x>416</x>
+    <x>415</x>
     <y>150</y>
     <width>160</width>
     <font>
@@ -375,9 +335,9 @@
     <horizontal_alignment>2</horizontal_alignment>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #81</name>
+    <name>text #73</name>
     <text>Blosc Comp. Level</text>
-    <x>406</x>
+    <x>405</x>
     <y>175</y>
     <width>170</width>
     <font>
@@ -387,9 +347,9 @@
     <horizontal_alignment>2</horizontal_alignment>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #84</name>
+    <name>text #76</name>
     <text>Blosc Shuffle</text>
-    <x>446</x>
+    <x>445</x>
     <y>200</y>
     <width>130</width>
     <font>
@@ -399,21 +359,9 @@
     <horizontal_alignment>2</horizontal_alignment>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #87</name>
-    <text>Blosc Num Threads</text>
-    <x>406</x>
-    <y>225</y>
-    <width>170</width>
-    <font>
-      <font family="Liberation Sans" style="REGULAR" size="16.0">
-      </font>
-    </font>
-    <horizontal_alignment>2</horizontal_alignment>
-  </widget>
-  <widget type="label" version="2.0.0">
-    <name>text #90</name>
+    <name>text #79</name>
     <text>Compression Factor</text>
-    <x>396</x>
+    <x>395</x>
     <y>100</y>
     <width>180</width>
     <font>
@@ -423,9 +371,9 @@
     <horizontal_alignment>2</horizontal_alignment>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #93</name>
+    <name>text update #82</name>
     <pv_name>$(P)$(R)CompFactor_RBV</pv_name>
-    <x>581</x>
+    <x>580</x>
     <y>101</y>
     <width>80</width>
     <height>18</height>
@@ -446,10 +394,10 @@
     <border_alarm_sensitive>false</border_alarm_sensitive>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #97</name>
+    <name>text #86</name>
     <text>Codec Status</text>
-    <x>456</x>
-    <y>250</y>
+    <x>455</x>
+    <y>275</y>
     <width>120</width>
     <font>
       <font family="Liberation Sans" style="REGULAR" size="16.0">
@@ -458,10 +406,10 @@
     <horizontal_alignment>2</horizontal_alignment>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #100</name>
+    <name>text update #89</name>
     <pv_name>$(P)$(R)CodecStatus</pv_name>
-    <x>581</x>
-    <y>251</y>
+    <x>580</x>
+    <y>276</y>
     <width>80</width>
     <height>18</height>
     <font>
@@ -481,10 +429,10 @@
     <horizontal_alignment>1</horizontal_alignment>
   </widget>
   <widget type="label" version="2.0.0">
-    <name>text #104</name>
+    <name>text #93</name>
     <text>Codec Error</text>
-    <x>396</x>
-    <y>275</y>
+    <x>395</x>
+    <y>300</y>
     <width>110</width>
     <font>
       <font family="Liberation Sans" style="REGULAR" size="16.0">
@@ -493,10 +441,10 @@
     <horizontal_alignment>2</horizontal_alignment>
   </widget>
   <widget type="textupdate" version="2.0.0">
-    <name>text update #107</name>
+    <name>text update #96</name>
     <pv_name>$(P)$(R)CodecError</pv_name>
-    <x>511</x>
-    <y>278</y>
+    <x>510</x>
+    <y>303</y>
     <width>255</width>
     <height>14</height>
     <foreground_color>
@@ -510,5 +458,109 @@
     <format>6</format>
     <show_units>false</show_units>
     <border_alarm_sensitive>false</border_alarm_sensitive>
+  </widget>
+  <widget type="textupdate" version="2.0.0">
+    <name>text update #100</name>
+    <pv_name>$(P)$(R)BloscNumThreads_RBV</pv_name>
+    <x>665</x>
+    <y>226</y>
+    <height>18</height>
+    <font>
+      <font family="Liberation Sans" style="REGULAR" size="16.0">
+      </font>
+    </font>
+    <foreground_color>
+      <color red="10" green="0" blue="184">
+      </color>
+    </foreground_color>
+    <background_color>
+      <color red="187" green="187" blue="187">
+      </color>
+    </background_color>
+    <format>1</format>
+    <show_units>false</show_units>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+  </widget>
+  <widget type="textentry" version="3.0.0">
+    <name>text entry #104</name>
+    <pv_name>$(P)$(R)BloscNumThreads</pv_name>
+    <x>580</x>
+    <y>225</y>
+    <width>80</width>
+    <font>
+      <font family="Liberation Sans" style="REGULAR" size="16.0">
+      </font>
+    </font>
+    <background_color>
+      <color red="115" green="223" blue="255">
+      </color>
+    </background_color>
+    <format>1</format>
+    <show_units>false</show_units>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>text #108</name>
+    <text>Blosc Num Threads</text>
+    <x>405</x>
+    <y>225</y>
+    <width>170</width>
+    <font>
+      <font family="Liberation Sans" style="REGULAR" size="16.0">
+      </font>
+    </font>
+    <horizontal_alignment>2</horizontal_alignment>
+  </widget>
+  <widget type="textupdate" version="2.0.0">
+    <name>text update #111</name>
+    <pv_name>$(P)$(R)LZ4HDF5BlockSize_RBV</pv_name>
+    <x>664</x>
+    <y>251</y>
+    <height>18</height>
+    <font>
+      <font family="Liberation Sans" style="REGULAR" size="16.0">
+      </font>
+    </font>
+    <foreground_color>
+      <color red="10" green="0" blue="184">
+      </color>
+    </foreground_color>
+    <background_color>
+      <color red="187" green="187" blue="187">
+      </color>
+    </background_color>
+    <format>1</format>
+    <show_units>false</show_units>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+  </widget>
+  <widget type="textentry" version="3.0.0">
+    <name>text entry #115</name>
+    <pv_name>$(P)$(R)LZ4HDF5BlockSize</pv_name>
+    <x>579</x>
+    <y>250</y>
+    <width>80</width>
+    <font>
+      <font family="Liberation Sans" style="REGULAR" size="16.0">
+      </font>
+    </font>
+    <background_color>
+      <color red="115" green="223" blue="255">
+      </color>
+    </background_color>
+    <format>1</format>
+    <show_units>false</show_units>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>text #119</name>
+    <text>LZ4HDF5 Block Size</text>
+    <x>394</x>
+    <y>250</y>
+    <width>180</width>
+    <font>
+      <font family="Liberation Sans" style="REGULAR" size="16.0">
+      </font>
+    </font>
+    <horizontal_alignment>2</horizontal_alignment>
   </widget>
 </display>

--- a/ADApp/op/edl/autoconvert/NDCodec.edl
+++ b/ADApp/op/edl/autoconvert/NDCodec.edl
@@ -69,7 +69,7 @@ release 0
 x 390
 y 40
 w 380
-h 260
+h 285
 lineColor rgb 0 0 0
 fillColor rgb 0 0 0
 lineWidth 0
@@ -105,7 +105,7 @@ beginObjectProperties
 major 4
 minor 7
 release 0
-x 676
+x 675
 y 51
 w 90
 h 18
@@ -129,7 +129,7 @@ beginObjectProperties
 major 4
 minor 7
 release 0
-x 666
+x 665
 y 76
 w 100
 h 18
@@ -153,7 +153,7 @@ beginObjectProperties
 major 4
 minor 1
 release 1
-x 525
+x 524
 y 50
 w 51
 h 20
@@ -173,7 +173,7 @@ beginObjectProperties
 major 4
 minor 1
 release 1
-x 476
+x 475
 y 75
 w 100
 h 20
@@ -193,7 +193,7 @@ beginObjectProperties
 major 4
 minor 7
 release 0
-x 666
+x 665
 y 126
 w 100
 h 18
@@ -217,7 +217,7 @@ beginObjectProperties
 major 4
 minor 7
 release 0
-x 581
+x 580
 y 125
 w 80
 h 20
@@ -243,7 +243,7 @@ beginObjectProperties
 major 4
 minor 1
 release 1
-x 456
+x 455
 y 125
 w 120
 h 20
@@ -263,7 +263,7 @@ beginObjectProperties
 major 4
 minor 7
 release 0
-x 666
+x 665
 y 151
 w 100
 h 18
@@ -287,7 +287,7 @@ beginObjectProperties
 major 4
 minor 7
 release 0
-x 666
+x 665
 y 176
 w 100
 h 18
@@ -311,7 +311,7 @@ beginObjectProperties
 major 4
 minor 7
 release 0
-x 666
+x 665
 y 201
 w 100
 h 18
@@ -329,13 +329,232 @@ newPos
 objType "controls"
 endObjectProperties
 
+# (Text Control)
+object activeXTextDspClass
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 580
+y 175
+w 80
+h 20
+controlPv "$(P)$(R)BloscCLevel"
+format "decimal"
+font "helvetica-medium-r-12.0"
+fontAlign "left"
+fgColor rgb 0 0 0
+bgColor rgb 29440 57088 65280
+editable
+motifWidget
+limitsFromDb
+nullColor rgb 60928 46592 11008
+smartRefresh
+fastUpdate
+newPos
+objType "controls"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 415
+y 150
+w 160
+h 20
+font "helvetica-medium-r-14.0"
+fontAlign "right"
+fgColor rgb 0 0 0
+bgColor index 3
+useDisplayBg
+value {
+  "Blosc Compressor"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 405
+y 175
+w 170
+h 20
+font "helvetica-medium-r-14.0"
+fontAlign "right"
+fgColor rgb 0 0 0
+bgColor index 3
+useDisplayBg
+value {
+  "Blosc Comp. Level"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 445
+y 200
+w 130
+h 20
+font "helvetica-medium-r-14.0"
+fontAlign "right"
+fgColor rgb 0 0 0
+bgColor index 3
+useDisplayBg
+value {
+  "Blosc Shuffle"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 395
+y 100
+w 180
+h 20
+font "helvetica-medium-r-14.0"
+fontAlign "right"
+fgColor rgb 0 0 0
+bgColor index 3
+useDisplayBg
+value {
+  "Compression Factor"
+}
+endObjectProperties
+
 # (Text Monitor)
 object activeXTextDspClass:noedit
 beginObjectProperties
 major 4
 minor 7
 release 0
-x 666
+x 580
+y 101
+w 80
+h 18
+controlPv "$(P)$(R)CompFactor_RBV"
+format "decimal"
+font "helvetica-medium-r-14.0"
+fontAlign "left"
+fgColor rgb 2560 0 47104
+bgColor rgb 47872 47872 47872
+limitsFromDb
+nullColor rgb 60928 46592 11008
+smartRefresh
+fastUpdate
+newPos
+objType "controls"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 455
+y 275
+w 120
+h 20
+font "helvetica-medium-r-14.0"
+fontAlign "right"
+fgColor rgb 0 0 0
+bgColor index 3
+useDisplayBg
+value {
+  "Codec Status"
+}
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 580
+y 276
+w 80
+h 18
+controlPv "$(P)$(R)CodecStatus"
+format "string"
+font "helvetica-medium-r-14.0"
+fontAlign "center"
+fgColor rgb 0 65535 0
+fgAlarm
+bgColor rgb 17920 17920 17920
+limitsFromDb
+nullColor rgb 60928 46592 11008
+smartRefresh
+fastUpdate
+newPos
+objType "controls"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 395
+y 300
+w 110
+h 20
+font "helvetica-medium-r-14.0"
+fontAlign "right"
+fgColor rgb 0 0 0
+bgColor index 3
+useDisplayBg
+value {
+  "Codec Error"
+}
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 510
+y 303
+w 255
+h 14
+controlPv "$(P)$(R)CodecError"
+format "string"
+font "helvetica-medium-r-12.0"
+fontAlign "left"
+fgColor rgb 2560 0 47104
+bgColor rgb 47872 47872 47872
+limitsFromDb
+nullColor rgb 60928 46592 11008
+smartRefresh
+fastUpdate
+newPos
+objType "controls"
+endObjectProperties
+
+# (Text Monitor)
+object activeXTextDspClass:noedit
+beginObjectProperties
+major 4
+minor 7
+release 0
+x 665
 y 226
 w 100
 h 18
@@ -359,33 +578,7 @@ beginObjectProperties
 major 4
 minor 7
 release 0
-x 581
-y 175
-w 80
-h 20
-controlPv "$(P)$(R)BloscCLevel"
-format "decimal"
-font "helvetica-medium-r-12.0"
-fontAlign "left"
-fgColor rgb 0 0 0
-bgColor rgb 29440 57088 65280
-editable
-motifWidget
-limitsFromDb
-nullColor rgb 60928 46592 11008
-smartRefresh
-fastUpdate
-newPos
-objType "controls"
-endObjectProperties
-
-# (Text Control)
-object activeXTextDspClass
-beginObjectProperties
-major 4
-minor 7
-release 0
-x 581
+x 580
 y 225
 w 80
 h 20
@@ -411,67 +604,7 @@ beginObjectProperties
 major 4
 minor 1
 release 1
-x 416
-y 150
-w 160
-h 20
-font "helvetica-medium-r-14.0"
-fontAlign "right"
-fgColor rgb 0 0 0
-bgColor index 3
-useDisplayBg
-value {
-  "Blosc Compressor"
-}
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 406
-y 175
-w 170
-h 20
-font "helvetica-medium-r-14.0"
-fontAlign "right"
-fgColor rgb 0 0 0
-bgColor index 3
-useDisplayBg
-value {
-  "Blosc Comp. Level"
-}
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 446
-y 200
-w 130
-h 20
-font "helvetica-medium-r-14.0"
-fontAlign "right"
-fgColor rgb 0 0 0
-bgColor index 3
-useDisplayBg
-value {
-  "Blosc Shuffle"
-}
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 406
+x 405
 y 225
 w 170
 h 20
@@ -485,37 +618,17 @@ value {
 }
 endObjectProperties
 
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 396
-y 100
-w 180
-h 20
-font "helvetica-medium-r-14.0"
-fontAlign "right"
-fgColor rgb 0 0 0
-bgColor index 3
-useDisplayBg
-value {
-  "Compression Factor"
-}
-endObjectProperties
-
 # (Text Monitor)
 object activeXTextDspClass:noedit
 beginObjectProperties
 major 4
 minor 7
 release 0
-x 581
-y 101
-w 80
+x 664
+y 251
+w 100
 h 18
-controlPv "$(P)$(R)CompFactor_RBV"
+controlPv "$(P)$(R)LZ4HDF5BlockSize_RBV"
 format "decimal"
 font "helvetica-medium-r-14.0"
 fontAlign "left"
@@ -529,93 +642,50 @@ newPos
 objType "controls"
 endObjectProperties
 
-# (Static Text)
-object activeXTextClass
+# (Text Control)
+object activeXTextDspClass
 beginObjectProperties
 major 4
-minor 1
-release 1
-x 456
+minor 7
+release 0
+x 579
 y 250
-w 120
-h 20
-font "helvetica-medium-r-14.0"
-fontAlign "right"
-fgColor rgb 0 0 0
-bgColor index 3
-useDisplayBg
-value {
-  "Codec Status"
-}
-endObjectProperties
-
-# (Text Monitor)
-object activeXTextDspClass:noedit
-beginObjectProperties
-major 4
-minor 7
-release 0
-x 581
-y 251
 w 80
-h 18
-controlPv "$(P)$(R)CodecStatus"
-format "string"
-font "helvetica-medium-r-14.0"
-fontAlign "center"
-fgColor rgb 0 65535 0
-fgAlarm
-bgColor rgb 17920 17920 17920
-limitsFromDb
-nullColor rgb 60928 46592 11008
-smartRefresh
-fastUpdate
-newPos
-objType "controls"
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 396
-y 275
-w 110
 h 20
-font "helvetica-medium-r-14.0"
-fontAlign "right"
-fgColor rgb 0 0 0
-bgColor index 3
-useDisplayBg
-value {
-  "Codec Error"
-}
-endObjectProperties
-
-# (Text Monitor)
-object activeXTextDspClass:noedit
-beginObjectProperties
-major 4
-minor 7
-release 0
-x 511
-y 278
-w 255
-h 14
-controlPv "$(P)$(R)CodecError"
-format "string"
+controlPv "$(P)$(R)LZ4HDF5BlockSize"
+format "decimal"
 font "helvetica-medium-r-12.0"
 fontAlign "left"
-fgColor rgb 2560 0 47104
-bgColor rgb 47872 47872 47872
+fgColor rgb 0 0 0
+bgColor rgb 29440 57088 65280
+editable
+motifWidget
 limitsFromDb
 nullColor rgb 60928 46592 11008
 smartRefresh
 fastUpdate
 newPos
 objType "controls"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 394
+y 250
+w 180
+h 20
+font "helvetica-medium-r-14.0"
+fontAlign "right"
+fgColor rgb 0 0 0
+bgColor index 3
+useDisplayBg
+value {
+  "LZ4HDF5 Block Size"
+}
 endObjectProperties
 
 # (Menu Button)
@@ -624,7 +694,7 @@ beginObjectProperties
 major 4
 minor 0
 release 0
-x 581
+x 580
 y 51
 w 90
 h 18
@@ -644,7 +714,7 @@ beginObjectProperties
 major 4
 minor 0
 release 0
-x 581
+x 580
 y 76
 w 80
 h 18
@@ -664,7 +734,7 @@ beginObjectProperties
 major 4
 minor 0
 release 0
-x 581
+x 580
 y 151
 w 80
 h 18
@@ -684,7 +754,7 @@ beginObjectProperties
 major 4
 minor 0
 release 0
-x 581
+x 580
 y 201
 w 80
 h 18

--- a/ADApp/op/opi/autoconvert/NDCodec.opi
+++ b/ADApp/op/opi/autoconvert/NDCodec.opi
@@ -118,7 +118,7 @@ $(pv_value)</tooltip>
       <color red="0" green="0" blue="0" />
     </foreground_color>
     <gradient>false</gradient>
-    <height>260</height>
+    <height>285</height>
     <horizontal_fill>true</horizontal_fill>
     <line_color>
       <color red="0" green="0" blue="0" />
@@ -271,7 +271,7 @@ $(pv_value)</tooltip>
     <widget_type>Text Update</widget_type>
     <width>90</width>
     <wrap_words>false</wrap_words>
-    <x>676</x>
+    <x>675</x>
     <y>51</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
@@ -322,7 +322,7 @@ $(pv_value)</tooltip>
     <widget_type>Text Update</widget_type>
     <width>100</width>
     <wrap_words>false</wrap_words>
-    <x>666</x>
+    <x>665</x>
     <y>76</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.MenuButton" version="1.0.0">
@@ -366,7 +366,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <widget_type>Menu Button</widget_type>
     <width>90</width>
-    <x>581</x>
+    <x>580</x>
     <y>51</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.MenuButton" version="1.0.0">
@@ -410,7 +410,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <widget_type>Menu Button</widget_type>
     <width>80</width>
-    <x>581</x>
+    <x>580</x>
     <y>76</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
@@ -450,7 +450,7 @@ $(pv_value)</tooltip>
     <widget_type>Label</widget_type>
     <width>40</width>
     <wrap_words>false</wrap_words>
-    <x>536</x>
+    <x>535</x>
     <y>50</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
@@ -490,7 +490,7 @@ $(pv_value)</tooltip>
     <widget_type>Label</widget_type>
     <width>100</width>
     <wrap_words>false</wrap_words>
-    <x>476</x>
+    <x>475</x>
     <y>75</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
@@ -541,7 +541,7 @@ $(pv_value)</tooltip>
     <widget_type>Text Update</widget_type>
     <width>100</width>
     <wrap_words>false</wrap_words>
-    <x>666</x>
+    <x>665</x>
     <y>126</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.TextInput" version="2.0.0">
@@ -603,7 +603,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <widget_type>Text Input</widget_type>
     <width>80</width>
-    <x>581</x>
+    <x>580</x>
     <y>125</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
@@ -643,7 +643,7 @@ $(pv_value)</tooltip>
     <widget_type>Label</widget_type>
     <width>120</width>
     <wrap_words>false</wrap_words>
-    <x>456</x>
+    <x>455</x>
     <y>125</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
@@ -694,7 +694,7 @@ $(pv_value)</tooltip>
     <widget_type>Text Update</widget_type>
     <width>100</width>
     <wrap_words>false</wrap_words>
-    <x>666</x>
+    <x>665</x>
     <y>151</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
@@ -745,7 +745,7 @@ $(pv_value)</tooltip>
     <widget_type>Text Update</widget_type>
     <width>100</width>
     <wrap_words>false</wrap_words>
-    <x>666</x>
+    <x>665</x>
     <y>176</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
@@ -796,59 +796,8 @@ $(pv_value)</tooltip>
     <widget_type>Text Update</widget_type>
     <width>100</width>
     <wrap_words>false</wrap_words>
-    <x>666</x>
+    <x>665</x>
     <y>201</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <alarm_pulsing>false</alarm_pulsing>
-    <auto_size>false</auto_size>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="187" green="187" blue="187" />
-    </background_color>
-    <border_alarm_sensitive>true</border_alarm_sensitive>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
-    </font>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <foreground_color>
-      <color red="10" green="0" blue="184" />
-    </foreground_color>
-    <format_type>1</format_type>
-    <height>18</height>
-    <horizontal_alignment>0</horizontal_alignment>
-    <name>Text Update</name>
-    <precision>0</precision>
-    <precision_from_pv>true</precision_from_pv>
-    <pv_name>$(P)$(R)BloscNumThreads_RBV</pv_name>
-    <pv_value />
-    <rotation_angle>0.0</rotation_angle>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_units>false</show_units>
-    <text>######</text>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <transparent>false</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Text Update</widget_type>
-    <width>100</width>
-    <wrap_words>false</wrap_words>
-    <x>666</x>
-    <y>226</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.MenuButton" version="1.0.0">
     <actions hook="false" hook_all="false" />
@@ -891,7 +840,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <widget_type>Menu Button</widget_type>
     <width>80</width>
-    <x>581</x>
+    <x>580</x>
     <y>151</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.TextInput" version="2.0.0">
@@ -953,7 +902,7 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <widget_type>Text Input</widget_type>
     <width>80</width>
-    <x>581</x>
+    <x>580</x>
     <y>175</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.MenuButton" version="1.0.0">
@@ -997,8 +946,452 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <widget_type>Menu Button</widget_type>
     <width>80</width>
-    <x>581</x>
+    <x>580</x>
     <y>201</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color red="255" green="255" blue="255" />
+    </background_color>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
+    </font>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <horizontal_alignment>2</horizontal_alignment>
+    <name>Label</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_scrollbar>false</show_scrollbar>
+    <text>Blosc Compressor</text>
+    <tooltip></tooltip>
+    <transparent>true</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>160</width>
+    <wrap_words>false</wrap_words>
+    <x>415</x>
+    <y>150</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color red="255" green="255" blue="255" />
+    </background_color>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
+    </font>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <horizontal_alignment>2</horizontal_alignment>
+    <name>Label</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_scrollbar>false</show_scrollbar>
+    <text>Blosc Comp. Level</text>
+    <tooltip></tooltip>
+    <transparent>true</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>170</width>
+    <wrap_words>false</wrap_words>
+    <x>405</x>
+    <y>175</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color red="255" green="255" blue="255" />
+    </background_color>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
+    </font>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <horizontal_alignment>2</horizontal_alignment>
+    <name>Label</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_scrollbar>false</show_scrollbar>
+    <text>Blosc Shuffle</text>
+    <tooltip></tooltip>
+    <transparent>true</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>130</width>
+    <wrap_words>false</wrap_words>
+    <x>445</x>
+    <y>200</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color red="255" green="255" blue="255" />
+    </background_color>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
+    </font>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <horizontal_alignment>2</horizontal_alignment>
+    <name>Label</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_scrollbar>false</show_scrollbar>
+    <text>Compression Factor</text>
+    <tooltip></tooltip>
+    <transparent>true</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>180</width>
+    <wrap_words>false</wrap_words>
+    <x>395</x>
+    <y>100</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color red="187" green="187" blue="187" />
+    </background_color>
+    <border_alarm_sensitive>true</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color red="10" green="0" blue="184" />
+    </foreground_color>
+    <format_type>1</format_type>
+    <height>18</height>
+    <horizontal_alignment>0</horizontal_alignment>
+    <name>Text Update</name>
+    <precision>0</precision>
+    <precision_from_pv>true</precision_from_pv>
+    <pv_name>$(P)$(R)CompFactor_RBV</pv_name>
+    <pv_value />
+    <rotation_angle>0.0</rotation_angle>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_units>false</show_units>
+    <text>######</text>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Text Update</widget_type>
+    <width>80</width>
+    <wrap_words>false</wrap_words>
+    <x>580</x>
+    <y>101</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color red="255" green="255" blue="255" />
+    </background_color>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
+    </font>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <horizontal_alignment>2</horizontal_alignment>
+    <name>Label</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_scrollbar>false</show_scrollbar>
+    <text>Codec Status</text>
+    <tooltip></tooltip>
+    <transparent>true</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>120</width>
+    <wrap_words>false</wrap_words>
+    <x>455</x>
+    <y>275</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color red="70" green="70" blue="70" />
+    </background_color>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
+    </font>
+    <forecolor_alarm_sensitive>true</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color name="OK" red="0" green="255" blue="0" />
+    </foreground_color>
+    <format_type>4</format_type>
+    <height>18</height>
+    <horizontal_alignment>1</horizontal_alignment>
+    <name>Text Update</name>
+    <precision>0</precision>
+    <precision_from_pv>true</precision_from_pv>
+    <pv_name>$(P)$(R)CodecStatus</pv_name>
+    <pv_value />
+    <rotation_angle>0.0</rotation_angle>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_units>false</show_units>
+    <text>######</text>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Text Update</widget_type>
+    <width>80</width>
+    <wrap_words>false</wrap_words>
+    <x>580</x>
+    <y>276</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color red="255" green="255" blue="255" />
+    </background_color>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
+    </font>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <horizontal_alignment>2</horizontal_alignment>
+    <name>Label</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_scrollbar>false</show_scrollbar>
+    <text>Codec Error</text>
+    <tooltip></tooltip>
+    <transparent>true</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>110</width>
+    <wrap_words>false</wrap_words>
+    <x>395</x>
+    <y>300</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color red="187" green="187" blue="187" />
+    </background_color>
+    <border_alarm_sensitive>true</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="8" style="0" pixels="false" />
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color red="10" green="0" blue="184" />
+    </foreground_color>
+    <format_type>4</format_type>
+    <height>14</height>
+    <horizontal_alignment>0</horizontal_alignment>
+    <name>Text Update</name>
+    <precision>0</precision>
+    <precision_from_pv>true</precision_from_pv>
+    <pv_name>$(P)$(R)CodecError</pv_name>
+    <pv_value />
+    <rotation_angle>0.0</rotation_angle>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_units>false</show_units>
+    <text>######</text>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Text Update</widget_type>
+    <width>255</width>
+    <wrap_words>false</wrap_words>
+    <x>510</x>
+    <y>303</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color red="187" green="187" blue="187" />
+    </background_color>
+    <border_alarm_sensitive>true</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color red="10" green="0" blue="184" />
+    </foreground_color>
+    <format_type>1</format_type>
+    <height>18</height>
+    <horizontal_alignment>0</horizontal_alignment>
+    <name>Text Update</name>
+    <precision>0</precision>
+    <precision_from_pv>true</precision_from_pv>
+    <pv_name>$(P)$(R)BloscNumThreads_RBV</pv_name>
+    <pv_value />
+    <rotation_angle>0.0</rotation_angle>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_units>false</show_units>
+    <text>######</text>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Text Update</widget_type>
+    <width>100</width>
+    <wrap_words>false</wrap_words>
+    <x>665</x>
+    <y>226</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.TextInput" version="2.0.0">
     <actions hook="false" hook_all="false" />
@@ -1059,128 +1452,8 @@ $(pv_value)</tooltip>
     <visible>true</visible>
     <widget_type>Text Input</widget_type>
     <width>80</width>
-    <x>581</x>
+    <x>580</x>
     <y>225</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <auto_size>false</auto_size>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
-    </font>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <height>20</height>
-    <horizontal_alignment>2</horizontal_alignment>
-    <name>Label</name>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_scrollbar>false</show_scrollbar>
-    <text>Blosc Compressor</text>
-    <tooltip></tooltip>
-    <transparent>true</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Label</widget_type>
-    <width>160</width>
-    <wrap_words>false</wrap_words>
-    <x>416</x>
-    <y>150</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <auto_size>false</auto_size>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
-    </font>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <height>20</height>
-    <horizontal_alignment>2</horizontal_alignment>
-    <name>Label</name>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_scrollbar>false</show_scrollbar>
-    <text>Blosc Comp. Level</text>
-    <tooltip></tooltip>
-    <transparent>true</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Label</widget_type>
-    <width>170</width>
-    <wrap_words>false</wrap_words>
-    <x>406</x>
-    <y>175</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <auto_size>false</auto_size>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
-    </font>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <height>20</height>
-    <horizontal_alignment>2</horizontal_alignment>
-    <name>Label</name>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_scrollbar>false</show_scrollbar>
-    <text>Blosc Shuffle</text>
-    <tooltip></tooltip>
-    <transparent>true</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Label</widget_type>
-    <width>130</width>
-    <wrap_words>false</wrap_words>
-    <x>446</x>
-    <y>200</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <actions hook="false" hook_all="false" />
@@ -1219,48 +1492,8 @@ $(pv_value)</tooltip>
     <widget_type>Label</widget_type>
     <width>170</width>
     <wrap_words>false</wrap_words>
-    <x>406</x>
+    <x>405</x>
     <y>225</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <auto_size>false</auto_size>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
-    </font>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <height>20</height>
-    <horizontal_alignment>2</horizontal_alignment>
-    <name>Label</name>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_scrollbar>false</show_scrollbar>
-    <text>Compression Factor</text>
-    <tooltip></tooltip>
-    <transparent>true</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Label</widget_type>
-    <width>180</width>
-    <wrap_words>false</wrap_words>
-    <x>396</x>
-    <y>100</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
     <actions hook="false" hook_all="false" />
@@ -1290,7 +1523,7 @@ $(pv_value)</tooltip>
     <name>Text Update</name>
     <precision>0</precision>
     <precision_from_pv>true</precision_from_pv>
-    <pv_name>$(P)$(R)CompFactor_RBV</pv_name>
+    <pv_name>$(P)$(R)LZ4HDF5BlockSize_RBV</pv_name>
     <pv_value />
     <rotation_angle>0.0</rotation_angle>
     <rules />
@@ -1308,81 +1541,49 @@ $(pv_value)</tooltip>
     <vertical_alignment>1</vertical_alignment>
     <visible>true</visible>
     <widget_type>Text Update</widget_type>
-    <width>80</width>
+    <width>100</width>
     <wrap_words>false</wrap_words>
-    <x>581</x>
-    <y>101</y>
+    <x>664</x>
+    <y>251</y>
   </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <auto_size>false</auto_size>
-    <background_color>
-      <color red="255" green="255" blue="255" />
-    </background_color>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="11" style="0" pixels="false" />
-    </font>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
-    <height>20</height>
-    <horizontal_alignment>2</horizontal_alignment>
-    <name>Label</name>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_scrollbar>false</show_scrollbar>
-    <text>Codec Status</text>
-    <tooltip></tooltip>
-    <transparent>true</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Label</widget_type>
-    <width>120</width>
-    <wrap_words>false</wrap_words>
-    <x>456</x>
-    <y>250</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+  <widget typeId="org.csstudio.opibuilder.widgets.TextInput" version="2.0.0">
     <actions hook="false" hook_all="false" />
     <alarm_pulsing>false</alarm_pulsing>
     <auto_size>false</auto_size>
     <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
     <background_color>
-      <color red="70" green="70" blue="70" />
+      <color red="115" green="223" blue="255" />
     </background_color>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <border_color>
       <color red="0" green="128" blue="255" />
     </border_color>
-    <border_style>0</border_style>
+    <border_style>3</border_style>
     <border_width>1</border_width>
+    <confirm_message></confirm_message>
     <enabled>true</enabled>
     <font>
       <fontdata fontName="Sans" height="11" style="0" pixels="false" />
     </font>
-    <forecolor_alarm_sensitive>true</forecolor_alarm_sensitive>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
-      <color name="OK" red="0" green="255" blue="0" />
+      <color red="0" green="0" blue="0" />
     </foreground_color>
-    <format_type>4</format_type>
-    <height>18</height>
-    <horizontal_alignment>1</horizontal_alignment>
-    <name>Text Update</name>
+    <format_type>1</format_type>
+    <height>20</height>
+    <horizontal_alignment>0</horizontal_alignment>
+    <limits_from_pv>false</limits_from_pv>
+    <maximum>Infinity</maximum>
+    <minimum>-Infinity</minimum>
+    <multiline_input>false</multiline_input>
+    <name>Text Input</name>
+    <next_focus>0</next_focus>
+    <password_input>false</password_input>
     <precision>0</precision>
     <precision_from_pv>true</precision_from_pv>
-    <pv_name>$(P)$(R)CodecStatus</pv_name>
+    <pv_name>$(P)$(R)LZ4HDF5BlockSize</pv_name>
     <pv_value />
+    <read_only>false</read_only>
     <rotation_angle>0.0</rotation_angle>
     <rules />
     <scale_options>
@@ -1391,18 +1592,21 @@ $(pv_value)</tooltip>
       <keep_wh_ratio>false</keep_wh_ratio>
     </scale_options>
     <scripts />
+    <selector_type>0</selector_type>
+    <show_h_scroll>false</show_h_scroll>
+    <show_native_border>true</show_native_border>
     <show_units>false</show_units>
-    <text>######</text>
+    <show_v_scroll>false</show_v_scroll>
+    <style>0</style>
+    <text></text>
     <tooltip>$(pv_name)
 $(pv_value)</tooltip>
     <transparent>false</transparent>
-    <vertical_alignment>1</vertical_alignment>
     <visible>true</visible>
-    <widget_type>Text Update</widget_type>
+    <widget_type>Text Input</widget_type>
     <width>80</width>
-    <wrap_words>false</wrap_words>
-    <x>581</x>
-    <y>251</y>
+    <x>579</x>
+    <y>250</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <actions hook="false" hook_all="false" />
@@ -1433,66 +1637,15 @@ $(pv_value)</tooltip>
     </scale_options>
     <scripts />
     <show_scrollbar>false</show_scrollbar>
-    <text>Codec Error</text>
+    <text>LZ4HDF5 Block Size</text>
     <tooltip></tooltip>
     <transparent>true</transparent>
     <vertical_alignment>1</vertical_alignment>
     <visible>true</visible>
     <widget_type>Label</widget_type>
-    <width>110</width>
+    <width>180</width>
     <wrap_words>false</wrap_words>
-    <x>396</x>
-    <y>275</y>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <alarm_pulsing>false</alarm_pulsing>
-    <auto_size>false</auto_size>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="187" green="187" blue="187" />
-    </background_color>
-    <border_alarm_sensitive>true</border_alarm_sensitive>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <fontdata fontName="Sans" height="8" style="0" pixels="false" />
-    </font>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <foreground_color>
-      <color red="10" green="0" blue="184" />
-    </foreground_color>
-    <format_type>4</format_type>
-    <height>14</height>
-    <horizontal_alignment>0</horizontal_alignment>
-    <name>Text Update</name>
-    <precision>0</precision>
-    <precision_from_pv>true</precision_from_pv>
-    <pv_name>$(P)$(R)CodecError</pv_name>
-    <pv_value />
-    <rotation_angle>0.0</rotation_angle>
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_units>false</show_units>
-    <text>######</text>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <transparent>false</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
-    <widget_type>Text Update</widget_type>
-    <width>255</width>
-    <wrap_words>false</wrap_words>
-    <x>511</x>
-    <y>278</y>
+    <x>394</x>
+    <y>250</y>
   </widget>
 </display>

--- a/ADApp/pluginSrc/NDFileHDF5.cpp
+++ b/ADApp/pluginSrc/NDFileHDF5.cpp
@@ -40,6 +40,7 @@ enum HDF5Compression_t {HDF5CompressNone=0,
                         HDF5CompressBlosc,
                         HDF5CompressBshuf,
                         HDF5CompressLZ4,
+                        HDF5CompressLZ4HDF5,
                         HDF5CompressJPEG};
 /* Filter ID officially assigned to blosc */
 #define FILTER_BLOSC 32001
@@ -1940,6 +1941,7 @@ asynStatus NDFileHDF5::writeInt32(asynUser *pasynUser, epicsInt32 value)
         filterId = FILTER_BSHUF;
         break;
       case HDF5CompressLZ4:
+      case HDF5CompressLZ4HDF5:
         filterId = FILTER_LZ4;
         break;
       case HDF5CompressJPEG:
@@ -3325,6 +3327,8 @@ asynStatus NDFileHDF5::configureCompression(NDArray *pArray)
       setIntegerParam(NDFileHDF5_compressionType, HDF5CompressBshuf);
     } else if (pArray->codec.name == codecName[NDCODEC_LZ4]) {
       setIntegerParam(NDFileHDF5_compressionType, HDF5CompressLZ4);
+    } else if (pArray->codec.name == codecName[NDCODEC_LZ4HDF5]) {
+      setIntegerParam(NDFileHDF5_compressionType, HDF5CompressLZ4HDF5);
     } else if (pArray->codec.name == codecName[NDCODEC_JPEG]) {
       setIntegerParam(NDFileHDF5_compressionType, HDF5CompressJPEG);
     }
@@ -3411,7 +3415,8 @@ asynStatus NDFileHDF5::configureCompression(NDArray *pArray)
         this->codec.name = codecName[NDCODEC_BSLZ4];
       }
       break;
-    case HDF5CompressLZ4: {
+    case HDF5CompressLZ4:
+    case HDF5CompressLZ4HDF5: {
         unsigned int cds[2];
         cds[0] = 0; /* lz4 selects the block size automatically */
         cds[1] = 0; /* Number of threads (not implemented) */
@@ -3420,7 +3425,11 @@ asynStatus NDFileHDF5::configureCompression(NDArray *pArray)
           asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR, "Failed to set h5 lz4 filter\n");
           break;
         }
-        this->codec.name = codecName[NDCODEC_LZ4];
+        if (compressionScheme == HDF5CompressLZ4) {
+          this->codec.name = codecName[NDCODEC_LZ4];
+        } else {
+          this->codec.name = codecName[NDCODEC_LZ4HDF5];
+        }
       }
       break;
     case HDF5CompressJPEG: {

--- a/ADApp/pluginSrc/NDPluginCodec.cpp
+++ b/ADApp/pluginSrc/NDPluginCodec.cpp
@@ -460,6 +460,7 @@ NDArray *decompressBlosc(NDArray *input, int numThreads, NDCodecStatus_t *status
 #ifdef HAVE_BITSHUFFLE
 #include <bitshuffle.h>
 #include <lz4.h>
+#include <lz4hdf5.h>
 
 NDArray *compressLZ4(NDArray *input, NDCodecStatus_t *status, char *errorMessage)
 {
@@ -517,11 +518,81 @@ NDArray *decompressLZ4(NDArray *input, NDCodecStatus_t *status, char *errorMessa
         return NULL;
     }
 
-    int ret = LZ4_decompress_fast((const char*)input->pData, (char*)output->pData, (int)info.totalBytes);
+    int ret = LZ4_decompress_safe((const char*)input->pData, (char*)output->pData, (int)input->compressedSize, (int)info.totalBytes);
 
     if (ret <= 0){
         output->release();
         sprintf(errorMessage, "Failed to LZ4 decompress");
+        *status = NDCODEC_ERROR;
+        return NULL;
+    }
+
+    output->codec.clear();
+
+    return output;
+}
+
+NDArray *compressLZ4HDF5(NDArray *input, NDCodecStatus_t *status, char *errorMessage)
+{
+    if (!input->codec.empty()) {
+        sprintf(errorMessage, "Array is already compressed");
+        *status = NDCODEC_WARNING;
+        return NULL;
+    }
+
+    NDArrayInfo_t info;
+    input->getInfo(&info);
+    int outputSize = LZ4_compressBound((int)info.totalBytes);
+    NDArray *output = allocArray(input, -1, outputSize);
+
+    if (!output) {
+        sprintf(errorMessage, "Failed to allocate LZ4HDF5 output array");
+        *status = NDCODEC_ERROR;
+        return NULL;
+    }
+
+    int compSize = compress_lz4hdf5((const char*)input->pData, (char*)output->pData, info.totalBytes, outputSize);
+
+    if (compSize <= 0) {
+        output->release();
+        sprintf(errorMessage, "Internal LZ4HDF5 error");
+        *status = NDCODEC_ERROR;
+        return NULL;
+    }
+
+    output->codec.name = codecName[NDCODEC_LZ4HDF5];
+    output->compressedSize = compSize;
+
+    return output;
+}
+
+
+NDArray *decompressLZ4HDF5(NDArray *input, NDCodecStatus_t *status, char *errorMessage)
+{
+    // Sanity check
+    if (input->codec.name != codecName[NDCODEC_LZ4HDF5]) {
+        sprintf(errorMessage, "Invalid codec '%s', expected '%s'",
+                input->codec.name.c_str(), codecName[NDCODEC_LZ4HDF5].c_str());
+        *status = NDCODEC_ERROR;
+        return NULL;
+    }
+
+    NDArrayInfo_t info;
+    input->getInfo(&info);
+
+    NDArray *output = allocArray(input);
+
+    if (!output) {
+        sprintf(errorMessage, "Failed to allocate LZ4HDF5 output array");
+        *status = NDCODEC_ERROR;
+        return NULL;
+    }
+
+    int ret = decompress_lz4hdf5((const char*)input->pData, (char*)output->pData, info.totalBytes);
+
+    if (ret <= 0){
+        output->release();
+        sprintf(errorMessage, "Failed to LZ4HDF5 decompress");
         *status = NDCODEC_ERROR;
         return NULL;
     }
@@ -714,6 +785,13 @@ void NDPluginCodec::processCallbacks(NDArray *pArray)
             break;
         }
 
+        case NDCODEC_LZ4HDF5: {
+            unlock();
+            result = compressLZ4HDF5(pArray, &codecStatus, errorMessage);
+            lock();
+            break;
+        }
+
         case NDCODEC_BSLZ4: {
             unlock();
             result = compressBSLZ4(pArray, &codecStatus, errorMessage);
@@ -750,6 +828,11 @@ void NDPluginCodec::processCallbacks(NDArray *pArray)
             result = decompressLZ4(pArray, &codecStatus, errorMessage);
             lock();
             setIntegerParam(NDCodecCompressor, NDCODEC_LZ4);
+        } else if (pArray->codec.name == codecName[NDCODEC_LZ4HDF5]) {
+            unlock();
+            result = decompressLZ4HDF5(pArray, &codecStatus, errorMessage);
+            lock();
+            setIntegerParam(NDCodecCompressor, NDCODEC_LZ4HDF5);
         } else if (pArray->codec.name == codecName[NDCODEC_BSLZ4]) {
             unlock();
             result = decompressBSLZ4(pArray, &codecStatus, errorMessage);

--- a/ADApp/pluginSrc/NDPluginCodec.cpp
+++ b/ADApp/pluginSrc/NDPluginCodec.cpp
@@ -53,8 +53,6 @@
 #define JPEG_MIN_QUALITY 1
 #define JPEG_MAX_QUALITY 100
 
-#define LZ4HDF5_DEFAULT_BLOCK_SIZE 1<<30; /* 1GB. LZ4 needs blocks < 1.9GB. */
-
 using std::string;
 
 static const char *driverName="NDPluginCodec";
@@ -544,9 +542,9 @@ NDArray *compressLZ4HDF5(NDArray *input, size_t blockSize, NDCodecStatus_t *stat
 
     NDArrayInfo_t info;
     input->getInfo(&info);
-    size_t nBlocks = (info.totalBytes-1)/blockSize +1;
+    size_t nBlocks;
 
-    int outputSize = LZ4_compressBound((int)info.totalBytes) + 4 + 8 + nBlocks*4;
+    int outputSize = lz4hdf5_compressBound(info.totalBytes, &blockSize, &nBlocks);
 
     NDArray *output = allocArray(input, -1, outputSize);
 
@@ -795,7 +793,6 @@ void NDPluginCodec::processCallbacks(NDArray *pArray)
             int iTemp;
             getIntegerParam(NDCodecLZ4HDF5BlockSize, &iTemp);
             blockSize = iTemp;
-            if (blockSize == 0) blockSize = LZ4HDF5_DEFAULT_BLOCK_SIZE;
             unlock();
             result = compressLZ4HDF5(pArray, blockSize, &codecStatus, errorMessage);
             lock();

--- a/ADApp/pluginSrc/NDPluginCodec.cpp
+++ b/ADApp/pluginSrc/NDPluginCodec.cpp
@@ -518,7 +518,7 @@ NDArray *decompressLZ4(NDArray *input, NDCodecStatus_t *status, char *errorMessa
         return NULL;
     }
 
-    int ret = LZ4_decompress_safe((const char*)input->pData, (char*)output->pData, (int)input->compressedSize, (int)info.totalBytes);
+    int ret = LZ4_decompress_fast((const char*)input->pData, (char*)output->pData, (int)info.totalBytes);
 
     if (ret <= 0){
         output->release();

--- a/ADApp/pluginSrc/NDPluginCodec.cpp
+++ b/ADApp/pluginSrc/NDPluginCodec.cpp
@@ -697,6 +697,20 @@ NDArray *decompressLZ4(NDArray *input, NDCodecStatus_t *status, char *errorMessa
     return NULL;
 }
 
+NDArray *compressLZ4HDF5(NDArray *input, size_t blockSize, NDCodecStatus_t *status, char *errorMessage)
+{
+    sprintf(errorMessage, "No LZ4 support");
+    *status = NDCODEC_ERROR;
+    return NULL;
+}
+
+NDArray *decompressLZ4HDF5(NDArray *input, size_t *blockSize, NDCodecStatus_t *status, char *errorMessage)
+{
+    sprintf(errorMessage, "No LZ4 support");
+    *status = NDCODEC_ERROR;
+    return NULL;
+}
+
 NDArray *compressBSLZ4(NDArray *input, NDCodecStatus_t *status, char *errorMessage)
 {
     sprintf(errorMessage, "No Bitshuffle support");

--- a/ADApp/pluginSrc/NDPluginCodec.cpp
+++ b/ADApp/pluginSrc/NDPluginCodec.cpp
@@ -53,6 +53,8 @@
 #define JPEG_MIN_QUALITY 1
 #define JPEG_MAX_QUALITY 100
 
+#define LZ4HDF5_DEFAULT_BLOCK_SIZE 1<<30; /* 1GB. LZ4 needs blocks < 1.9GB. */
+
 using std::string;
 
 static const char *driverName="NDPluginCodec";
@@ -532,7 +534,7 @@ NDArray *decompressLZ4(NDArray *input, NDCodecStatus_t *status, char *errorMessa
     return output;
 }
 
-NDArray *compressLZ4HDF5(NDArray *input, NDCodecStatus_t *status, char *errorMessage)
+NDArray *compressLZ4HDF5(NDArray *input, size_t blockSize, NDCodecStatus_t *status, char *errorMessage)
 {
     if (!input->codec.empty()) {
         sprintf(errorMessage, "Array is already compressed");
@@ -542,7 +544,10 @@ NDArray *compressLZ4HDF5(NDArray *input, NDCodecStatus_t *status, char *errorMes
 
     NDArrayInfo_t info;
     input->getInfo(&info);
-    int outputSize = LZ4_compressBound((int)info.totalBytes);
+    size_t nBlocks = (info.totalBytes-1)/blockSize +1;
+
+    int outputSize = LZ4_compressBound((int)info.totalBytes) + 4 + 8 + nBlocks*4;
+
     NDArray *output = allocArray(input, -1, outputSize);
 
     if (!output) {
@@ -551,7 +556,7 @@ NDArray *compressLZ4HDF5(NDArray *input, NDCodecStatus_t *status, char *errorMes
         return NULL;
     }
 
-    int compSize = compress_lz4hdf5((const char*)input->pData, (char*)output->pData, info.totalBytes, outputSize);
+    int compSize = compress_lz4hdf5((const char*)input->pData, (char*)output->pData, info.totalBytes, outputSize, blockSize);
 
     if (compSize <= 0) {
         output->release();
@@ -567,7 +572,7 @@ NDArray *compressLZ4HDF5(NDArray *input, NDCodecStatus_t *status, char *errorMes
 }
 
 
-NDArray *decompressLZ4HDF5(NDArray *input, NDCodecStatus_t *status, char *errorMessage)
+NDArray *decompressLZ4HDF5(NDArray *input, size_t *blockSize, NDCodecStatus_t *status, char *errorMessage)
 {
     // Sanity check
     if (input->codec.name != codecName[NDCODEC_LZ4HDF5]) {
@@ -588,7 +593,7 @@ NDArray *decompressLZ4HDF5(NDArray *input, NDCodecStatus_t *status, char *errorM
         return NULL;
     }
 
-    int ret = decompress_lz4hdf5((const char*)input->pData, (char*)output->pData, info.totalBytes);
+    int ret = decompress_lz4hdf5((const char*)input->pData, (char*)output->pData, info.totalBytes, blockSize);
 
     if (ret <= 0){
         output->release();
@@ -786,8 +791,13 @@ void NDPluginCodec::processCallbacks(NDArray *pArray)
         }
 
         case NDCODEC_LZ4HDF5: {
+            size_t blockSize;
+            int iTemp;
+            getIntegerParam(NDCodecLZ4HDF5BlockSize, &iTemp);
+            blockSize = iTemp;
+            if (blockSize == 0) blockSize = LZ4HDF5_DEFAULT_BLOCK_SIZE;
             unlock();
-            result = compressLZ4HDF5(pArray, &codecStatus, errorMessage);
+            result = compressLZ4HDF5(pArray, blockSize, &codecStatus, errorMessage);
             lock();
             break;
         }
@@ -829,9 +839,11 @@ void NDPluginCodec::processCallbacks(NDArray *pArray)
             lock();
             setIntegerParam(NDCodecCompressor, NDCODEC_LZ4);
         } else if (pArray->codec.name == codecName[NDCODEC_LZ4HDF5]) {
+            size_t blockSize;
             unlock();
-            result = decompressLZ4HDF5(pArray, &codecStatus, errorMessage);
+            result = decompressLZ4HDF5(pArray, &blockSize, &codecStatus, errorMessage);
             lock();
+            setIntegerParam(NDCodecLZ4HDF5BlockSize, (int) blockSize);
             setIntegerParam(NDCodecCompressor, NDCODEC_LZ4HDF5);
         } else if (pArray->codec.name == codecName[NDCODEC_BSLZ4]) {
             unlock();
@@ -954,28 +966,30 @@ NDPluginCodec::NDPluginCodec(const char *portName, int queueSize, int blockingCa
 {
     //static const char *functionName = "NDPluginCodec";
 
-    createParam(NDCodecModeString,            asynParamInt32,   &NDCodecMode);
-    createParam(NDCodecCompressorString,      asynParamInt32,   &NDCodecCompressor);
-    createParam(NDCodecCompFactorString,      asynParamFloat64, &NDCodecCompFactor);
-    createParam(NDCodecCodecStatusString,     asynParamInt32,   &NDCodecCodecStatus);
-    createParam(NDCodecCodecErrorString,      asynParamOctet,   &NDCodecCodecError);
-    createParam(NDCodecJPEGQualityString,     asynParamInt32,   &NDCodecJPEGQuality);
-    createParam(NDCodecBloscCompressorString, asynParamInt32,   &NDCodecBloscCompressor);
-    createParam(NDCodecBloscCLevelString,     asynParamInt32,   &NDCodecBloscCLevel);
-    createParam(NDCodecBloscShuffleString,    asynParamInt32,   &NDCodecBloscShuffle);
-    createParam(NDCodecBloscNumThreadsString, asynParamInt32,   &NDCodecBloscNumThreads);
+    createParam(NDCodecModeString,             asynParamInt32,   &NDCodecMode);
+    createParam(NDCodecCompressorString,       asynParamInt32,   &NDCodecCompressor);
+    createParam(NDCodecCompFactorString,       asynParamFloat64, &NDCodecCompFactor);
+    createParam(NDCodecCodecStatusString,      asynParamInt32,   &NDCodecCodecStatus);
+    createParam(NDCodecCodecErrorString,       asynParamOctet,   &NDCodecCodecError);
+    createParam(NDCodecJPEGQualityString,      asynParamInt32,   &NDCodecJPEGQuality);
+    createParam(NDCodecBloscCompressorString,  asynParamInt32,   &NDCodecBloscCompressor);
+    createParam(NDCodecBloscCLevelString,      asynParamInt32,   &NDCodecBloscCLevel);
+    createParam(NDCodecBloscShuffleString,     asynParamInt32,   &NDCodecBloscShuffle);
+    createParam(NDCodecBloscNumThreadsString,  asynParamInt32,   &NDCodecBloscNumThreads);
+    createParam(NDCodecLZ4HDF5BlockSizeString, asynParamInt32,   &NDCodecLZ4HDF5BlockSize);
 
     /* Set the plugin type string */
     setStringParam(NDPluginDriverPluginType, "NDPluginCodec");
 
-    setIntegerParam(NDCodecCompressor,      NDCODEC_NONE);
-    setDoubleParam (NDCodecCompFactor,      1.0);
-    setIntegerParam(NDCodecCodecStatus,     NDCODEC_SUCCESS);
+    setIntegerParam(NDCodecCompressor,       NDCODEC_NONE);
+    setDoubleParam (NDCodecCompFactor,       1.0);
+    setIntegerParam(NDCodecCodecStatus,      NDCODEC_SUCCESS);
     setStringParam(NDCodecCodecError,        "");
-    setIntegerParam(NDCodecJPEGQuality,     85);
-    setIntegerParam(NDCodecBloscCompressor, NDCODEC_BLOSC_BLOSCLZ);
-    setIntegerParam(NDCodecBloscCLevel,     5);
-    setIntegerParam(NDCodecBloscNumThreads, 1);
+    setIntegerParam(NDCodecJPEGQuality,      85);
+    setIntegerParam(NDCodecBloscCompressor,  NDCODEC_BLOSC_BLOSCLZ);
+    setIntegerParam(NDCodecBloscCLevel,      5);
+    setIntegerParam(NDCodecBloscNumThreads,  1);
+    setIntegerParam(NDCodecLZ4HDF5BlockSize, 0);
 
     // Enable ArrayCallbacks.
     // This plugin currently ignores this setting and always does callbacks, so make the setting reflect the behavior

--- a/ADApp/pluginSrc/NDPluginCodec.h
+++ b/ADApp/pluginSrc/NDPluginCodec.h
@@ -33,6 +33,7 @@ typedef enum {
 typedef enum {
     NDCODEC_BLOSC_BLOSCLZ,
     NDCODEC_BLOSC_LZ4,
+    NDCODEC_BLOSC_LZ4HDF5,
     NDCODEC_BLOSC_LZ4HC,
     NDCODEC_BLOSC_SNAPPY,
     NDCODEC_BLOSC_ZLIB,
@@ -60,6 +61,8 @@ NDArray *compressBlosc(NDArray *input, int clevel, int shuffle, NDCodecBloscComp
 NDArray *decompressBlosc(NDArray *input, int numThreads, NDCodecStatus_t *status, char *errorMessage);
 NDArray *compressLZ4(NDArray *input, NDCodecStatus_t *status, char *errorMessage);
 NDArray *decompressLZ4(NDArray *input, NDCodecStatus_t *status, char *errorMessage);
+NDArray *compressLZ4HDF5(NDArray *input, NDCodecStatus_t *status, char *errorMessage);
+NDArray *decompressLZ4HDF5(NDArray *input, NDCodecStatus_t *status, char *errorMessage);
 NDArray *compressBSLZ4(NDArray *input, NDCodecStatus_t *status, char *errorMessage);
 NDArray *decompressBSLZ4(NDArray *input, NDCodecStatus_t *status, char *errorMessage);
 

--- a/ADApp/pluginSrc/NDPluginCodec.h
+++ b/ADApp/pluginSrc/NDPluginCodec.h
@@ -3,26 +3,21 @@
 
 #include "NDPluginDriver.h"
 
-#define NDCodecModeString             "MODE"             /* (NDCodecMode_t r/w) Mode: Compress/Decompress */
-#define NDCodecCompressorString       "COMPRESSOR"       /* (NDCodecCompressor_t r/w) Which codec to use */
-#define NDCodecCompFactorString       "COMP_FACTOR"      /* (double r/o) Compression percentage (0 = no compression) */
-#define NDCodecCodecStatusString      "CODEC_STATUS"     /* (int r/o) Compression status: success or failure */
-#define NDCodecCodecErrorString       "CODEC_ERROR"      /* (string r/o) Error message if compression fails */
-#define NDCodecJPEGQualityString      "JPEG_QUALITY"     /* (int r/w) JPEG Compression quality */
-#define NDCodecBloscCompressorString  "BLOSC_COMPRESSOR" /* (NDCodecBloscComp_t r/w) Which Blosc compressor to use */
-#define NDCodecBloscCLevelString      "BLOSC_CLEVEL"     /* (int r/w) Blosc compression level */
-#define NDCodecBloscShuffleString     "BLOSC_SHUFFLE"    /* (bool r/w) Should Blosc apply shuffling? */
-#define NDCodecBloscNumThreadsString  "BLOSC_NUMTHREADS" /* (int r/w) Number of threads to be used by Blosc */
+#define NDCodecModeString             "MODE"              /* (NDCodecMode_t r/w) Mode: Compress/Decompress */
+#define NDCodecCompressorString       "COMPRESSOR"        /* (NDCodecCompressor_t r/w) Which codec to use */
+#define NDCodecCompFactorString       "COMP_FACTOR"       /* (double r/o) Compression percentage (0 = no compression) */
+#define NDCodecCodecStatusString      "CODEC_STATUS"      /* (int r/o) Compression status: success or failure */
+#define NDCodecCodecErrorString       "CODEC_ERROR"       /* (string r/o) Error message if compression fails */
+#define NDCodecJPEGQualityString      "JPEG_QUALITY"      /* (int r/w) JPEG Compression quality */
+#define NDCodecBloscCompressorString  "BLOSC_COMPRESSOR"  /* (NDCodecBloscComp_t r/w) Which Blosc compressor to use */
+#define NDCodecBloscCLevelString      "BLOSC_CLEVEL"      /* (int r/w) Blosc compression level */
+#define NDCodecBloscShuffleString     "BLOSC_SHUFFLE"     /* (bool r/w) Should Blosc apply shuffling? */
+#define NDCodecBloscNumThreadsString  "BLOSC_NUMTHREADS"  /* (int r/w) Number of threads to be used by Blosc */
+#define NDCodecLZ4HDF5BlockSizeString "LZ4HDF5_BLOCKSIZE" /* (int r/w) Block size for lz4hdf5 compression */
 
 /** Compress/decompress NDArrays according to available codecs.
   * This plugin is a source of NDArray callbacks, passing the (possibly
   * compressed/decompressed) NDArray data to clients that register for callbacks.
-  * The plugin currently supports the following codecs (if available at compile
-  * time):
-  * <ul>
-  *  <li> JPEG</li>
-  *  <li> Blosc</li>
-  * </ul>
   */
 
 typedef enum {
@@ -61,8 +56,8 @@ NDArray *compressBlosc(NDArray *input, int clevel, int shuffle, NDCodecBloscComp
 NDArray *decompressBlosc(NDArray *input, int numThreads, NDCodecStatus_t *status, char *errorMessage);
 NDArray *compressLZ4(NDArray *input, NDCodecStatus_t *status, char *errorMessage);
 NDArray *decompressLZ4(NDArray *input, NDCodecStatus_t *status, char *errorMessage);
-NDArray *compressLZ4HDF5(NDArray *input, NDCodecStatus_t *status, char *errorMessage);
-NDArray *decompressLZ4HDF5(NDArray *input, NDCodecStatus_t *status, char *errorMessage);
+NDArray *compressLZ4HDF5(NDArray *input, size_t blockSize, NDCodecStatus_t *status, char *errorMessage);
+NDArray *decompressLZ4HDF5(NDArray *input, size_t *blockSize, NDCodecStatus_t *status, char *errorMessage);
 NDArray *compressBSLZ4(NDArray *input, NDCodecStatus_t *status, char *errorMessage);
 NDArray *decompressBSLZ4(NDArray *input, NDCodecStatus_t *status, char *errorMessage);
 
@@ -90,6 +85,7 @@ protected:
     int NDCodecBloscCLevel;
     int NDCodecBloscShuffle;
     int NDCodecBloscNumThreads;
+    int NDCodecLZ4HDF5BlockSize;
 
 };
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,14 +19,36 @@ the EXAMPLE_RELEASE_PATHS.local, EXAMPLE_RELEASE_LIBS.local, and EXAMPLE_RELEASE
 files respectively, in the configure/ directory of the appropriate release of the
 [top-level areaDetector](https://github.com/areaDetector/areaDetector) repository.
 
-## __R3-15 (July XXX 1, 2025)__
+## __R3-15 (April XXX, 2026)__
 
 ### Fixes for Github Actions
   * Fixed problem with TIRPC in asyn.
   * Updated from windows-2019 to windows-2022.
+  
+### New NDPluginPvxs plugin
+  * This is similar NDPluginPva except that it uses the external PVXS library
+    rather than the pvAccess library from EPICS base.
+    This support will be included if WITH_PVXS=YES.
+    Thanks to James Souter for this.
 
 ### NDPluginCodec
+  * Added support for the lz4hdf5 codec.  This does LZ4 compression in blocks.
+    It is the codec used for LZ4 compression on Dectris detectors with the Stream2 interface.
+    It is also the codec used for writing LZ4 compressed data to HDF5 files.
+    There are new records LZ4HDF5BlockSize and LZ4HDF5BlockSize_RBV for writing and
+    reading the blocksize for this codec.
+  * NOTE: The order of the enums in the Compressor mbbo record has changed so that
+    LZ4 and LZ4HDF5 are adjacent.
+    This breaks backwards compatibility for autosave files, and for scripts that use
+    the enum index rather than string for this record.
   * Fixed memory leaks in the JPEG compressor and decompressor. Thanks to Evan Daykin for this.
+
+### NDFileHDF
+  * Added support for direct chunk write for NDArrays compressed with the lz4hd5 codec.
+    
+### Database template files
+  * Fixed record names in NDROIStat.template to avoid record name duplication.
+  * Added optional default transform type macro (DFLTTRANSTYPE) in NDTransform.template.
 
 ### ADTop.adl
   * Added ADHamammatsuDCAM and BlackflyS PGE 23S6C.


### PR DESCRIPTION
This adds support for the lz4hdf5 codec to NDPluginCodec and NDFileHDF5.   The codec itself is in ADSupport. There are also changes to ADEiger to use this new codec for Stream2 LZ4 compression, and to ADViewers to display arrays with this codec in ImageJ.