### PR TITLE
NDPluginProcess & NDPluginStats: guard three divide-by-zero paths reachable from user PVs

### DIFF
--- a/ADApp/pluginSrc/NDPluginProcess.cpp
+++ b/ADApp/pluginSrc/NDPluginProcess.cpp
@@ -92,6 +92,7 @@ void NDPluginProcess::processCallbacks(NDArray *pArray)
     }
     if (enableFilter) {
         getIntegerParam(NDPluginProcessNumFilter,       &numFilter);
+        if (numFilter < 1) numFilter = 1;
         getDoubleParam (NDPluginProcessOOffset,         &oOffset);
         getDoubleParam (NDPluginProcessOScale,          &oScale);
         getDoubleParam (NDPluginProcessOC1,             &oc1);
@@ -235,7 +236,7 @@ void NDPluginProcess::processCallbacks(NDArray *pArray)
       this->pNDArrayPool->convert(pScratch, &pArrayOut, (NDDataType_t)dataType);
     }
 
-    if (autoOffsetScale && (NULL != pArrayOut)) {
+    if (autoOffsetScale && (NULL != pArrayOut) && (maxValue > minValue)) {
         pArrayOut->getInfo(&arrayInfo);
         double maxScale = pow(2., arrayInfo.bytesPerElement*8) - 1;
         scale = maxScale /(maxValue-minValue);

--- a/ADApp/pluginSrc/NDPluginStats.cpp
+++ b/ADApp/pluginSrc/NDPluginStats.cpp
@@ -39,6 +39,7 @@ asynStatus NDPluginStats::doComputeHistogramT(NDArray *pArray, NDStats_t *pStats
 
     pArray->getInfo(&arrayInfo);
     nElements = arrayInfo.nElements;
+    if (pStats->histMax <= pStats->histMin) pStats->histMax = pStats->histMin + 1;
     scale = (pStats->histSize - 1) / (pStats->histMax - pStats->histMin);
 
     pStats->histBelow = 0;


### PR DESCRIPTION
## Summary

Three divide-by-zero paths in `NDPluginProcess` and `NDPluginStats` are all
reachable from user-writable PVs that have no enforcement (no DRVL, no
min/max relationship checked). This adds minimal inline guards, matching the
guard idiom already used elsewhere in these files (e.g. `computeHistX`'s
`if (histSize < 1) histSize = 1;`).

Two commits, one per plugin:

1. **`NDPluginProcess`** — two divisors in `processCallbacks`:
   - `NumFilter == 0` → `O1/O2/F1/F2 = … / numFiltered` with `numFiltered == 0`.
     `NumFilter` has no DRVL; the auto-reset sets `numFiltered = 0`, the ramp
     `if (numFiltered < numFilter)` is `0 < 0` (false), so it stays 0 and every
     output element and the persistent filter buffer become inf/NaN. Fixed by
     flooring `numFilter` at 1.
   - `AutoOffsetScale` → `scale = maxScale / (maxValue - minValue)`. A uniform
     frame (dark / saturated / closed shutter — routine at start-up) leaves
     `maxValue == minValue`, so `scale = +inf` is latched into the `Scale` PV
     with `EnableOffsetScale` forced on, ruining every later frame. Fixed by
     only computing/latching the scale when `maxValue > minValue`.

2. **`NDPluginStats`** — `doComputeHistogramT`:
   - `scale = (histSize - 1) / (histMax - histMin)` with no check that
     `histMax > histMin`. `HIST_MIN`/`HIST_MAX` are user PVs; setting them equal
     makes the denominator 0, `scale` becomes `±inf`, and for a pixel equal to
     `histMin` the term `0 * inf = NaN` feeds `(int)NaN` — undefined behaviour.
     Fixed with the same inline clamp the sibling `computeHistX` already uses.

## Reachability (why each is a real defect, not defensive noise)

- `NumFilter = 0`: `:200` auto-reset arms → `:210` `numFiltered = 0` → `:213` no
  increment → `:215` `oc2 / 0`.
- Uniform frame: min/max scan (`:167-168`) leaves `minValue == maxValue` →
  `:241` `maxScale / 0` → `+inf` latched at `:243`, `EnableOffsetScale = 1` at
  `:247`.
- `HIST_MIN == HIST_MAX`: `:42` divides with no prior guard → `:48` feeds the
  `inf`/`NaN` scale into `(int)(…)`.

All three are reachable from any CA put or autosave restore during normal
operation.

## Testing

Not built locally (no EPICS support tree configured in this checkout); the
changes are three type-correct one-line guards against the existing locals /
struct fields and introduce no new symbols. Relying on CI for the compile.
