### PR TITLE
Make QSRV aware of waveforms which are strings

### DIFF
--- a/ADApp/Db/ADBase.template
+++ b/ADApp/Db/ADBase.template
@@ -433,6 +433,7 @@ record(waveform, "$(P)$(R)StatusMessage_RBV")
     field(FTVL, "CHAR")
     field(NELM, "256")
     field(SCAN, "I/O Intr")
+    info(Q:form, "String")
 }
 
 record(waveform, "$(P)$(R)StringToServer_RBV")
@@ -442,6 +443,7 @@ record(waveform, "$(P)$(R)StringToServer_RBV")
     field(FTVL, "CHAR")
     field(NELM, "256")
     field(SCAN, "I/O Intr")
+    info(Q:form, "String")
 }
 
 record(waveform, "$(P)$(R)StringFromServer_RBV")
@@ -451,6 +453,7 @@ record(waveform, "$(P)$(R)StringFromServer_RBV")
     field(FTVL, "CHAR")
     field(NELM, "256")
     field(SCAN, "I/O Intr")
+    info(Q:form, "String")
 }
 
 ################################################################@###

--- a/ADApp/Db/ADPrefixes.template
+++ b/ADApp/Db/ADPrefixes.template
@@ -7,5 +7,6 @@ record(waveform, "$(P)$(R)ChannelPrefixes")
 {
    field(FTVL, "CHAR")
    field(NELM, "$(NELEMENTS)")
+   info(Q:form, "String")
 }
 

--- a/ADApp/Db/NDArrayBase.template
+++ b/ADApp/Db/NDArrayBase.template
@@ -782,6 +782,7 @@ record(waveform, "$(P)$(R)NDAttributesMacros")
     field(FTVL, "CHAR")
     field(NELM, "256")
     info(autosaveFields, "VAL")
+    info(Q:form, "String")
 }
 
 ###################################################################
@@ -796,6 +797,7 @@ record(waveform, "$(P)$(R)NDAttributesFile")
     field(FTVL, "CHAR")
     field(NELM, "$(XMLSIZE=256)")
     info(autosaveFields, "VAL")
+    info(Q:form, "String")
 }
 
 ###################################################################

--- a/ADApp/Db/NDAttributeN.template
+++ b/ADApp/Db/NDAttributeN.template
@@ -32,6 +32,7 @@ record(waveform, "$(P)$(R)AttrName")
     field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))ATTR_ATTRNAME")
     field(FTVL, "CHAR")
     field(NELM, "256")
+    info(Q:form, "String")
 }
 
 record(waveform, "$(P)$(R)AttrName_RBV")
@@ -41,6 +42,7 @@ record(waveform, "$(P)$(R)AttrName_RBV")
     field(FTVL, "CHAR")
     field(NELM, "256")
     field(SCAN, "I/O Intr")
+    info(Q:form, "String")
 }
 
 ###################################################################

--- a/ADApp/Db/NDBadPixel.template
+++ b/ADApp/Db/NDBadPixel.template
@@ -14,4 +14,5 @@ record(waveform, "$(P)$(R)FileName")
     field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))BAD_PIXEL_FILE_NAME")
     field(FTVL, "CHAR")
     field(NELM, "256")
+    info(Q:form, "String")
 }

--- a/ADApp/Db/NDCircularBuff.template
+++ b/ADApp/Db/NDCircularBuff.template
@@ -91,6 +91,7 @@ record(waveform, "$(P)$(R)TriggerCalc") {
   field(FTVL, "CHAR")
   field(NELM, "256")
   field(PINI, "1")
+  info(Q:form, "String")
 }
 
 # # Trigger calculation readback
@@ -100,6 +101,7 @@ record(waveform, "$(P)$(R)TriggerCalc_RBV") {
   field(FTVL, "CHAR")
   field(NELM, "256")
   field(SCAN, "I/O Intr")
+  info(Q:form, "String")
 }
 
 # # Trigger calculation value

--- a/ADApp/Db/NDCodec.template
+++ b/ADApp/Db/NDCodec.template
@@ -259,4 +259,5 @@ record(waveform, "$(P)$(R)CodecError")
     field(SCAN, "I/O Intr")
     field(FTVL, "CHAR")
     field(NELM, "256")
+    info(Q:form, "String")
 }

--- a/ADApp/Db/NDFile.template
+++ b/ADApp/Db/NDFile.template
@@ -17,6 +17,7 @@ record(waveform, "$(P)$(R)FilePath")
     field(FTVL, "CHAR")
     field(NELM, "256")
     info(autosaveFields, "VAL")
+    info(Q:form, "String")
 }
 
 record(waveform, "$(P)$(R)FilePath_RBV")
@@ -26,6 +27,7 @@ record(waveform, "$(P)$(R)FilePath_RBV")
     field(FTVL, "CHAR")
     field(NELM, "256")
     field(SCAN, "I/O Intr")
+    info(Q:form, "String")
 }
 
 record(bi, "$(P)$(R)FilePathExists_RBV")
@@ -65,6 +67,7 @@ record(waveform, "$(P)$(R)FileName")
     field(FTVL, "CHAR")
     field(NELM, "256")
     info(autosaveFields, "VAL")
+    info(Q:form, "String")
 }
 
 record(waveform, "$(P)$(R)FileName_RBV")
@@ -74,6 +77,7 @@ record(waveform, "$(P)$(R)FileName_RBV")
     field(FTVL, "CHAR")
     field(NELM, "256")
     field(SCAN, "I/O Intr")
+    info(Q:form, "String")
 }
 
 record(longout, "$(P)$(R)FileNumber")
@@ -123,6 +127,7 @@ record(waveform, "$(P)$(R)FileTemplate")
     field(FTVL, "CHAR")
     field(NELM, "256")
     info(autosaveFields, "VAL")
+    info(Q:form, "String")
 }
 
 record(waveform, "$(P)$(R)FileTemplate_RBV")
@@ -132,6 +137,7 @@ record(waveform, "$(P)$(R)FileTemplate_RBV")
     field(FTVL, "CHAR")
     field(NELM, "256")
     field(SCAN, "I/O Intr")
+    info(Q:form, "String")
 }
 
 # Full filename, including path
@@ -142,6 +148,7 @@ record(waveform, "$(P)$(R)FullFileName_RBV")
     field(FTVL, "CHAR")
     field(NELM, "512")
     field(SCAN, "I/O Intr")
+    info(Q:form, "String")
 }
 
 # Autosave flag
@@ -350,6 +357,7 @@ record(waveform, "$(P)$(R)WriteMessage")
     field(FTVL, "CHAR")
     field(NELM, "256")
     field(SCAN, "I/O Intr")
+    info(Q:form, "String")
 }
 
 record(bo, "$(P)$(R)LazyOpen")

--- a/ADApp/Db/NDFileHDF5.template
+++ b/ADApp/Db/NDFileHDF5.template
@@ -820,6 +820,7 @@ record(waveform, "$(P)$(R)XMLErrorMsg_RBV")
     field(FTVL, "CHAR")
     field(NELM, "256")
     field(SCAN, "I/O Intr")
+    info(Q:form, "String")
 }
 
 record(bi, "$(P)$(R)XMLValid_RBV")
@@ -843,6 +844,7 @@ record(waveform, "$(P)$(R)XMLFileName")
     field(FTVL, "CHAR")
     field(NELM, "$(XMLSIZE=2048)")
     info(autosaveFields, "VAL")
+    info(Q:form, "String")
 }
 
 record(waveform, "$(P)$(R)XMLFileName_RBV")
@@ -852,6 +854,7 @@ record(waveform, "$(P)$(R)XMLFileName_RBV")
     field(FTVL, "CHAR")
     field(NELM, "$(XMLSIZE=2048)")
     field(SCAN, "I/O Intr")
+    info(Q:form, "String")
 }
 
 record(bi, "$(P)$(R)SWMRSupported_RBV")

--- a/ADApp/Db/NDFileNexus.template
+++ b/ADApp/Db/NDFileNexus.template
@@ -34,6 +34,7 @@ record(waveform, "$(P)$(R)TemplateFilePath")
     field(FTVL, "CHAR")
     field(NELM, "256")
     info(autosaveFields, "VAL")
+    info(Q:form, "String")
 }
 
 record(waveform, "$(P)$(R)TemplateFilePath_RBV")
@@ -43,6 +44,7 @@ record(waveform, "$(P)$(R)TemplateFilePath_RBV")
     field(FTVL, "CHAR")
     field(NELM, "256")
     field(SCAN, "I/O Intr")
+    info(Q:form, "String")
 }
 
 # Template Filename
@@ -54,6 +56,7 @@ record(waveform, "$(P)$(R)TemplateFileName")
     field(FTVL, "CHAR")
     field(NELM, "256")
     info(autosaveFields, "VAL")
+    info(Q:form, "String")
 }
 
 record(waveform, "$(P)$(R)TemplateFileName_RBV")
@@ -63,6 +66,7 @@ record(waveform, "$(P)$(R)TemplateFileName_RBV")
     field(FTVL, "CHAR")
     field(NELM, "256")
     field(SCAN, "I/O Intr")
+    info(Q:form, "String")
 }
 
 record(bi, "$(P)$(R)FileTemplateValid")

--- a/ADApp/Db/NDOverlayN.template
+++ b/ADApp/Db/NDOverlayN.template
@@ -392,6 +392,7 @@ record(waveform, "$(P)$(R)DisplayText")
     field(FTVL, "CHAR")
     field(NELM, "256")
     info(autosaveFields, "VAL")
+    info(Q:form, "String")
 }
 
 record(waveform, "$(P)$(R)DisplayText_RBV")
@@ -401,6 +402,7 @@ record(waveform, "$(P)$(R)DisplayText_RBV")
     field(FTVL, "CHAR")
     field(NELM, "256")
     field(SCAN, "I/O Intr")
+    info(Q:form, "String")
 }
 
 record(stringout, "$(P)$(R)TimeStampFormat")

--- a/ADApp/Db/NDPosPlugin.template
+++ b/ADApp/Db/NDPosPlugin.template
@@ -17,6 +17,7 @@ record(waveform, "$(P)$(R)Filename")
     field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))NDPos_Filename")
     field(FTVL, "CHAR")
     field(NELM, "1000000")
+    info(Q:form, "String")
 }
 
 record(waveform, "$(P)$(R)Filename_RBV")
@@ -26,6 +27,7 @@ record(waveform, "$(P)$(R)Filename_RBV")
     field(FTVL, "CHAR")
     field(NELM, "1000000")
     field(SCAN, "I/O Intr")
+    info(Q:form, "String")
 }
 
 record(bi, "$(P)$(R)FileValid_RBV")

--- a/ADApp/Db/NDPva.template
+++ b/ADApp/Db/NDPva.template
@@ -15,4 +15,5 @@ record(waveform, "$(P)$(R)PvName_RBV")
     field(FTVL, "CHAR")
     field(NELM, "256")
     field(SCAN, "I/O Intr")
+    info(Q:form, "String")
 }


### PR DESCRIPTION
This is necessary so these records are served as NTScalar with string value, instead of NTScalarArray with char[] value. This also simplifies clients, since they won't have to convert char[] into strings themselves.