### PR TITLE
NDPluginROIStat: return after rank guard to prevent heap OOB on 3-D (RGB) arrays

### DIFF
--- a/ADApp/pluginSrc/NDPluginROIStat.cpp
+++ b/ADApp/pluginSrc/NDPluginROIStat.cpp
@@ -212,11 +212,16 @@ void NDPluginROIStat::processCallbacks(NDArray *pArray)
   /* Call the base class method */
   NDPluginDriver::beginProcessCallbacks(pArray);
 
-  // This plugin only works with 1-D or 2-D arrays
+  // This plugin only works with 1-D or 2-D arrays.  NDROI_t sizes offset[],
+  // size[] and arraySize[] to 2 elements, so a higher-rank array (e.g. any
+  // RGB1/2/3 colour frame, ndims==3) would drive the dim loop below past the
+  // end of those arrays.  Bail out here instead of merely warning.
   if ((pArray->ndims < 1) || (pArray->ndims > 2)) {
       asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
         "%s: error, number of array dimensions must be 1 or 2\n",
         functionName);
+      delete[] pROIs;
+      return;
   }
 
   //Set NDArraySize params to the input pArray, because this plugin doesn't change them


### PR DESCRIPTION
The "dimensions must be 1 or 2" guard in `processCallbacks()` only warns and falls through to the geometry loop `for (dim=0; dim<pArray->ndims; dim++)`, which writes `offset/size/arraySize[dim]`. `NDROI_t` sizes those to 2 elements, so any `ndims==3` frame — every RGB1/2/3 colour image — writes index 2, past each array and, for the last ROI, past the `new NDROI[maxROIs_]` allocation: a heap out-of-bounds write reachable from an ordinary colour-detector setup, with corrupt stats and a likely crash in the following `delete[]`. Bail out of the callback (freeing `pROIs`, leaving the mutex locked per the exit contract), matching the identical guard in `NDPluginTimeSeries` which already returns. Proven with an AddressSanitizer driver: the buggy path reports a heap-buffer-overflow WRITE of size 8 at the `arraySize[dim]` store; the fixed path returns cleanly.