### PR TITLE
NDPluginStats: value-initialise stats structs so dark frames don't broadcast garbage

### DIFF
--- a/ADApp/pluginSrc/NDPluginStats.cpp
+++ b/ADApp/pluginSrc/NDPluginStats.cpp
@@ -427,7 +427,15 @@ void NDPluginStats::processCallbacks(NDArray *pArray)
     size_t bgdPixels;
     int bgdWidth;
     int dim;
-    NDStats_t stats, *pStats=&stats, statsTemp, *pStatsTemp=&statsTemp;
+    // Value-initialise both stats structs.  NDStats_t is a POD with no
+    // constructor, and several fields (sigmaXY, skewX/Y, kurtosisX/Y,
+    // eccentricity, orientation) are assigned only inside the M00 > 0 block of
+    // doComputeCentroid.  A dark or below-threshold frame (M00 == 0), or
+    // ComputeCentroid disabled, leaves them unwritten while they are copied
+    // unconditionally into the broadcast time-series array and the _RBV
+    // parameters below.  Zero-init makes an unassigned field read as 0 instead
+    // of stack garbage.
+    NDStats_t stats={}, *pStats=&stats, statsTemp={}, *pStatsTemp=&statsTemp;
     double bgdCounts, avgBgd;
     NDArray *pBgdArray=NULL;
     int computeStatistics, computeCentroid, computeProfiles, computeHistogram;


### PR DESCRIPTION
`NDStats_t stats, statsTemp;` are POD locals, never zeroed. The central-moment fields (`sigmaXY`, `skewX/Y`, `kurtosisX/Y`, `eccentricity`, `orientation`) are written only inside `if (M00 > 0.)`, but copied unconditionally into the broadcast time-series array and the `_RBV` params. A dark or below-threshold frame (`M00 == 0`), or `ComputeCentroid = 0`, publishes stack garbage — possibly NaN/inf — to those PVs and waveforms, corrupting archives and firing spurious alarms. Value-initialise both structs (`= {}`); pointer members stay allocated/freed under their existing symmetric guards. Proven with a driver running the broadcast path on `0xAA`-poisoned stack memory with a dark frame: garbage before, 0 after.