### PR TITLE
Fix naming of header and variable in NDPluginAttribute tests

### DIFF
--- a/ADApp/pluginSrc/NDPluginCodec.h
+++ b/ADApp/pluginSrc/NDPluginCodec.h
@@ -40,21 +40,21 @@ typedef enum {
  * thread-safe.
  */
 
-NDArray *compressJPEG(NDArray *input, int quality, NDCodecStatus_t *status, char *errorMessage);
-NDArray *decompressJPEG(NDArray *input, NDCodecStatus_t *status, char *errorMessage);
+NDPLUGIN_API NDArray *compressJPEG(NDArray *input, int quality, NDCodecStatus_t *status, char *errorMessage);
+NDPLUGIN_API NDArray *decompressJPEG(NDArray *input, NDCodecStatus_t *status, char *errorMessage);
 
-NDArray *compressZlib(NDArray *input, int clevel, NDCodecStatus_t *status, char *errorMessage);
-NDArray *decompressZlib(NDArray *input, NDCodecStatus_t *status, char *errorMessage);
+NDPLUGIN_API NDArray *compressZlib(NDArray *input, int clevel, NDCodecStatus_t *status, char *errorMessage);
+NDPLUGIN_API NDArray *decompressZlib(NDArray *input, NDCodecStatus_t *status, char *errorMessage);
 
-NDArray *compressBlosc(NDArray *input, int clevel, int shuffle, NDCodecBloscComp_t compressor,
+NDPLUGIN_API NDArray *compressBlosc(NDArray *input, int clevel, int shuffle, NDCodecBloscComp_t compressor,
                        int numThreads, NDCodecStatus_t *status, char *errorMessage);
-NDArray *decompressBlosc(NDArray *input, int numThreads, NDCodecStatus_t *status, char *errorMessage);
-NDArray *compressLZ4(NDArray *input, NDCodecStatus_t *status, char *errorMessage);
-NDArray *decompressLZ4(NDArray *input, NDCodecStatus_t *status, char *errorMessage);
-NDArray *compressLZ4HDF5(NDArray *input, size_t blockSize, NDCodecStatus_t *status, char *errorMessage);
-NDArray *decompressLZ4HDF5(NDArray *input, size_t *blockSize, NDCodecStatus_t *status, char *errorMessage);
-NDArray *compressBSLZ4(NDArray *input, NDCodecStatus_t *status, char *errorMessage);
-NDArray *decompressBSLZ4(NDArray *input, NDCodecStatus_t *status, char *errorMessage);
+NDPLUGIN_API NDArray *decompressBlosc(NDArray *input, int numThreads, NDCodecStatus_t *status, char *errorMessage);
+NDPLUGIN_API NDArray *compressLZ4(NDArray *input, NDCodecStatus_t *status, char *errorMessage);
+NDPLUGIN_API NDArray *decompressLZ4(NDArray *input, NDCodecStatus_t *status, char *errorMessage);
+NDPLUGIN_API NDArray *compressLZ4HDF5(NDArray *input, size_t blockSize, NDCodecStatus_t *status, char *errorMessage);
+NDPLUGIN_API NDArray *decompressLZ4HDF5(NDArray *input, size_t *blockSize, NDCodecStatus_t *status, char *errorMessage);
+NDPLUGIN_API NDArray *compressBSLZ4(NDArray *input, NDCodecStatus_t *status, char *errorMessage);
+NDPLUGIN_API NDArray *decompressBSLZ4(NDArray *input, NDCodecStatus_t *status, char *errorMessage);
 
 
 class NDPLUGIN_API NDPluginCodec : public NDPluginDriver {

--- a/ADApp/pluginTests/test_NDPluginAttribute.cpp
+++ b/ADApp/pluginTests/test_NDPluginAttribute.cpp
@@ -15,7 +15,7 @@
 #include <NDPluginDriver.h>
 #include <NDArray.h>
 #include <asynDriver.h>
-#include <Codec.h>
+#include <NDCodec.h>
 #include <NDPluginAttribute.h>
 #include <NDPluginCodec.h>
 
@@ -111,7 +111,7 @@ BOOST_AUTO_TEST_CASE(test_attribute_compressed_array)
 {
     NDArray *input = createTestArray(true);
     BOOST_REQUIRE(input != NULL);
-    BOOST_CHECK_EQUAL(input->codec.name, codecName[NDCODEC_ZLIB]);
+    BOOST_CHECK_EQUAL(input->codec.name, NDCodecName[NDCODEC_ZLIB]);
 
     double testVal = 99.0;
     input->pAttributeList->add("CompAttr", "", NDAttrFloat64, &testVal);


### PR DESCRIPTION
Naming was changed in previous PR, and the PR with these tests was merged before the changed names were applied
