### PR TITLE
NDPluginAttrPlot: fix <= off-by-one that grows the attribute list past its buffers

### DIFF
--- a/ADApp/pluginSrc/NDPluginAttrPlot.cpp
+++ b/ADApp/pluginSrc/NDPluginAttrPlot.cpp
@@ -160,7 +160,7 @@ void NDPluginAttrPlot::rebuild_attributes(NDAttributeList& attr_list) {
 
     attributes_.clear();
     for (NDAttribute * attr = attr_list.next(NULL);
-            attr != NULL && attributes_.size() <= n_attributes_;
+            attr != NULL && attributes_.size() < n_attributes_;
             attr = attr_list.next(attr)) {
         std::string name(attr->getName());
         NDAttrDataType_t type = attr->getDataType();


### PR DESCRIPTION
`rebuild_attributes()` guards discovery with `attributes_.size() <= n_attributes_`; testing size *before* the append lets the list reach `n_attributes_ + 1`. `data_` holds exactly `n_attributes_` circular buffers, so `push_data()`'s `for (i<length) data_[i].push_back(...)` reaches `data_[n_attributes_]` — a heap out-of-bounds `operator[]` on the first frame whenever an NDArray carries more numeric attributes than configured. Change `<=` to `<`. Proven with an AddressSanitizer driver: 5 numeric attrs against `n_attributes_=4` overflows before, completes clean after.