### PR TITLE
NDPluginTimeSeries: divide the averaged sum before narrowing, not after

### DIFF
--- a/ADApp/pluginSrc/NDPluginTimeSeries.cpp
+++ b/ADApp/pluginSrc/NDPluginTimeSeries.cpp
@@ -188,7 +188,7 @@ asynStatus NDPluginTimeSeries::doAddToTimeSeriesT(NDArray *pArray)
     if (numAveraged_ < numAverage_) continue;
     /* We have now collected the desired number of points to average */
     for (signal=0; signal<numSignals_; signal++) {
-      pTimeCircular[signal * numTimePoints_ + currentTimePoint_] = (epicsType)averageStore_[signal]/numAveraged_;
+      pTimeCircular[signal * numTimePoints_ + currentTimePoint_] = (epicsType)(averageStore_[signal]/numAveraged_);
       averageStore_[signal] = 0;
     }
     numAveraged_ = 0;


### PR DESCRIPTION
`(epicsType)averageStore_[signal]/numAveraged_` parses as `((epicsType)sum)/n` — the `double` sum is truncated or wrapped to the narrow element type *before* the divide. With averaging on, three UInt8 samples of 200 sum to 600 → `(epicsUInt8)600 == 88` → `88/3 == 29` instead of 200. Parenthesize as `(epicsType)(averageStore_[signal]/numAveraged_)`; float element types are unaffected. Proven with a driver reproducing the exact expression.