### PR TITLE
NDPluginCircularBuff: writing 0 to SoftTrigger disarms, does not fire

### DIFF
--- a/ADApp/pluginSrc/NDPluginCircularBuff.cpp
+++ b/ADApp/pluginSrc/NDPluginCircularBuff.cpp
@@ -267,14 +267,17 @@ asynStatus NDPluginCircularBuff::writeInt32(asynUser *pasynUser, epicsInt32 valu
         // Set the parameter in the parameter library.
         status = (asynStatus) setIntegerParam(function, value);
 
-        // Set a soft trigger
-        setIntegerParam(NDCircBuffTriggered, 1);
+        // Writing 0 disarms the soft trigger; only a non-zero write fires it.
+        if (value) {
+            // Set a soft trigger
+            setIntegerParam(NDCircBuffTriggered, 1);
 
-        epicsInt32 flushOn;
-        getIntegerParam(NDCircBuffFlushOnSoftTrig, &flushOn);
+            epicsInt32 flushOn;
+            getIntegerParam(NDCircBuffFlushOnSoftTrig, &flushOn);
 
-        if (flushOn > 0){
-            flushPreBuffer();
+            if (flushOn > 0){
+                flushPreBuffer();
+            }
         }
 
     }  else if (function == NDCircBuffPreTrigger){


### PR DESCRIPTION
## Summary

In `NDPluginCircularBuff::writeInt32`, the `NDCircBuffSoftTrigger` branch stored
the written `value` and then latched `NDCircBuffTriggered = 1` and flushed the
pre-trigger buffer **unconditionally** — the value was never tested:

```cpp
}  else if (function == NDCircBuffSoftTrigger){
    status = (asynStatus) setIntegerParam(function, value);

    // Set a soft trigger
    setIntegerParam(NDCircBuffTriggered, 1);          // always, whatever was written

    epicsInt32 flushOn;
    getIntegerParam(NDCircBuffFlushOnSoftTrig, &flushOn);
    if (flushOn > 0){
        flushPreBuffer();
    }
}
```

So writing **0** to `SoftTrigger` fires the trigger exactly like writing 1.

## Why it matters

The plugin's own vocabulary treats `0` as "off": every disarm path in this file
clears **both** `NDCircBuffSoftTrigger` and `NDCircBuffTriggered` to `0` (e.g.
the capture-complete and stop paths). So `0` unambiguously means "not
triggered" everywhere else in the plugin — except the one place a client can
write it, which ignored it and armed instead.

Consequences of the current behaviour:

- `caput $(P)$(R)SoftTrigger 0` — the natural way for an operator or a sequencer
  to **disarm** between acquisitions — latches `Triggered`, flushes the
  pre-trigger ring downstream, and starts a post-trigger capture at the wrong
  moment.
- A `PINI`/autosave restore of `SoftTrigger = 0` at IOC start **arms the plugin
  on boot**, again capturing at an unintended time.

There is no way, through this parameter, to write a value that does *not* fire
the trigger.

## The fix

Guard the trigger latch and the pre-buffer flush behind `if (value)`, so a
non-zero write fires the soft trigger and a `0` write is a no-op arm (a plain
disarm/parameter update):

```cpp
}  else if (function == NDCircBuffSoftTrigger){
    status = (asynStatus) setIntegerParam(function, value);

    // Writing 0 disarms the soft trigger; only a non-zero write fires it.
    if (value) {
        setIntegerParam(NDCircBuffTriggered, 1);

        epicsInt32 flushOn;
        getIntegerParam(NDCircBuffFlushOnSoftTrig, &flushOn);
        if (flushOn > 0){
            flushPreBuffer();
        }
    }
}
```

## Family check

`setIntegerParam(NDCircBuffTriggered, 1)` occurs in exactly one place — this
`SoftTrigger` branch — so this is the only site that latched the trigger while
ignoring the written value. The other `NDCircBuffTriggered` writes are the
auto-trigger logic in `processCallbacks` (which sets it from the computed
`triggered` state, not from a user write) and the disarm paths (which set it to
`0`). None of those needed a change.

## Testing

Not compiled locally — this checkout has no configured areaDetector build tree,
so a build was not run here. The change is a single guarded block with no new
symbols; CI will compile it. The behavioural change is exactly: a `0` write to
`SoftTrigger` no longer latches `Triggered` or flushes the pre-buffer.
