### PR TITLE
Fix include in test_NDPluginAttribute

### DIFF
--- a/ADApp/pluginTests/test_NDPluginAttribute.cpp
+++ b/ADApp/pluginTests/test_NDPluginAttribute.cpp
@@ -15,7 +15,7 @@
 #include <NDPluginDriver.h>
 #include <NDArray.h>
 #include <asynDriver.h>
-#include <Codec.h>
+#include <NDCodec.h>
 #include <NDPluginAttribute.h>
 #include <NDPluginCodec.h>
 


### PR DESCRIPTION
<Codec.h> was renamed to <NDCodec.h> in 29fbc2d4 (Rename Code.h -> NDCodec.h, prepend static vars with ND, fix all references, 2026-04-27).

Fixes: d044c3de (Allow NDPluginAttribute to support compressed arrays. Add unit tests for NDPluginAttribute, 2026-04-27)

---

this should hopefully fix CI.